### PR TITLE
Version 1.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,9 +202,9 @@ The SQL language is wrapped in a nice builder notation. DBFlow generates a ```$T
 ```java
 
 new Select().from(DeviceObject.class)
-                             .where(Condition.column(DeviceObject$Table.NAME).is("Samsung-Galaxy S5"))
-                             .and(Condition.column(DeviceObject$Table.CARRIER).is("T-MOBILE"))
-                             .and(Condition.column(DeviceObject$Table.LOCATION).is(location);
+                             .where(Condition.column(DeviceObject$Table.NAME).eq("Samsung-Galaxy S5"))
+                             .and(Condition.column(DeviceObject$Table.CARRIER).eq("T-MOBILE"))
+                             .and(Condition.column(DeviceObject$Table.LOCATION).eq(location);
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Android Weekly](http://img.shields.io/badge/Android%20Weekly-%23129-2CB3E5.svg?style=flat)](http://androidweekly.net/issues/issue-129)
 [![Android Arsenal](https://img.shields.io/badge/Android%20Arsenal-DBFlow-brightgreen.svg?style=flat)](https://android-arsenal.com/details/1/1134) 
-[![Raizlabs Repository](http://img.shields.io/badge/Raizlabs%20Repository-1.3.1-blue.svg?style=flat)](https://github.com/Raizlabs/maven-releases)
+[![Raizlabs Repository](http://img.shields.io/badge/Raizlabs%20Repository-1.4.0-blue.svg?style=flat)](https://github.com/Raizlabs/maven-releases)
 
 DBFlow
 ======
@@ -17,19 +17,15 @@ What sets this library apart: **every** feature has been unit tested to ensure f
 
 ## Changelog
 
-### 1.3.1
-  1. Fixes issue where ```$ContainerAdapter``` generated the incorrect ```updateAutoIncrement()``` method.
-  2. Also updated ```ModelContainerUtils``` to utilize the more efficient usage of ```save()```, ```insert()```, and ```update()``` just like ```Model``` already do.
+#### 1.4.0
 
-### 1.3.0
-
-  1. Adds in ```ConflictAction``` you can specify for a ```@Table``` insert and update methods. This will not work on earlier than FROYO (API 8) for update statements.
-  2. Added ```InsertTransaction``` and ```InsertModelTransaction``` that handle insert queries with the ```TransactionManager```
-  3. Now ```BaseModel``` will directly call ```UPDATE``` and ```INSERT``` methods in the ```update()``` and ```insert()``` instead of using ```save()``` when calling those methods directly for a small performance gain.
-  4. Added checking and attempts. Thanks [wongcain](https://github.com/wongcain)
-  5. Now supports ```ForeignKeyContainer``` which when placed in a field of a ```Model```, will hold onto the foreign key cursor data and provide an on-demand lazy loading of foreign key objects by calling ```toModel()```.
-  6. Added support for ```LoadFromCursorListener```, ```SQLiteStatementListener```, and ```ContentValuesListener``` within a model to implement to perform some custom action during use of those methods.
-  7. Added a ```saveForeignKeyModel()``` option in ```Column``` to disable ```save()``` on a contained foreign key ```Model``` or ```ModelContainer``` from within its associated Adapter class. Thanks [davidschreiber](https://github.com/davidschreiber)
+1. Fixes a crash within ```ModelUtils`` from the compiler` for a non-standard column
+2. Add validation to ensure crash does not happen from (1).
+3. Add ```INSERT``` as ```Queriable``` interface.
+4. ```Queriable``` interface was drastically simplified down to two methods. ```query()``` and ```queryClose()```. Never fear ```ModelQueriable``` is here! Same as previous ```Queriable``` just new and more descriptive name.
+5. ```Condition.columnRaw()``` will not TypeConvert or convert the value to a SQL escaped string when used. 
+6. ```Condition.eq()``` added that just mirrors ```is()``` but will sound nicer when writing some queries.
+7. ```Condition.column(columnName).concatenateToColumn(value)``` will concatenate the query: ```columnName=columnName || 'value'``` for strings, or ```columnName=columnName + value``` for numbers. It will handle type converters appropriately
 
 for older changes, from other xx.xx versions, check it out [here](https://github.com/Raizlabs/DBFlow/wiki)
 

--- a/README.md
+++ b/README.md
@@ -74,12 +74,12 @@ Add the library to the project-level build.gradle, using the [apt plugin](https:
 ```groovy
 
   dependencies {
-    apt 'com.raizlabs.android:DBFlow-Compiler:1.2.0'
-    aarLinkSources 'com.raizlabs.android:DBFlow-Compiler:1.2.0:sources@jar'
-    compile 'com.raizlabs.android:DBFlow-Core:1.2.0'
-    aarLinkSources 'com.raizlabs.android:DBFlow-Core:1.2.0:sources@jar'
-    compile 'com.raizlabs.android:DBFlow:1.2.0'
-    aarLinkSources 'com.raizlabs.android:DBFlow:1.2.0:sources@jar'
+    apt 'com.raizlabs.android:DBFlow-Compiler:1.4.0'
+    aarLinkSources 'com.raizlabs.android:DBFlow-Compiler:1.4.0:sources@jar'
+    compile 'com.raizlabs.android:DBFlow-Core:1.4.0'
+    aarLinkSources 'com.raizlabs.android:DBFlow-Core:1.4.0:sources@jar'
+    compile 'com.raizlabs.android:DBFlow:1.4.0'
+    aarLinkSources 'com.raizlabs.android:DBFlow:1.4.0:sources@jar'
   }
 
 ```

--- a/compiler/src/main/java/com/raizlabs/android/dbflow/processor/definition/ColumnDefinition.java
+++ b/compiler/src/main/java/com/raizlabs/android/dbflow/processor/definition/ColumnDefinition.java
@@ -204,7 +204,7 @@ public class ColumnDefinition extends BaseDefinition implements FlowWriter {
                 List<AdapterQueryBuilder> elseNullPuts = new ArrayList<>();
                 for (ForeignKeyReference foreignKeyReference : foreignKeyReferences) {
                     TypeMirror castedClass = ModelUtils.getTypeMirrorFromAnnotation(foreignKeyReference);
-                    ModelUtils.writeContentValueStatement(javaWriter, isContentValues, columnCount.intValue(),
+                    ModelUtils. writeContentValueStatement(javaWriter, isContentValues, columnCount.intValue(),
                             foreignKeyReference.columnName(),
                             columnName, castedClass.toString(),
                             foreignKeyReference.foreignColumnName(), foreignKeyReference.foreignColumnName(),

--- a/compiler/src/main/java/com/raizlabs/android/dbflow/processor/utils/ModelUtils.java
+++ b/compiler/src/main/java/com/raizlabs/android/dbflow/processor/utils/ModelUtils.java
@@ -45,6 +45,10 @@ public class ModelUtils {
         boolean nullCheck = !isContentValues;
         if(nullCheck) {
             String statement = StatementMap.getStatement(SQLiteType.get(castedClass));
+            if(statement == null) {
+                throw new IOException(String.format("Writing insert statement failed for: %1s. A type converter" +
+                        "must be defined for this type.", castedClass));
+            }
             nullCheck = (statement.equals("String") || statement.equals("Blob") || !isColumnPrimitive);
         } else {
             contentValue.appendContentValues();

--- a/compiler/src/main/java/com/raizlabs/android/dbflow/processor/utils/ModelUtils.java
+++ b/compiler/src/main/java/com/raizlabs/android/dbflow/processor/utils/ModelUtils.java
@@ -47,7 +47,7 @@ public class ModelUtils {
             String statement = StatementMap.getStatement(SQLiteType.get(castedClass));
             if(statement == null) {
                 throw new IOException(String.format("Writing insert statement failed for: %1s. A type converter" +
-                        "must be defined for this type.", castedClass));
+                        "must be defined for this type, or if this field is a Model, must be a foreign key definition.", castedClass));
             }
             nullCheck = (statement.equals("String") || statement.equals("Blob") || !isColumnPrimitive);
         } else {

--- a/compiler/src/main/java/com/raizlabs/android/dbflow/processor/validator/ColumnValidator.java
+++ b/compiler/src/main/java/com/raizlabs/android/dbflow/processor/validator/ColumnValidator.java
@@ -16,42 +16,46 @@ public class ColumnValidator implements Validator<ColumnDefinition> {
 
         boolean success = true;
 
-        if(columnDefinition.columnName == null || columnDefinition.columnName.isEmpty()) {
+        if (columnDefinition.columnName == null || columnDefinition.columnName.isEmpty()) {
             success = false;
             processorManager.logError("Field %1s cannot have a null column name", columnDefinition.columnFieldName);
         }
 
         int columnType = columnDefinition.columnType;
-        if(columnType == Column.FOREIGN_KEY) {
-            if(columnDefinition.foreignKeyReferences == null || columnDefinition.foreignKeyReferences.length == 0) {
+        if (columnType == Column.FOREIGN_KEY) {
+            if (columnDefinition.foreignKeyReferences == null || columnDefinition.foreignKeyReferences.length == 0) {
                 success = false;
                 processorManager.logError("Foreign Key for field %1s is missing it's references.", columnDefinition.columnFieldName);
             }
 
         } else if (columnType == Column.NORMAL) {
-            if(columnDefinition.foreignKeyReferences != null) {
+            if (columnDefinition.foreignKeyReferences != null) {
                 processorManager.logError("A non-foreign key field %1s defines references.", columnDefinition.columnFieldName);
                 success = false;
             }
         } else if (columnType == Column.PRIMARY_KEY || columnType == Column.PRIMARY_KEY_AUTO_INCREMENT) {
-            if(columnDefinition.foreignKeyReferences != null) {
+            if (columnDefinition.foreignKeyReferences != null) {
                 processorManager.logError("A non-foreign key field %1s defines references.", columnDefinition.columnFieldName);
                 success = false;
             }
 
-            if(columnType == Column.PRIMARY_KEY_AUTO_INCREMENT) {
-                if(autoIncrementingPrimaryKey == null) {
+            if (columnType == Column.PRIMARY_KEY_AUTO_INCREMENT) {
+                if (autoIncrementingPrimaryKey == null) {
                     autoIncrementingPrimaryKey = columnDefinition;
-                } else if(!autoIncrementingPrimaryKey.equals(columnDefinition)) {
+                } else if (!autoIncrementingPrimaryKey.equals(columnDefinition)) {
                     processorManager.logError("Only one autoincrementing primary key is allowed on table");
                     success = false;
                 }
             } else {
-                if(columnDefinition.isModel) {
+                if (columnDefinition.isModel) {
                     processorManager.logError("Primary keys cannot be model objects");
                     success = false;
                 }
             }
+        }
+
+        if (columnType != Column.FOREIGN_KEY && columnDefinition.isModel || columnDefinition.isModelContainer) {
+            processorManager.logError("A Model or ModelContainer field must be a Column.FOREIGN_KEY_REFERENCE");
         }
 
         return success;

--- a/compiler/src/main/java/com/raizlabs/android/dbflow/processor/validator/ColumnValidator.java
+++ b/compiler/src/main/java/com/raizlabs/android/dbflow/processor/validator/ColumnValidator.java
@@ -56,7 +56,7 @@ public class ColumnValidator implements Validator<ColumnDefinition> {
             }
         }
 
-        if (columnType != Column.FOREIGN_KEY && columnDefinition.isModel || columnDefinition.isModelContainer) {
+        if (columnType != Column.FOREIGN_KEY && (columnDefinition.isModel || columnDefinition.isModelContainer)) {
             processorManager.logError("A Model or ModelContainer field must be a Column.FOREIGN_KEY_REFERENCE");
         }
 

--- a/compiler/src/main/java/com/raizlabs/android/dbflow/processor/validator/ColumnValidator.java
+++ b/compiler/src/main/java/com/raizlabs/android/dbflow/processor/validator/ColumnValidator.java
@@ -34,8 +34,15 @@ public class ColumnValidator implements Validator<ColumnDefinition> {
                 success = false;
             }
         } else if (columnType == Column.PRIMARY_KEY || columnType == Column.PRIMARY_KEY_AUTO_INCREMENT) {
+            if (autoIncrementingPrimaryKey != null && columnType == Column.PRIMARY_KEY) {
+                processorManager.logError("You cannot mix and match autoincrementing and composite primary keys.");
+                success = false;
+            }
             if (columnDefinition.foreignKeyReferences != null) {
                 processorManager.logError("A non-foreign key field %1s defines references.", columnDefinition.columnFieldName);
+                success = false;
+            } else if (columnDefinition.isModel) {
+                processorManager.logError("Primary keys cannot be Model objects");
                 success = false;
             }
 
@@ -44,11 +51,6 @@ public class ColumnValidator implements Validator<ColumnDefinition> {
                     autoIncrementingPrimaryKey = columnDefinition;
                 } else if (!autoIncrementingPrimaryKey.equals(columnDefinition)) {
                     processorManager.logError("Only one autoincrementing primary key is allowed on table");
-                    success = false;
-                }
-            } else {
-                if (columnDefinition.isModel) {
-                    processorManager.logError("Primary keys cannot be model objects");
                     success = false;
                 }
             }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=1.3.1
+VERSION_NAME=1.3.2
 VERSION_CODE=1
 GROUP=com.raizlabs.android
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=1.3.2
+VERSION_NAME=1.4.0
 VERSION_CODE=1
 GROUP=com.raizlabs.android
 

--- a/library/src/androidTest/java/com/raizlabs/android/dbflow/test/sql/UpdateTest.java
+++ b/library/src/androidTest/java/com/raizlabs/android/dbflow/test/sql/UpdateTest.java
@@ -37,6 +37,11 @@ public class UpdateTest extends FlowTestCase {
 
         String query = new Update().table(BoxedModel.class).set(Condition.columnRaw(BoxedModel$Table.RBLNUMBER).is(BoxedModel$Table.RBLNUMBER + " + 1")).getQuery();
         assertEquals("UPDATE BoxedModel SET rblNumber=rblNumber + 1", query.trim());
+
+
+        query = new Update().table(BoxedModel.class).set(Condition.column(BoxedModel$Table.RBLNUMBER).concatenateToColumn(1)).getQuery();
+        assertEquals("UPDATE BoxedModel SET rblNumber=rblNumber + 1", query.trim());
+
     }
 
     public void testUpdateEffect() {

--- a/library/src/androidTest/java/com/raizlabs/android/dbflow/test/sql/UpdateTest.java
+++ b/library/src/androidTest/java/com/raizlabs/android/dbflow/test/sql/UpdateTest.java
@@ -7,6 +7,7 @@ import com.raizlabs.android.dbflow.sql.language.Where;
 import com.raizlabs.android.dbflow.sql.builder.Condition;
 import com.raizlabs.android.dbflow.test.FlowTestCase;
 import com.raizlabs.android.dbflow.test.structure.TestModel1;
+import com.raizlabs.android.dbflow.test.structure.TestModel1$Table;
 
 /**
  * Description:
@@ -33,6 +34,9 @@ public class UpdateTest extends FlowTestCase {
 
         assertEquals("UPDATE TestModel1 SET name='newvalue' WHERE name='oldvalue'", where.getQuery().trim());
         where.query();
+
+        String query = new Update().table(BoxedModel.class).set(Condition.columnRaw(BoxedModel$Table.RBLNUMBER).is(BoxedModel$Table.RBLNUMBER + " + 1")).getQuery();
+        assertEquals("UPDATE BoxedModel SET rblNumber=rblNumber + 1", query.trim());
     }
 
     public void testUpdateEffect() {

--- a/library/src/androidTest/java/com/raizlabs/android/dbflow/test/sql/UpdateTest.java
+++ b/library/src/androidTest/java/com/raizlabs/android/dbflow/test/sql/UpdateTest.java
@@ -42,6 +42,8 @@ public class UpdateTest extends FlowTestCase {
         query = new Update().table(BoxedModel.class).set(Condition.column(BoxedModel$Table.RBLNUMBER).concatenateToColumn(1)).getQuery();
         assertEquals("UPDATE BoxedModel SET rblNumber=rblNumber + 1", query.trim());
 
+        query = new Update().table(BoxedModel.class).set(Condition.column(BoxedModel$Table.NAME).concatenateToColumn("Test")).getQuery();
+        assertEquals("UPDATE BoxedModel SET name=name || 'Test'", query.trim());
     }
 
     public void testUpdateEffect() {

--- a/library/src/main/java/com/raizlabs/android/dbflow/list/FlowCursorList.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/list/FlowCursorList.java
@@ -9,7 +9,7 @@ import com.raizlabs.android.dbflow.runtime.DBTransactionInfo;
 import com.raizlabs.android.dbflow.runtime.TransactionManager;
 import com.raizlabs.android.dbflow.runtime.transaction.BaseResultTransaction;
 import com.raizlabs.android.dbflow.runtime.transaction.TransactionListener;
-import com.raizlabs.android.dbflow.sql.Queriable;
+import com.raizlabs.android.dbflow.sql.ModelQueriable;
 import com.raizlabs.android.dbflow.sql.SqlUtils;
 import com.raizlabs.android.dbflow.sql.builder.Condition;
 import com.raizlabs.android.dbflow.sql.language.Select;
@@ -31,7 +31,7 @@ public class FlowCursorList<ModelClass extends Model> {
 
     private boolean cacheModels;
 
-    private Queriable<ModelClass> mQueriable;
+    private ModelQueriable<ModelClass> mQueriable;
 
     private CursorObserver mObserver;
 
@@ -40,12 +40,12 @@ public class FlowCursorList<ModelClass extends Model> {
      *
      * @param cacheModels For every call to {@link #getItem(int)}, do we want to keep a reference to it so
      *                    we do not need to convert the cursor data back into a {@link ModelClass} again.
-     * @param queriable   The SQL where query to use when doing a query.
+     * @param modelQueriable   The SQL where query to use when doing a query.
      */
-    public FlowCursorList(boolean cacheModels, Queriable<ModelClass> queriable) {
-        mQueriable = queriable;
+    public FlowCursorList(boolean cacheModels, ModelQueriable<ModelClass> modelQueriable) {
+        mQueriable = modelQueriable;
         mCursor = mQueriable.query();
-        mTable = queriable.getTable();
+        mTable = modelQueriable.getTable();
         this.cacheModels = cacheModels;
 
         if (cacheModels) {

--- a/library/src/main/java/com/raizlabs/android/dbflow/list/FlowTableList.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/list/FlowTableList.java
@@ -15,7 +15,7 @@ import com.raizlabs.android.dbflow.runtime.transaction.TransactionListenerAdapte
 import com.raizlabs.android.dbflow.runtime.transaction.process.ProcessModel;
 import com.raizlabs.android.dbflow.runtime.transaction.process.ProcessModelHelper;
 import com.raizlabs.android.dbflow.runtime.transaction.process.ProcessModelInfo;
-import com.raizlabs.android.dbflow.sql.Queriable;
+import com.raizlabs.android.dbflow.sql.ModelQueriable;
 import com.raizlabs.android.dbflow.sql.SqlUtils;
 import com.raizlabs.android.dbflow.sql.builder.Condition;
 import com.raizlabs.android.dbflow.sql.language.Delete;
@@ -78,13 +78,13 @@ public class FlowTableList<ModelClass extends Model> extends ContentObserver imp
     }
 
     /**
-     * Constructs an instance of this list with the specfied {@link com.raizlabs.android.dbflow.sql.Queriable} object.
+     * Constructs an instance of this list with the specfied {@link com.raizlabs.android.dbflow.sql.ModelQueriable} object.
      *
-     * @param queriable The object that can query from a database.
+     * @param modelQueriable The object that can query from a database.
      */
-    public FlowTableList(Queriable<ModelClass> queriable) {
+    public FlowTableList(ModelQueriable<ModelClass> modelQueriable) {
         super(null);
-        mCursorList = new FlowCursorList<ModelClass>(transact, queriable);
+        mCursorList = new FlowCursorList<ModelClass>(transact, modelQueriable);
     }
 
     /**

--- a/library/src/main/java/com/raizlabs/android/dbflow/runtime/TransactionManager.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/runtime/TransactionManager.java
@@ -158,9 +158,8 @@ public class TransactionManager {
      * @param transactionInfo The information on how we should approach this request.
      * @param queriable       The {@link com.raizlabs.android.dbflow.sql.Queriable} statement that we wish to execute. The query base should not be a select as this
      *                        does not return any results.
-     * @param <ModelClass>    The class that implements {@link com.raizlabs.android.dbflow.structure.Model}
      */
-    public <ModelClass extends Model> void transactQuery(DBTransactionInfo transactionInfo, Queriable<ModelClass> queriable) {
+    public void transactQuery(DBTransactionInfo transactionInfo, Queriable queriable) {
         transactQuery(transactionInfo, queriable, null);
     }
 
@@ -170,10 +169,9 @@ public class TransactionManager {
      * @param transactionInfo           The information on how we should approach this request.
      * @param queriable                 The {@link com.raizlabs.android.dbflow.sql.Queriable} statement that we wish to execute.
      * @param cursorTransactionListener The cursor from the DB that we can process
-     * @param <ModelClass>              The class that implements {@link com.raizlabs.android.dbflow.structure.Model}
      */
-    public <ModelClass extends Model> void transactQuery(DBTransactionInfo transactionInfo, Queriable<ModelClass> queriable, TransactionListener<Cursor> cursorTransactionListener) {
-        addTransaction(new QueryTransaction<ModelClass>(transactionInfo, queriable, cursorTransactionListener));
+    public void transactQuery(DBTransactionInfo transactionInfo, Queriable queriable, TransactionListener<Cursor> cursorTransactionListener) {
+        addTransaction(new QueryTransaction(transactionInfo, queriable, cursorTransactionListener));
     }
 
     /**
@@ -196,7 +194,7 @@ public class TransactionManager {
      */
     public <ModelClass extends Model> void fetchFromTable(TransactionListener<List<ModelClass>> transactionListener,
                                                           ConditionQueryBuilder<ModelClass> whereConditionQueryBuilder, String... columns) {
-        addTransaction(new SelectListTransaction<ModelClass>(transactionListener, whereConditionQueryBuilder, columns));
+        addTransaction(new SelectListTransaction<>(transactionListener, whereConditionQueryBuilder, columns));
     }
 
     // region Database Select Methods
@@ -212,7 +210,7 @@ public class TransactionManager {
      */
     public <ModelClass extends Model> void fetchFromTable(Class<ModelClass> tableClass,
                                                           TransactionListener<List<ModelClass>> transactionListener, Condition... conditions) {
-        addTransaction(new SelectListTransaction<ModelClass>(transactionListener, tableClass, conditions));
+        addTransaction(new SelectListTransaction<>(transactionListener, tableClass, conditions));
     }
 
     /**
@@ -236,7 +234,7 @@ public class TransactionManager {
      * @param <ModelClass>        The class that implements {@link com.raizlabs.android.dbflow.structure.Model}.
      */
     public <ModelClass extends Model> void fetchFromTable(Where<ModelClass> where, TransactionListener<List<ModelClass>> transactionListener) {
-        addTransaction(new SelectListTransaction<ModelClass>(where, transactionListener));
+        addTransaction(new SelectListTransaction<>(where, transactionListener));
     }
 
     /**
@@ -278,7 +276,7 @@ public class TransactionManager {
      */
     public <ModelClass extends Model> void fetchModel(Where<ModelClass> where,
                                                       final TransactionListener<ModelClass> transactionListener) {
-        addTransaction(new SelectSingleModelTransaction<ModelClass>(where, transactionListener));
+        addTransaction(new SelectSingleModelTransaction<>(where, transactionListener));
     }
 
     /**
@@ -329,7 +327,7 @@ public class TransactionManager {
      * @param modelInfo Holds information about this save request
      */
     public <ModelClass extends Model> void save(ProcessModelInfo<ModelClass> modelInfo) {
-        addTransaction(new SaveModelTransaction<ModelClass>(modelInfo));
+        addTransaction(new SaveModelTransaction<>(modelInfo));
     }
 
     // endregion
@@ -344,7 +342,7 @@ public class TransactionManager {
      * @param modelInfo Holds information about this delete request
      */
     public <ModelClass extends Model> void delete(ProcessModelInfo<ModelClass> modelInfo) {
-        addTransaction(new DeleteModelListTransaction<ModelClass>(modelInfo));
+        addTransaction(new DeleteModelListTransaction<>(modelInfo));
     }
 
     /**
@@ -358,7 +356,7 @@ public class TransactionManager {
      */
     public <ModelClass extends Model> void delete(DBTransactionInfo transactionInfo,
                                                   Class<ModelClass> table, Condition... conditions) {
-        addTransaction(new DeleteTransaction<ModelClass>(transactionInfo, table, conditions));
+        addTransaction(new DeleteTransaction<>(transactionInfo, table, conditions));
     }
 
     /**
@@ -371,7 +369,7 @@ public class TransactionManager {
      */
     public <ModelClass extends Model> void delete(DBTransactionInfo transactionInfo,
                                                   ConditionQueryBuilder<ModelClass> conditionQueryBuilder) {
-        addTransaction(new DeleteTransaction<ModelClass>(transactionInfo, conditionQueryBuilder));
+        addTransaction(new DeleteTransaction<>(transactionInfo, conditionQueryBuilder));
     }
 
     // endregion
@@ -386,7 +384,7 @@ public class TransactionManager {
      * @param modelInfo Holds information about this update request
      */
     public <ModelClass extends Model> void update(ProcessModelInfo<ModelClass> modelInfo) {
-        addTransaction(new UpdateModelListTransaction<ModelClass>(modelInfo));
+        addTransaction(new UpdateModelListTransaction<>(modelInfo));
     }
 
     /**

--- a/library/src/main/java/com/raizlabs/android/dbflow/runtime/transaction/InsertTransaction.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/runtime/transaction/InsertTransaction.java
@@ -1,7 +1,6 @@
 package com.raizlabs.android.dbflow.runtime.transaction;
 
 import com.raizlabs.android.dbflow.runtime.DBTransactionInfo;
-import com.raizlabs.android.dbflow.sql.StringQuery;
 import com.raizlabs.android.dbflow.sql.builder.Condition;
 import com.raizlabs.android.dbflow.sql.language.Insert;
 import com.raizlabs.android.dbflow.structure.Model;
@@ -20,7 +19,7 @@ public class InsertTransaction<ModelClass extends Model> extends QueryTransactio
      * @param columnValues      The column and their corresponding values.
      */
     public InsertTransaction(DBTransactionInfo dbTransactionInfo, Class<ModelClass> insertTable, Condition... columnValues) {
-        super(dbTransactionInfo, new StringQuery<>(insertTable, new Insert<>(insertTable).columnValues(columnValues).getQuery()), null);
+        super(dbTransactionInfo, new Insert<>(insertTable).columnValues(columnValues), null);
     }
 
     /**
@@ -30,7 +29,7 @@ public class InsertTransaction<ModelClass extends Model> extends QueryTransactio
      * @param insert            The insert statement to use.
      */
     public InsertTransaction(DBTransactionInfo dbTransactionInfo, Insert<ModelClass> insert) {
-        super(dbTransactionInfo, new StringQuery<>(insert.getTable(), insert.getQuery()));
+        super(dbTransactionInfo, insert);
     }
 
 }

--- a/library/src/main/java/com/raizlabs/android/dbflow/runtime/transaction/QueryTransaction.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/runtime/transaction/QueryTransaction.java
@@ -13,7 +13,7 @@ import com.raizlabs.android.dbflow.structure.Model;
  */
 public class QueryTransaction<ModelClass extends Model> extends BaseResultTransaction<Cursor> {
 
-    private Queriable<ModelClass> mQueriable;
+    private Queriable mQueriable;
 
     /**
      * Constructs a new instance that will simply run a query as a transaction.
@@ -21,7 +21,7 @@ public class QueryTransaction<ModelClass extends Model> extends BaseResultTransa
      * @param dbTransactionInfo The information on how to process the transaction
      * @param queriable         The data object that that has certain methods pertaining to queries.
      */
-    public QueryTransaction(DBTransactionInfo dbTransactionInfo, Queriable<ModelClass> queriable) {
+    public QueryTransaction(DBTransactionInfo dbTransactionInfo, Queriable queriable) {
         this(dbTransactionInfo, queriable, null);
     }
 
@@ -32,7 +32,7 @@ public class QueryTransaction<ModelClass extends Model> extends BaseResultTransa
      * @param queriable                 The data object that that has certain methods pertaining to queries.
      * @param cursorTransactionListener The callback that gets invoked that enables processing of the cursor.
      */
-    public QueryTransaction(DBTransactionInfo dbTransactionInfo, Queriable<ModelClass> queriable, TransactionListener<Cursor> cursorTransactionListener) {
+    public QueryTransaction(DBTransactionInfo dbTransactionInfo, Queriable queriable, TransactionListener<Cursor> cursorTransactionListener) {
         super(dbTransactionInfo, cursorTransactionListener);
         mQueriable = queriable;
     }

--- a/library/src/main/java/com/raizlabs/android/dbflow/sql/ModelQueriable.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/sql/ModelQueriable.java
@@ -1,0 +1,40 @@
+package com.raizlabs.android.dbflow.sql;
+
+import com.raizlabs.android.dbflow.list.FlowCursorList;
+import com.raizlabs.android.dbflow.list.FlowTableList;
+import com.raizlabs.android.dbflow.structure.Model;
+
+import java.util.List;
+
+/**
+ * Description: An interface for query objects to enable you to query from the database in a structured way.
+ */
+public interface ModelQueriable<ModelClass extends Model> extends Queriable {
+
+    /**
+     * @return a list of model converted items
+     */
+    public List<ModelClass> queryList();
+
+    /**
+     * @return Single model, the first of potentially many results
+     */
+    public ModelClass querySingle();
+
+    /**
+     * @return the table that this query comes from.
+     */
+    public Class<ModelClass> getTable();
+
+    /**
+     * @return A cursor-backed list that handles conversion, retrieval, and caching of lists. Can
+     * cache models dynamically by setting {@link com.raizlabs.android.dbflow.list.FlowCursorList#setCacheModels(boolean)} to true.
+     */
+    public FlowCursorList<ModelClass> queryCursorList();
+
+    /**
+     * @return A cursor-backed {@link java.util.List} that handles conversion, retrieval, caching, content changes,
+     * and more.
+     */
+    public FlowTableList<ModelClass> queryTableList();
+}

--- a/library/src/main/java/com/raizlabs/android/dbflow/sql/Queriable.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/sql/Queriable.java
@@ -2,16 +2,10 @@ package com.raizlabs.android.dbflow.sql;
 
 import android.database.Cursor;
 
-import com.raizlabs.android.dbflow.list.FlowCursorList;
-import com.raizlabs.android.dbflow.list.FlowTableList;
-import com.raizlabs.android.dbflow.structure.Model;
-
-import java.util.List;
-
 /**
- * Description: An interface for query objects to enable you to query from the database in a structured way.
+ * Description:
  */
-public interface Queriable<ModelClass extends Model> {
+public interface Queriable {
 
     /**
      * @return a cursor from the DB based on this query
@@ -24,30 +18,4 @@ public interface Queriable<ModelClass extends Model> {
      */
     public void queryClose();
 
-    /**
-     * @return a list of model converted items
-     */
-    public List<ModelClass> queryList();
-
-    /**
-     * @return Single model, the first of potentially many results
-     */
-    public ModelClass querySingle();
-
-    /**
-     * @return the table that this query comes from.
-     */
-    public Class<ModelClass> getTable();
-
-    /**
-     * @return A cursor-backed list that handles conversion, retrieval, and caching of lists. Can
-     * cache models dynamically by setting {@link com.raizlabs.android.dbflow.list.FlowCursorList#setCacheModels(boolean)} to true.
-     */
-    public FlowCursorList<ModelClass> queryCursorList();
-
-    /**
-     * @return A cursor-backed {@link java.util.List} that handles conversion, retrieval, caching, content changes,
-     * and more.
-     */
-    public FlowTableList<ModelClass> queryTableList();
 }

--- a/library/src/main/java/com/raizlabs/android/dbflow/sql/StringQuery.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/sql/StringQuery.java
@@ -14,7 +14,7 @@ import java.util.List;
  * Description: Provides a very basic query mechanism for strings. It runs a modification query and will only run
  * {@link android.database.sqlite.SQLiteDatabase#rawQuery(String, String[])}.
  */
-public class StringQuery<ModelClass extends Model> implements Query, Queriable<ModelClass> {
+public class StringQuery<ModelClass extends Model> implements Query, ModelQueriable<ModelClass> {
 
     /**
      * The full SQLite query to use

--- a/library/src/main/java/com/raizlabs/android/dbflow/sql/builder/Condition.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/sql/builder/Condition.java
@@ -1,6 +1,8 @@
 package com.raizlabs.android.dbflow.sql.builder;
 
 import com.raizlabs.android.dbflow.annotation.Collate;
+import com.raizlabs.android.dbflow.config.FlowManager;
+import com.raizlabs.android.dbflow.converter.TypeConverter;
 import com.raizlabs.android.dbflow.sql.QueryBuilder;
 import com.raizlabs.android.dbflow.structure.Model;
 
@@ -28,6 +30,16 @@ public class Condition {
          * Not-equals comparison
          */
         public static final String NOT_EQUALS = "!=";
+
+        /**
+         * String concatenation
+         */
+        public static final String CONCATENATE = "||";
+
+        /**
+         * Number addition
+         */
+        public static final String PLUS = "+";
 
         /**
          * If something is LIKE another (a case insensitive search).
@@ -432,6 +444,33 @@ public class Condition {
      */
     public Condition separator(String separator) {
         mSeparator = separator;
+        return this;
+    }
+
+    /**
+     * Will concatenate a value to the specified condition such that: itemOrder=itemOrder + value or
+     * if its a SQL string: name=name||'value'
+     *
+     * @param value
+     * @return
+     */
+    @SuppressWarnings("unchecked")
+    public Condition concatenateToColumn(Object value) {
+        mOperation = String.format(" %1s%1s ", Operation.EQUALS, mColumn);
+        if (value != null) {
+            TypeConverter typeConverter = FlowManager.getTypeConverterForClass(value.getClass());
+            if (typeConverter != null) {
+                value = typeConverter.getDBValue(value);
+            }
+        }
+        if (value instanceof String) {
+            mOperation = String.format("%1s %1s ", mOperation, Operation.CONCATENATE);
+        } else if (value instanceof Number) {
+            mOperation = String.format("%1s %1s ", mOperation, Operation.PLUS);
+        } else {
+            throw new IllegalArgumentException(String.format("Cannot concatenate the %1s", value != null ? value.getClass() : "null"));
+        }
+        mValue = value;
         return this;
     }
 

--- a/library/src/main/java/com/raizlabs/android/dbflow/sql/builder/Condition.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/sql/builder/Condition.java
@@ -457,7 +457,7 @@ public class Condition {
     @SuppressWarnings("unchecked")
     public Condition concatenateToColumn(Object value) {
         mOperation = String.format("%1s%1s", Operation.EQUALS, mColumn);
-        if (value != null) {
+        if (value != null && !isRaw) {
             TypeConverter typeConverter = FlowManager.getTypeConverterForClass(value.getClass());
             if (typeConverter != null) {
                 value = typeConverter.getDBValue(value);

--- a/library/src/main/java/com/raizlabs/android/dbflow/sql/builder/Condition.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/sql/builder/Condition.java
@@ -223,6 +223,11 @@ public class Condition {
     protected String mSeparator;
 
     /**
+     * If it is a raw condition, we will not attempt to escape or convert the values.
+     */
+    protected boolean isRaw = false;
+
+    /**
      * Creates a new instance
      *
      * @param columnName The name of the column in the DB
@@ -232,6 +237,19 @@ public class Condition {
             throw new IllegalArgumentException("Column " + columnName + " cannot be null");
         }
         mColumn = columnName;
+    }
+
+    /**
+     * Creates a new instance with a raw condition query. The values will not be converted into
+     * SQL-safe value. Ex: itemOrder =itemOrder + 1. If not raw, this becomes itemOrder ='itemOrder + 1'
+     *
+     * @param columnName
+     * @return This raw condition
+     */
+    public static Condition columnRaw(String columnName) {
+        Condition condition = column(columnName);
+        condition.isRaw = true;
+        return condition;
     }
 
     public static Condition column(String columnName) {
@@ -482,8 +500,9 @@ public class Condition {
 
         // Do not use value for these operators, we do not want to convert the value to a string.
         if (!Operation.IS_NOT_NULL.equals(operation().trim()) && !Operation.IS_NULL.equals(operation().trim())) {
-            conditionQueryBuilder.append(conditionQueryBuilder.convertValueToString(value()));
+            conditionQueryBuilder.append(isRaw ? value() : conditionQueryBuilder.convertValueToString(value()));
         }
+
         if (postArgument() != null) {
             conditionQueryBuilder.appendSpace().append(postArgument());
         }

--- a/library/src/main/java/com/raizlabs/android/dbflow/sql/builder/Condition.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/sql/builder/Condition.java
@@ -456,7 +456,7 @@ public class Condition {
      */
     @SuppressWarnings("unchecked")
     public Condition concatenateToColumn(Object value) {
-        mOperation = String.format(" %1s%1s ", Operation.EQUALS, mColumn);
+        mOperation = String.format("%1s%1s", Operation.EQUALS, mColumn);
         if (value != null) {
             TypeConverter typeConverter = FlowManager.getTypeConverterForClass(value.getClass());
             if (typeConverter != null) {

--- a/library/src/main/java/com/raizlabs/android/dbflow/sql/builder/Condition.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/sql/builder/Condition.java
@@ -259,12 +259,26 @@ public class Condition {
     /**
      * Assigns the operation to "="
      *
-     * @param value The value of the column in the DB
+     * @param value The value of the column from the {@link com.raizlabs.android.dbflow.structure.Model} Note
+     *              this value may be type converted if used in a {@link com.raizlabs.android.dbflow.sql.builder.ConditionQueryBuilder}
+     *              so a {@link com.raizlabs.android.dbflow.structure.Model} value is safe here.
      * @return This condition
      */
     public Condition is(Object value) {
         mOperation = Operation.EQUALS;
         return value(value);
+    }
+
+    /**
+     * Assigns the operation to "=" the equals operator.
+     *
+     * @param value The value of the column from the {@link com.raizlabs.android.dbflow.structure.Model} Note
+     *              this value may be type converted if used in a {@link com.raizlabs.android.dbflow.sql.builder.ConditionQueryBuilder}
+     *              so a {@link com.raizlabs.android.dbflow.structure.Model} value is safe here.
+     * @return This condition
+     */
+    public Condition eq(Object value) {
+        return is(value);
     }
 
     /**

--- a/library/src/main/java/com/raizlabs/android/dbflow/sql/language/From.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/sql/language/From.java
@@ -5,7 +5,7 @@ import android.database.Cursor;
 import com.raizlabs.android.dbflow.config.FlowManager;
 import com.raizlabs.android.dbflow.list.FlowCursorList;
 import com.raizlabs.android.dbflow.list.FlowTableList;
-import com.raizlabs.android.dbflow.sql.Queriable;
+import com.raizlabs.android.dbflow.sql.ModelQueriable;
 import com.raizlabs.android.dbflow.sql.Query;
 import com.raizlabs.android.dbflow.sql.QueryBuilder;
 import com.raizlabs.android.dbflow.sql.builder.Condition;
@@ -19,7 +19,7 @@ import java.util.List;
  * Author: andrewgrosner
  * Description: The SQL FROM query wrapper that must have a {@link com.raizlabs.android.dbflow.sql.Query} base.
  */
-public class From<ModelClass extends Model> implements WhereBase<ModelClass>, Queriable<ModelClass> {
+public class From<ModelClass extends Model> implements WhereBase<ModelClass>, ModelQueriable<ModelClass> {
 
     /**
      * The base such as {@link Delete}, {@link Select} and more!

--- a/library/src/main/java/com/raizlabs/android/dbflow/sql/language/Insert.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/sql/language/Insert.java
@@ -1,7 +1,10 @@
 package com.raizlabs.android.dbflow.sql.language;
 
+import android.database.Cursor;
+
 import com.raizlabs.android.dbflow.annotation.ConflictAction;
 import com.raizlabs.android.dbflow.config.FlowManager;
+import com.raizlabs.android.dbflow.sql.Queriable;
 import com.raizlabs.android.dbflow.sql.Query;
 import com.raizlabs.android.dbflow.sql.builder.Condition;
 import com.raizlabs.android.dbflow.sql.builder.ConditionQueryBuilder;
@@ -11,7 +14,7 @@ import com.raizlabs.android.dbflow.structure.Model;
 /**
  * Description: The SQLite INSERT command
  */
-public class Insert<ModelClass extends Model> implements Query {
+public class Insert<ModelClass extends Model> implements Query, Queriable {
 
     /**
      * The table class that this INSERT points to
@@ -199,5 +202,18 @@ public class Insert<ModelClass extends Model> implements Query {
      */
     public Class<ModelClass> getTable() {
         return mTable;
+    }
+
+    @Override
+    public Cursor query() {
+        return FlowManager.getDatabaseForTable(mTable).getWritableDatabase().rawQuery(getQuery(), null);
+    }
+
+    @Override
+    public void queryClose() {
+        Cursor cursor = query();
+        if (cursor != null) {
+            cursor.close();
+        }
     }
 }

--- a/library/src/main/java/com/raizlabs/android/dbflow/sql/language/Set.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/sql/language/Set.java
@@ -1,5 +1,9 @@
 package com.raizlabs.android.dbflow.sql.language;
 
+import android.database.Cursor;
+
+import com.raizlabs.android.dbflow.config.FlowManager;
+import com.raizlabs.android.dbflow.sql.Queriable;
 import com.raizlabs.android.dbflow.sql.Query;
 import com.raizlabs.android.dbflow.sql.QueryBuilder;
 import com.raizlabs.android.dbflow.sql.builder.Condition;
@@ -9,7 +13,7 @@ import com.raizlabs.android.dbflow.structure.Model;
 /**
  * Description: Used to specify the SET part of an {@link com.raizlabs.android.dbflow.sql.language.Update} query.
  */
-public class Set<ModelClass extends Model> implements WhereBase<ModelClass> {
+public class Set<ModelClass extends Model> implements WhereBase<ModelClass>, Queriable {
 
     private ConditionQueryBuilder<ModelClass> mConditionQueryBuilder;
 
@@ -91,5 +95,18 @@ public class Set<ModelClass extends Model> implements WhereBase<ModelClass> {
     @Override
     public Query getQueryBuilderBase() {
         return mUpdate;
+    }
+
+    @Override
+    public Cursor query() {
+        return FlowManager.getDatabaseForTable(mConditionQueryBuilder.getTableClass()).getWritableDatabase().rawQuery(getQuery(), null);
+    }
+
+    @Override
+    public void queryClose() {
+        Cursor cursor = query();
+        if (cursor != null) {
+            cursor.close();
+        }
     }
 }

--- a/library/src/main/java/com/raizlabs/android/dbflow/sql/language/Where.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/sql/language/Where.java
@@ -12,7 +12,7 @@ import com.raizlabs.android.dbflow.runtime.DBTransactionInfo;
 import com.raizlabs.android.dbflow.runtime.TransactionManager;
 import com.raizlabs.android.dbflow.runtime.transaction.QueryTransaction;
 import com.raizlabs.android.dbflow.runtime.transaction.TransactionListener;
-import com.raizlabs.android.dbflow.sql.Queriable;
+import com.raizlabs.android.dbflow.sql.ModelQueriable;
 import com.raizlabs.android.dbflow.sql.Query;
 import com.raizlabs.android.dbflow.sql.QueryBuilder;
 import com.raizlabs.android.dbflow.sql.SqlUtils;
@@ -26,7 +26,7 @@ import java.util.List;
  * Author: andrewgrosner
  * Description: Defines the SQL WHERE statement of the query.
  */
-public class Where<ModelClass extends Model> implements Query, Queriable<ModelClass> {
+public class Where<ModelClass extends Model> implements Query, ModelQueriable<ModelClass> {
 
     /**
      * The first chunk of the SQL statement before this query.


### PR DESCRIPTION
1. Fixes a crash within ```ModelUtils``` for a non-standard column #40 
2. Add validation to ensure crash does not happen.
3. Add ```INSERT``` as ```Queriable``` interface.
4. ```Queriable``` interface was drastically simplified down to two methods. ```query()``` and ```queryClose()```. Never fear ```ModelQueriable``` is here! Same as previous ```Queriable``` just new and more descriptive name.
5. ```Condition.columnRaw()``` will not TypeConvert or convert the value to a SQL escaped string when used. 
6. ```Condition.eq()``` added that just mirrors ```is()``` but will sound nicer when writing some queries.
7. ```Condition.column(columnName).concatenateToColumn(value)``` will concatenate the query: ```columnName=columnName || 'value'``` for strings, or ```columnName=columnName + value``` for numbers. It will handle type converters appropriately