### PR TITLE
Significant Performance Increase

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=1.4.4
+VERSION_NAME=1.4.5
 VERSION_CODE=1
 GROUP=com.raizlabs.android
 

--- a/library/src/main/java/com/raizlabs/android/dbflow/runtime/FlowContentObserver.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/runtime/FlowContentObserver.java
@@ -12,6 +12,7 @@ import com.raizlabs.android.dbflow.structure.Model;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Author: andrewgrosner
@@ -21,6 +22,17 @@ import java.util.List;
  * above {@link android.os.Build.VERSION_CODES#JELLY_BEAN}. If below it will only provide one callback.
  */
 public class FlowContentObserver extends ContentObserver {
+
+    private static List<FlowContentObserver> mObserverList = new ArrayList<>();
+
+    /**
+     * @return true if we have registered for content changes. Otherwise we do not notify
+     * in {@link com.raizlabs.android.dbflow.sql.SqlUtils#notifyModelChanged(Class, com.raizlabs.android.dbflow.structure.BaseModel.Action)}
+     * for efficiency purposes.
+     */
+    public static boolean shouldNotify() {
+        return !mObserverList.isEmpty();
+    }
 
     /**
      * Listeners for model changes.
@@ -56,6 +68,7 @@ public class FlowContentObserver extends ContentObserver {
      */
     public void registerForContentChanges(Context context, Class<? extends Model> table) {
         context.getContentResolver().registerContentObserver(SqlUtils.getNotificationUri(table, null), true, this);
+        mObserverList.add(this);
     }
 
     /**
@@ -63,6 +76,7 @@ public class FlowContentObserver extends ContentObserver {
      */
     public void unregisterForContentChanges(Context context) {
         context.getContentResolver().unregisterContentObserver(this);
+        mObserverList.remove(this);
     }
 
     @Override

--- a/library/src/main/java/com/raizlabs/android/dbflow/sql/SqlUtils.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/sql/SqlUtils.java
@@ -10,9 +10,9 @@ import android.support.annotation.IntDef;
 
 import com.raizlabs.android.dbflow.annotation.ConflictAction;
 import com.raizlabs.android.dbflow.config.BaseDatabaseDefinition;
-import com.raizlabs.android.dbflow.config.FlowLog;
 import com.raizlabs.android.dbflow.config.FlowManager;
 import com.raizlabs.android.dbflow.runtime.DBTransactionInfo;
+import com.raizlabs.android.dbflow.runtime.FlowContentObserver;
 import com.raizlabs.android.dbflow.runtime.TransactionManager;
 import com.raizlabs.android.dbflow.runtime.transaction.process.DeleteModelListTransaction;
 import com.raizlabs.android.dbflow.runtime.transaction.process.InsertModelTransaction;
@@ -20,6 +20,7 @@ import com.raizlabs.android.dbflow.runtime.transaction.process.ProcessModelInfo;
 import com.raizlabs.android.dbflow.sql.language.Delete;
 import com.raizlabs.android.dbflow.structure.BaseModel;
 import com.raizlabs.android.dbflow.structure.BaseModelView;
+import com.raizlabs.android.dbflow.structure.InternalAdapter;
 import com.raizlabs.android.dbflow.structure.Model;
 import com.raizlabs.android.dbflow.structure.ModelAdapter;
 import com.raizlabs.android.dbflow.structure.ModelViewAdapter;
@@ -98,12 +99,12 @@ public class SqlUtils {
         if (modelAdapter == null) {
             if (BaseModelView.class.isAssignableFrom(table)) {
                 modelAdapter = FlowManager.getModelViewAdapter((Class<? extends BaseModelView<? extends Model>>) table);
-                model = ((ModelViewAdapter<ModelClass, ?>)modelAdapter).newInstance();
+                model = ((ModelViewAdapter<ModelClass, ?>) modelAdapter).newInstance();
             }
         } else {
             model = ((ModelAdapter<ModelClass>) modelAdapter).newInstance();
         }
-        if(modelAdapter != null) {
+        if (modelAdapter != null) {
             if (cursor.moveToFirst()) {
                 do {
                     modelAdapter.loadFromCursor(cursor, model);
@@ -128,19 +129,15 @@ public class SqlUtils {
     @SuppressWarnings("unchecked")
     public static <ModelClass extends Model> ModelClass convertToModel(boolean dontMoveToFirst, Class<ModelClass> table, Cursor cursor) {
         ModelClass model = null;
-        try {
-            if (dontMoveToFirst || cursor.moveToFirst()) {
-                ModelAdapter<ModelClass> modelAdapter = FlowManager.getModelAdapter(table);
-                if (modelAdapter == null) {
-                    if (BaseModelView.class.isAssignableFrom(table)) {
-                        model = (ModelClass) FlowManager.getModelViewAdapter((Class<? extends BaseModelView<? extends Model>>) table).loadFromCursor(cursor);
-                    }
-                } else {
-                    model = modelAdapter.loadFromCursor(cursor);
+        if (dontMoveToFirst || cursor.moveToFirst()) {
+            ModelAdapter<ModelClass> modelAdapter = FlowManager.getModelAdapter(table);
+            if (modelAdapter == null) {
+                if (BaseModelView.class.isAssignableFrom(table)) {
+                    model = (ModelClass) FlowManager.getModelViewAdapter((Class<? extends BaseModelView<? extends Model>>) table).loadFromCursor(cursor);
                 }
+            } else {
+                model = modelAdapter.loadFromCursor(cursor);
             }
-        } catch (Exception e) {
-            FlowLog.log(FlowLog.Level.E, "Failed to process cursor.", e);
         }
 
         return model;
@@ -169,14 +166,14 @@ public class SqlUtils {
      * Checks whether the SQL query returns a {@link android.database.Cursor} with a count of at least 1. This
      * means that the query was successful. It is commonly used when checking if a {@link com.raizlabs.android.dbflow.structure.Model} exists.
      *
-     * @param flowManager  The database manager that we run this query on
+     * @param table        The table to check
      * @param sql          The SQL command to perform, must not be ; terminated.
      * @param args         The optional string arguments when we use "?" in the sql
      * @param <ModelClass> The class that implements {@link com.raizlabs.android.dbflow.structure.Model}
      * @return
      */
-    public static <ModelClass extends Model> boolean hasData(Class<ModelClass> modelClass, String sql, String... args) {
-        BaseDatabaseDefinition flowManager = FlowManager.getDatabaseForTable(modelClass);
+    public static <ModelClass extends Model> boolean hasData(Class<ModelClass> table, String sql, String... args) {
+        BaseDatabaseDefinition flowManager = FlowManager.getDatabaseForTable(table);
         Cursor cursor = flowManager.getWritableDatabase().rawQuery(sql, args);
         boolean hasData = (cursor.getCount() > 0);
         cursor.close();
@@ -186,21 +183,15 @@ public class SqlUtils {
     /**
      * Syncs the model to the database depending on it's save mode.
      *
-     * @param async
-     * @param model
-     * @param contentValues
-     * @param mode
-     * @param <ModelClass>
+     * @see #save(boolean, com.raizlabs.android.dbflow.structure.Model, com.raizlabs.android.dbflow.structure.RetrievalAdapter, com.raizlabs.android.dbflow.structure.ModelAdapter)
      */
+    @Deprecated
     public static <ModelClass extends Model> void sync(boolean async, ModelClass model, ModelAdapter<ModelClass> modelAdapter, @SaveMode int mode) {
         if (!async) {
 
             if (model == null) {
                 throw new IllegalArgumentException("Model from " + modelAdapter.getModelClass() + " was null");
             }
-
-            BaseDatabaseDefinition flowManager = FlowManager.getDatabaseForTable(model.getClass());
-            final SQLiteDatabase db = flowManager.getWritableDatabase();
 
             boolean exists = false;
             BaseModel.Action action = BaseModel.Action.SAVE;
@@ -214,14 +205,51 @@ public class SqlUtils {
             }
 
             if (exists) {
-                exists = update(false, model, modelAdapter);
+                exists = update(false, model, modelAdapter, modelAdapter);
             }
 
             if (!exists) {
-                insert(false, model, modelAdapter);
+                insert(false, model, modelAdapter, modelAdapter);
             }
 
-            //notifyModelChanged(model.getClass(), action);
+            if (FlowContentObserver.shouldNotify()) {
+                notifyModelChanged(model.getClass(), action);
+            }
+        } else {
+            TransactionManager.getInstance().save(ProcessModelInfo.withModels(model).info(DBTransactionInfo.createSave()));
+        }
+    }
+
+    /**
+     * Saves the model into the DB based on whether it exists or not.
+     *
+     * @param async        Whether it goes on the {@link com.raizlabs.android.dbflow.runtime.DBTransactionQueue} or done immediately.
+     * @param model        The model to save
+     * @param modelAdapter The {@link com.raizlabs.android.dbflow.structure.ModelAdapter} to use
+     * @param <ModelClass> The class that implements {@link com.raizlabs.android.dbflow.structure.Model}
+     */
+    @SuppressWarnings("unchecked")
+    public static <ModelClass extends Model, TableClass extends Model, AdapterClass extends RetrievalAdapter & InternalAdapter>
+    void save(boolean async, TableClass model, AdapterClass adapter, ModelAdapter<ModelClass> modelAdapter) {
+        if (!async) {
+
+            if (model == null) {
+                throw new IllegalArgumentException("Model from " + modelAdapter.getModelClass() + " was null");
+            }
+
+            boolean exists = adapter.exists(model);
+
+            if (exists) {
+                exists = update(false, model, adapter, modelAdapter);
+            }
+
+            if (!exists) {
+                insert(false, model, adapter, modelAdapter);
+            }
+
+            if (FlowContentObserver.shouldNotify()) {
+                notifyModelChanged(model.getClass(), BaseModel.Action.SAVE);
+            }
         } else {
             TransactionManager.getInstance().save(ProcessModelInfo.withModels(model).info(DBTransactionInfo.createSave()));
         }
@@ -237,25 +265,27 @@ public class SqlUtils {
      * @return true if model was inserted, false if not. Also false could mean that it is placed on the
      * {@link com.raizlabs.android.dbflow.runtime.DBTransactionQueue} using async to true.
      */
-    public static <ModelClass extends Model> boolean update(boolean async, ModelClass model, ModelAdapter<ModelClass> modelAdapter) {
+    @SuppressWarnings("unchecked")
+    public static <ModelClass extends Model, TableClass extends Model, AdapterClass extends RetrievalAdapter & InternalAdapter>
+    boolean update(boolean async, TableClass model, AdapterClass adapter, ModelAdapter<ModelClass> modelAdapter) {
         boolean exists = false;
         if (!async) {
             SQLiteDatabase db = FlowManager.getDatabaseForTable(model.getClass()).getWritableDatabase();
             ContentValues contentValues = new ContentValues();
-            modelAdapter.bindToContentValues(contentValues, model);
+            adapter.bindToContentValues(contentValues, model);
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.FROYO) {
                 exists = (db.updateWithOnConflict(modelAdapter.getTableName(), contentValues,
-                        modelAdapter.getPrimaryModelWhere(model).getQuery(), null,
+                        adapter.getPrimaryModelWhere(model).getQuery(), null,
                         ConflictAction.getSQLiteDatabaseAlgorithmInt(modelAdapter.getUpdateOnConflictAction())) != 0);
             } else {
                 exists = (db.update(modelAdapter.getTableName(), contentValues,
-                        modelAdapter.getPrimaryModelWhere(model).getQuery(), null) != 0);
+                        adapter.getPrimaryModelWhere(model).getQuery(), null) != 0);
             }
             if (!exists) {
                 // insert
-                insert(false, model, modelAdapter);
-            } else {
-                //notifyModelChanged(model.getClass(), BaseModel.Action.UPDATE);
+                insert(false, model, adapter, modelAdapter);
+            } else if (FlowContentObserver.shouldNotify()) {
+                notifyModelChanged(model.getClass(), BaseModel.Action.UPDATE);
             }
         } else {
             TransactionManager.getInstance().update(ProcessModelInfo.withModels(model).info(DBTransactionInfo.createSave()));
@@ -271,13 +301,17 @@ public class SqlUtils {
      * @param modelAdapter The adapter to use.
      * @param <ModelClass> The class that implements {@link com.raizlabs.android.dbflow.structure.Model}
      */
-    public static <ModelClass extends Model> void insert(boolean async, ModelClass model, ModelAdapter<ModelClass> modelAdapter) {
+    @SuppressWarnings("unchecked")
+    public static <ModelClass extends Model, TableClass extends Model, AdapterClass extends RetrievalAdapter & InternalAdapter>
+    void insert(boolean async, TableClass model, AdapterClass adapter, ModelAdapter<ModelClass> modelAdapter) {
         if (!async) {
             SQLiteStatement insertStatement = modelAdapter.getInsertStatement();
-            modelAdapter.bindToStatement(insertStatement, model);
+            adapter.bindToStatement(insertStatement, model);
             long id = insertStatement.executeInsert();
-            modelAdapter.updateAutoIncrement(model, id);
-            //notifyModelChanged(model.getClass(), BaseModel.Action.INSERT);
+            adapter.updateAutoIncrement(model, id);
+            if (FlowContentObserver.shouldNotify()) {
+                notifyModelChanged(model.getClass(), BaseModel.Action.INSERT);
+            }
         } else {
             TransactionManager.getInstance().addTransaction(new InsertModelTransaction<>(ProcessModelInfo.withModels(model).info(DBTransactionInfo.createSave())));
         }
@@ -287,16 +321,18 @@ public class SqlUtils {
     /**
      * Deletes {@link com.raizlabs.android.dbflow.structure.Model} from the database using the specfied {@link com.raizlabs.android.dbflow.config.FlowManager}
      *
-     * @param model        The model to delete
-     * @param async        Whether it goes on the {@link com.raizlabs.android.dbflow.runtime.DBTransactionQueue} or done immediately.
-     * @param <ModelClass> The class that implements {@link com.raizlabs.android.dbflow.structure.Model}
+     * @param model The model to delete
+     * @param async Whether it goes on the {@link com.raizlabs.android.dbflow.runtime.DBTransactionQueue} or done immediately.
      */
     @SuppressWarnings("unchecked")
-    public static <ModelClass extends Model> void delete(final ModelClass model, ModelAdapter<ModelClass> modelAdapter, boolean async) {
+    public static <TableClass extends Model, AdapterClass extends RetrievalAdapter & InternalAdapter>
+    void delete(final TableClass model, AdapterClass modelAdapter, boolean async) {
         if (!async) {
-            new Delete().from((Class<ModelClass>) model.getClass()).where(modelAdapter.getPrimaryModelWhere(model)).query();
+            new Delete().from((Class<TableClass>) model.getClass()).where(modelAdapter.getPrimaryModelWhere(model)).query();
             modelAdapter.updateAutoIncrement(model, 0);
-            //notifyModelChanged(model.getClass(), BaseModel.Action.DELETE);
+            if (FlowContentObserver.shouldNotify()) {
+                notifyModelChanged(model.getClass(), BaseModel.Action.DELETE);
+            }
         } else {
             TransactionManager.getInstance().addTransaction(new DeleteModelListTransaction<>(ProcessModelInfo.withModels(model).fetch()));
         }
@@ -305,10 +341,11 @@ public class SqlUtils {
     /**
      * Notifies the {@link android.database.ContentObserver} that the model has changed.
      *
-     * @param model
+     * @param action     The {@link com.raizlabs.android.dbflow.structure.BaseModel.Action} enum
+     * @param table The table of the model
      */
-    public static void notifyModelChanged(Class<? extends Model> modelClass, BaseModel.Action action) {
-        FlowManager.getContext().getContentResolver().notifyChange(getNotificationUri(modelClass, action), null, true);
+    public static void notifyModelChanged(Class<? extends Model> table, BaseModel.Action action) {
+        FlowManager.getContext().getContentResolver().notifyChange(getNotificationUri(table, action), null, true);
     }
 
     /**

--- a/library/src/main/java/com/raizlabs/android/dbflow/sql/SqlUtils.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/sql/SqlUtils.java
@@ -214,7 +214,7 @@ public class SqlUtils {
             }
 
             if (FlowContentObserver.shouldNotify()) {
-                notifyModelChanged(model.getClass(), action);
+                notifyModelChanged(modelAdapter.getModelClass(), action);
             }
         } else {
             TransactionManager.getInstance().save(ProcessModelInfo.withModels(model).info(DBTransactionInfo.createSave()));
@@ -249,7 +249,7 @@ public class SqlUtils {
             }
 
             if (FlowContentObserver.shouldNotify()) {
-                notifyModelChanged(model.getClass(), BaseModel.Action.SAVE);
+                notifyModelChanged(modelAdapter.getModelClass(), BaseModel.Action.SAVE);
             }
         } else {
             TransactionManager.getInstance().save(ProcessModelInfo.withModels(model).info(DBTransactionInfo.createSave()));
@@ -271,7 +271,7 @@ public class SqlUtils {
     boolean update(boolean async, TableClass model, AdapterClass adapter, ModelAdapter<ModelClass> modelAdapter) {
         boolean exists = false;
         if (!async) {
-            SQLiteDatabase db = FlowManager.getDatabaseForTable(model.getClass()).getWritableDatabase();
+            SQLiteDatabase db = FlowManager.getDatabaseForTable(modelAdapter.getModelClass()).getWritableDatabase();
             ContentValues contentValues = new ContentValues();
             adapter.bindToContentValues(contentValues, model);
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.FROYO) {
@@ -286,7 +286,7 @@ public class SqlUtils {
                 // insert
                 insert(false, model, adapter, modelAdapter);
             } else if (FlowContentObserver.shouldNotify()) {
-                notifyModelChanged(model.getClass(), BaseModel.Action.UPDATE);
+                notifyModelChanged(modelAdapter.getModelClass(), BaseModel.Action.UPDATE);
             }
         } else {
             TransactionManager.getInstance().update(ProcessModelInfo.withModels(model).info(DBTransactionInfo.createSave()));
@@ -311,7 +311,7 @@ public class SqlUtils {
             long id = insertStatement.executeInsert();
             adapter.updateAutoIncrement(model, id);
             if (FlowContentObserver.shouldNotify()) {
-                notifyModelChanged(model.getClass(), BaseModel.Action.INSERT);
+                notifyModelChanged(modelAdapter.getModelClass(), BaseModel.Action.INSERT);
             }
         } else {
             TransactionManager.getInstance().addTransaction(new InsertModelTransaction<>(ProcessModelInfo.withModels(model).info(DBTransactionInfo.createSave())));
@@ -329,7 +329,7 @@ public class SqlUtils {
     public static <TableClass extends Model, AdapterClass extends RetrievalAdapter & InternalAdapter>
     void delete(final TableClass model, AdapterClass modelAdapter, boolean async) {
         if (!async) {
-            new Delete().from((Class<TableClass>) model.getClass()).where(modelAdapter.getPrimaryModelWhere(model)).query();
+            new Delete().from((Class<TableClass>) modelAdapter.getModelClass()).where(modelAdapter.getPrimaryModelWhere(model)).query();
             modelAdapter.updateAutoIncrement(model, 0);
             if (FlowContentObserver.shouldNotify()) {
                 notifyModelChanged(model.getClass(), BaseModel.Action.DELETE);

--- a/library/src/main/java/com/raizlabs/android/dbflow/sql/SqlUtils.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/sql/SqlUtils.java
@@ -20,10 +20,10 @@ import com.raizlabs.android.dbflow.runtime.transaction.process.ProcessModelInfo;
 import com.raizlabs.android.dbflow.sql.language.Delete;
 import com.raizlabs.android.dbflow.structure.BaseModel;
 import com.raizlabs.android.dbflow.structure.BaseModelView;
+import com.raizlabs.android.dbflow.structure.InstanceAdapter;
 import com.raizlabs.android.dbflow.structure.InternalAdapter;
 import com.raizlabs.android.dbflow.structure.Model;
 import com.raizlabs.android.dbflow.structure.ModelAdapter;
-import com.raizlabs.android.dbflow.structure.ModelViewAdapter;
 import com.raizlabs.android.dbflow.structure.RetrievalAdapter;
 
 import java.util.ArrayList;
@@ -94,19 +94,17 @@ public class SqlUtils {
     @SuppressWarnings("unchecked")
     public static <ModelClass extends Model> List<ModelClass> convertToList(Class<ModelClass> table, Cursor cursor) {
         final List<ModelClass> entities = new ArrayList<ModelClass>();
-        RetrievalAdapter modelAdapter = FlowManager.getModelAdapter(table);
-        Model model = null;
+        InstanceAdapter modelAdapter = FlowManager.getModelAdapter(table);
+
         if (modelAdapter == null) {
             if (BaseModelView.class.isAssignableFrom(table)) {
                 modelAdapter = FlowManager.getModelViewAdapter((Class<? extends BaseModelView<? extends Model>>) table);
-                model = ((ModelViewAdapter<ModelClass, ?>) modelAdapter).newInstance();
             }
-        } else {
-            model = ((ModelAdapter<ModelClass>) modelAdapter).newInstance();
         }
         if (modelAdapter != null) {
             if (cursor.moveToFirst()) {
                 do {
+                    Model model = modelAdapter.newInstance();
                     modelAdapter.loadFromCursor(cursor, model);
                     entities.add((ModelClass) model);
                 }
@@ -341,8 +339,8 @@ public class SqlUtils {
     /**
      * Notifies the {@link android.database.ContentObserver} that the model has changed.
      *
-     * @param action     The {@link com.raizlabs.android.dbflow.structure.BaseModel.Action} enum
-     * @param table The table of the model
+     * @param action The {@link com.raizlabs.android.dbflow.structure.BaseModel.Action} enum
+     * @param table  The table of the model
      */
     public static void notifyModelChanged(Class<? extends Model> table, BaseModel.Action action) {
         FlowManager.getContext().getContentResolver().notifyChange(getNotificationUri(table, action), null, true);

--- a/library/src/main/java/com/raizlabs/android/dbflow/sql/SqlUtils.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/sql/SqlUtils.java
@@ -121,20 +121,23 @@ public class SqlUtils {
      * @param dontMoveToFirst If it's a list or at a specific position, do not reset the cursor
      * @param table           The model class that we convert the cursor data into.
      * @param cursor          The cursor from the DB
-     * @param <ModelClass>
-     * @return
+     * @param <ModelClass>    The class that implements {@link com.raizlabs.android.dbflow.structure.Model}
+     * @return A model transformed from the {@link android.database.Cursor}
      */
     @SuppressWarnings("unchecked")
     public static <ModelClass extends Model> ModelClass convertToModel(boolean dontMoveToFirst, Class<ModelClass> table, Cursor cursor) {
         ModelClass model = null;
         if (dontMoveToFirst || cursor.moveToFirst()) {
-            ModelAdapter<ModelClass> modelAdapter = FlowManager.getModelAdapter(table);
+            InstanceAdapter modelAdapter = FlowManager.getModelAdapter(table);
             if (modelAdapter == null) {
                 if (BaseModelView.class.isAssignableFrom(table)) {
-                    model = (ModelClass) FlowManager.getModelViewAdapter((Class<? extends BaseModelView<? extends Model>>) table).loadFromCursor(cursor);
+                    modelAdapter = FlowManager.getModelViewAdapter((Class<? extends BaseModelView<? extends Model>>) table);
                 }
-            } else {
-                model = modelAdapter.loadFromCursor(cursor);
+            }
+
+            if (modelAdapter != null) {
+                model = (ModelClass) modelAdapter.newInstance();
+                modelAdapter.loadFromCursor(cursor, model);
             }
         }
 

--- a/library/src/main/java/com/raizlabs/android/dbflow/structure/BaseModel.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/structure/BaseModel.java
@@ -51,7 +51,7 @@ public abstract class BaseModel implements Model {
     @SuppressWarnings("unchecked")
     @Override
     public void save(boolean async) {
-        mModelAdapter.save(async, this, SqlUtils.SAVE_MODE_DEFAULT);
+        mModelAdapter.save(async, this);
     }
 
     @SuppressWarnings("unchecked")

--- a/library/src/main/java/com/raizlabs/android/dbflow/structure/InstanceAdapter.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/structure/InstanceAdapter.java
@@ -1,0 +1,14 @@
+package com.raizlabs.android.dbflow.structure;
+
+/**
+ * Description: Provides a {@link #newInstance()} method to a {@link com.raizlabs.android.dbflow.structure.RetrievalAdapter}
+ */
+public interface InstanceAdapter<TableClass extends Model, ModelClass extends Model>
+        extends RetrievalAdapter<TableClass, ModelClass> {
+
+    /**
+     * @return A new model using its default constructor. This is why default is required so that
+     * we don't use reflection to create objects = faster.
+     */
+    public ModelClass newInstance();
+}

--- a/library/src/main/java/com/raizlabs/android/dbflow/structure/InternalAdapter.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/structure/InternalAdapter.java
@@ -27,7 +27,17 @@ public interface InternalAdapter<TableClass extends Model, ModelClass extends Mo
      * @param saveMode The {@link com.raizlabs.android.dbflow.sql.SqlUtils} save mode. Can be {@link com.raizlabs.android.dbflow.sql.SqlUtils#SAVE_MODE_DEFAULT},
      *                 {@link com.raizlabs.android.dbflow.sql.SqlUtils#SAVE_MODE_INSERT}, or {@link com.raizlabs.android.dbflow.sql.SqlUtils#SAVE_MODE_UPDATE}
      */
+    @Deprecated
     public void save(boolean async, ModelClass model, int saveMode);
+
+    /**
+     * Saves the specified model to the DB.
+     *
+     * @param async    Whether to put it on the {@link com.raizlabs.android.dbflow.runtime.DBTransactionQueue}
+     * @param model    The model to save/insert/update
+     */
+    public void save(boolean async, ModelClass model);
+
 
     /**
      * Inserts the specified model into the DB.

--- a/library/src/main/java/com/raizlabs/android/dbflow/structure/ModelAdapter.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/structure/ModelAdapter.java
@@ -12,7 +12,7 @@ import com.raizlabs.android.dbflow.sql.builder.ConditionQueryBuilder;
  * Author: andrewgrosner
  * Description: Internal adapter that gets extended when a {@link com.raizlabs.android.dbflow.annotation.Table} gets used.
  */
-public abstract class ModelAdapter<ModelClass extends Model> implements InternalAdapter<ModelClass, ModelClass>, RetrievalAdapter<ModelClass> {
+public abstract class ModelAdapter<ModelClass extends Model> implements InternalAdapter<ModelClass, ModelClass>, RetrievalAdapter<ModelClass, ModelClass> {
 
     private ConditionQueryBuilder<ModelClass> mPrimaryWhere;
 
@@ -45,15 +45,22 @@ public abstract class ModelAdapter<ModelClass extends Model> implements Internal
     }
 
     /**
+     * @see #save(boolean, Model)
+     */
+    @Deprecated
+    public synchronized void save(boolean async, ModelClass model, int saveMode) {
+        SqlUtils.sync(async, model, this, saveMode);
+    }
+
+    /**
      * Saves the specified model to the DB using the specified saveMode in {@link com.raizlabs.android.dbflow.sql.SqlUtils}.
      *
      * @param async    Whether to put it on the {@link com.raizlabs.android.dbflow.runtime.DBTransactionQueue}
      * @param model    The model to save/insert/update
-     * @param saveMode The {@link com.raizlabs.android.dbflow.sql.SqlUtils} save mode. Can be {@link com.raizlabs.android.dbflow.sql.SqlUtils#SAVE_MODE_DEFAULT},
-     *                 {@link com.raizlabs.android.dbflow.sql.SqlUtils#SAVE_MODE_INSERT}, or {@link com.raizlabs.android.dbflow.sql.SqlUtils#SAVE_MODE_UPDATE}
      */
-    public synchronized void save(boolean async, ModelClass model, int saveMode) {
-        SqlUtils.sync(async, model, this, saveMode);
+    @Override
+    public synchronized void save(boolean async, ModelClass model) {
+        SqlUtils.save(async, model, this, this);
     }
 
     /**
@@ -63,7 +70,7 @@ public abstract class ModelAdapter<ModelClass extends Model> implements Internal
      * @param model The model to insert.
      */
     public synchronized void insert(boolean async, ModelClass model) {
-        SqlUtils.insert(async, model, this);
+        SqlUtils.insert(async, model, this, this);
     }
 
     /**
@@ -73,7 +80,7 @@ public abstract class ModelAdapter<ModelClass extends Model> implements Internal
      * @param model The model to update.
      */
     public synchronized void update(boolean async, ModelClass model) {
-        SqlUtils.update(async, model, this);
+        SqlUtils.update(async, model, this, this);
     }
 
     /**
@@ -113,8 +120,6 @@ public abstract class ModelAdapter<ModelClass extends Model> implements Internal
     public long getAutoIncrementingId(ModelClass model) {
         return 0;
     }
-
-    public abstract ConditionQueryBuilder<ModelClass> getPrimaryModelWhere(ModelClass model);
 
     /**
      * @return Only created once if doesn't exist, the extended class will return the builder to use.

--- a/library/src/main/java/com/raizlabs/android/dbflow/structure/ModelAdapter.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/structure/ModelAdapter.java
@@ -12,11 +12,9 @@ import com.raizlabs.android.dbflow.sql.builder.ConditionQueryBuilder;
  * Author: andrewgrosner
  * Description: Internal adapter that gets extended when a {@link com.raizlabs.android.dbflow.annotation.Table} gets used.
  */
-public abstract class ModelAdapter<ModelClass extends Model> implements InternalAdapter<ModelClass, ModelClass>, RetrievalAdapter<ModelClass, ModelClass> {
+public abstract class ModelAdapter<ModelClass extends Model> implements InternalAdapter<ModelClass, ModelClass>, InstanceAdapter<ModelClass, ModelClass> {
 
     private ConditionQueryBuilder<ModelClass> mPrimaryWhere;
-
-    private ConditionQueryBuilder<ModelClass> mFullWhere;
 
     private SQLiteStatement mInsertStatement;
 
@@ -106,14 +104,6 @@ public abstract class ModelAdapter<ModelClass extends Model> implements Internal
     }
 
     /**
-     * @return true if it has a {@link com.raizlabs.android.dbflow.annotation.Column#PRIMARY_KEY_AUTO_INCREMENT} field.
-     * This is used to help check for existence before saving for maximum speed optimization.
-     */
-    public boolean hasAutoIncrementPrimaryKey() {
-        return false;
-    }
-
-    /**
      * @return The value for the {@link com.raizlabs.android.dbflow.annotation.Column#PRIMARY_KEY_AUTO_INCREMENT}
      * if it has the field. This method is overridden when its specified for the {@link ModelClass}
      */
@@ -148,12 +138,6 @@ public abstract class ModelAdapter<ModelClass extends Model> implements Internal
      * @return The query used to insert a model using a {@link android.database.sqlite.SQLiteStatement}
      */
     protected abstract String getInsertStatementQuery();
-
-    /**
-     * @return A new model using its default constructor. This is why default is required so that
-     * we don't use reflection to create objects = faster.
-     */
-    public abstract ModelClass newInstance();
 
     /**
      * @return The conflict algorithm to use when updating a row in this table.

--- a/library/src/main/java/com/raizlabs/android/dbflow/structure/ModelViewAdapter.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/structure/ModelViewAdapter.java
@@ -9,7 +9,7 @@ import com.raizlabs.android.dbflow.sql.builder.ConditionQueryBuilder;
  * Description: The base class for a {@link ModelViewClass} adapter that defines how it interacts with the DB.
  */
 public abstract class ModelViewAdapter<ModelClass extends Model, ModelViewClass extends BaseModelView<ModelClass>>
-        implements RetrievalAdapter<ModelViewClass> {
+        implements RetrievalAdapter<ModelViewClass, ModelViewClass> {
 
     /**
      * Creates a new {@link ModelViewClass} and loads the cursor into it.
@@ -32,12 +32,6 @@ public abstract class ModelViewAdapter<ModelClass extends Model, ModelViewClass 
      * @return a string of the query that is used to create this model view.
      */
     public abstract String getCreationQuery();
-
-    /**
-     * @param modelView The modelview to read values from
-     * @return The {@link com.raizlabs.android.dbflow.sql.builder.ConditionQueryBuilder} of all its columns
-     */
-    public abstract ConditionQueryBuilder<ModelViewClass> getPrimaryModelWhere(ModelViewClass modelView);
 
     /**
      * @return The name of this view in the database

--- a/library/src/main/java/com/raizlabs/android/dbflow/structure/ModelViewAdapter.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/structure/ModelViewAdapter.java
@@ -26,7 +26,7 @@ public abstract class ModelViewAdapter<ModelClass extends Model, ModelViewClass 
     /**
      * @return A new instace of the {@link ModelViewClass} must have a default constructor.
      */
-    protected abstract ModelViewClass newInstance();
+    public abstract ModelViewClass newInstance();
 
     /**
      * @return a string of the query that is used to create this model view.

--- a/library/src/main/java/com/raizlabs/android/dbflow/structure/ModelViewAdapter.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/structure/ModelViewAdapter.java
@@ -9,7 +9,7 @@ import com.raizlabs.android.dbflow.sql.builder.ConditionQueryBuilder;
  * Description: The base class for a {@link ModelViewClass} adapter that defines how it interacts with the DB.
  */
 public abstract class ModelViewAdapter<ModelClass extends Model, ModelViewClass extends BaseModelView<ModelClass>>
-        implements RetrievalAdapter<ModelViewClass, ModelViewClass> {
+        implements InstanceAdapter<ModelViewClass, ModelViewClass> {
 
     /**
      * Creates a new {@link ModelViewClass} and loads the cursor into it.
@@ -22,11 +22,6 @@ public abstract class ModelViewAdapter<ModelClass extends Model, ModelViewClass 
         loadFromCursor(cursor, modelViewClass);
         return modelViewClass;
     }
-
-    /**
-     * @return A new instace of the {@link ModelViewClass} must have a default constructor.
-     */
-    public abstract ModelViewClass newInstance();
 
     /**
      * @return a string of the query that is used to create this model view.

--- a/library/src/main/java/com/raizlabs/android/dbflow/structure/RetrievalAdapter.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/structure/RetrievalAdapter.java
@@ -2,11 +2,13 @@ package com.raizlabs.android.dbflow.structure;
 
 import android.database.Cursor;
 
+import com.raizlabs.android.dbflow.sql.builder.ConditionQueryBuilder;
+
 /**
  * Description: Provides a base retrieval interface for all {@link com.raizlabs.android.dbflow.structure.Model} backed
  * adapters.
  */
-public interface RetrievalAdapter<ModelClass extends Model> {
+public interface RetrievalAdapter<TableClass extends Model, ModelClass extends Model> {
 
     /**
      * Assigns the {@link android.database.Cursor} data into the specified {@link ModelClass}
@@ -16,11 +18,12 @@ public interface RetrievalAdapter<ModelClass extends Model> {
      */
     public void loadFromCursor(Cursor cursor, ModelClass model);
 
-
     /**
      * @param model The model to query values from
      * @return True if it exists as VIEW row in the database table
      */
     public boolean exists(ModelClass model);
+
+    public ConditionQueryBuilder<TableClass> getPrimaryModelWhere(ModelClass model);
 
 }

--- a/library/src/main/java/com/raizlabs/android/dbflow/structure/container/BaseModelContainer.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/structure/container/BaseModelContainer.java
@@ -106,7 +106,7 @@ public abstract class BaseModelContainer<ModelClass extends Model, DataClass> im
 
     @Override
     public void save(boolean async) {
-        mContainerAdapter.save(async, this, SqlUtils.SAVE_MODE_DEFAULT);
+        mContainerAdapter.save(async, this);
     }
 
     @Override

--- a/library/src/main/java/com/raizlabs/android/dbflow/structure/container/ContainerAdapter.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/structure/container/ContainerAdapter.java
@@ -1,25 +1,39 @@
 package com.raizlabs.android.dbflow.structure.container;
 
-import com.raizlabs.android.dbflow.sql.builder.ConditionQueryBuilder;
+import com.raizlabs.android.dbflow.sql.SqlUtils;
 import com.raizlabs.android.dbflow.structure.InternalAdapter;
 import com.raizlabs.android.dbflow.structure.Model;
 import com.raizlabs.android.dbflow.structure.RetrievalAdapter;
+
+import static com.raizlabs.android.dbflow.sql.SqlUtils.*;
 
 /**
  * Description: The base class that generated {@link com.raizlabs.android.dbflow.structure.container.ContainerAdapter} implement
  * to provide the necessary interactions.
  */
-public abstract class ContainerAdapter<ModelClass extends Model> implements InternalAdapter<ModelClass, ModelContainer<ModelClass, ?>>, RetrievalAdapter<ModelContainer<ModelClass, ?>> {
+public abstract class ContainerAdapter<ModelClass extends Model> implements InternalAdapter<ModelClass, ModelContainer<ModelClass, ?>>, RetrievalAdapter<ModelClass, ModelContainer<ModelClass, ?>> {
 
     /**
      * Saves the container to the DB.
      *
      * @param async          Whether it is immediate or on {@link com.raizlabs.android.dbflow.runtime.DBTransactionQueue}
      * @param modelContainer The container to read data from into {@link android.content.ContentValues}
-     * @param saveMode       The {@link com.raizlabs.android.dbflow.sql.SqlUtils.SaveMode}
+     * @param saveMode       The {@link SaveMode}
      */
+    @Deprecated
     public void save(boolean async, ModelContainer<ModelClass, ?> modelContainer, int saveMode) {
         ModelContainerUtils.sync(async, modelContainer, this, saveMode);
+    }
+
+    /**
+     * Saves the container to the DB.
+     *
+     * @param async          Whether it is immediate or on {@link com.raizlabs.android.dbflow.runtime.DBTransactionQueue}
+     * @param modelContainer The container to read data from into {@link android.content.ContentValues}
+     */
+    @Override
+    public void save(boolean async, ModelContainer<ModelClass, ?> modelContainer) {
+        SqlUtils.save(async, modelContainer, this, modelContainer.getModelAdapter());
     }
 
     /**
@@ -29,7 +43,7 @@ public abstract class ContainerAdapter<ModelClass extends Model> implements Inte
      * @param modelContainer The model container to insert.
      */
     public void insert(boolean async, ModelContainer<ModelClass, ?> modelContainer) {
-        ModelContainerUtils.insert(async, modelContainer, this);
+        SqlUtils.insert(async, modelContainer, this, modelContainer.getModelAdapter());
     }
 
     /**
@@ -39,7 +53,7 @@ public abstract class ContainerAdapter<ModelClass extends Model> implements Inte
      * @param modelContainer The model to update.
      */
     public void update(boolean async, ModelContainer<ModelClass, ?> modelContainer) {
-        ModelContainerUtils.update(async, modelContainer, this);
+        SqlUtils.update(async, modelContainer, this, modelContainer.getModelAdapter());
     }
 
     /**
@@ -50,7 +64,7 @@ public abstract class ContainerAdapter<ModelClass extends Model> implements Inte
      */
     @Override
     public void delete(boolean async, ModelContainer<ModelClass, ?> modelContainer) {
-        ModelContainerUtils.delete(modelContainer, this, async);
+        SqlUtils.delete(modelContainer, this, async);
     }
 
     /**
@@ -81,13 +95,6 @@ public abstract class ContainerAdapter<ModelClass extends Model> implements Inte
     public long getAutoIncrementingId(ModelContainer<ModelClass, ?> modelContainer) {
         return 0;
     }
-
-    /**
-     * @param modelContainer
-     * @return a {@link com.raizlabs.android.dbflow.sql.builder.ConditionQueryBuilder} of the primary keys
-     * of the model object.
-     */
-    public abstract ConditionQueryBuilder<ModelClass> getPrimaryModelWhere(ModelContainer<ModelClass, ?> modelContainer);
 
     /**
      * Returns the type of the column for this model container. It's useful for when we do not know the exact class of the column

--- a/library/src/main/java/com/raizlabs/android/dbflow/structure/container/ModelContainerUtils.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/structure/container/ModelContainerUtils.java
@@ -60,7 +60,7 @@ public class ModelContainerUtils {
                 insert(false, modelContainer, containerAdapter);
             }
 
-            SqlUtils.notifyModelChanged(modelContainer.getTable(), action);
+            //SqlUtils.notifyModelChanged(modelContainer.getTable(), action);
 
         } else {
             TransactionManager.getInstance().save(ProcessModelInfo.withModels(modelContainer));
@@ -81,7 +81,7 @@ public class ModelContainerUtils {
         if (!async) {
             new Delete().from(modelContainer.getTable()).where(containerAdapter.getPrimaryModelWhere(modelContainer)).query();
             containerAdapter.updateAutoIncrement(modelContainer, 0);
-            SqlUtils.notifyModelChanged(modelContainer.getTable(), BaseModel.Action.DELETE);
+            //SqlUtils.notifyModelChanged(modelContainer.getTable(), BaseModel.Action.DELETE);
         } else {
             TransactionManager.getInstance().delete(ProcessModelInfo.withModels(modelContainer));
         }
@@ -102,7 +102,7 @@ public class ModelContainerUtils {
             modelAdapter.bindToStatement(insertStatement, modelContainer);
             long id = insertStatement.executeInsert();
             modelAdapter.updateAutoIncrement(modelContainer, id);
-            SqlUtils.notifyModelChanged(modelAdapter.getModelClass(), BaseModel.Action.INSERT);
+            //SqlUtils.notifyModelChanged(modelAdapter.getModelClass(), BaseModel.Action.INSERT);
         } else {
             TransactionManager.getInstance().addTransaction(new InsertModelTransaction<>(ProcessModelInfo.withModels(modelContainer)
                     .info(DBTransactionInfo.createSave())));
@@ -138,7 +138,7 @@ public class ModelContainerUtils {
                 // insert
                 insert(false, modelContainer, modelClassContainerAdapter);
             } else {
-                SqlUtils.notifyModelChanged(modelClassModelAdapter.getModelClass(), BaseModel.Action.UPDATE);
+                //SqlUtils.notifyModelChanged(modelClassModelAdapter.getModelClass(), BaseModel.Action.UPDATE);
             }
         } else {
             TransactionManager.getInstance().update(ProcessModelInfo.withModels(modelContainer).info(DBTransactionInfo.createSave()));

--- a/library/src/main/java/com/raizlabs/android/dbflow/structure/container/ModelContainerUtils.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/structure/container/ModelContainerUtils.java
@@ -19,10 +19,10 @@ import com.raizlabs.android.dbflow.structure.Model;
 import com.raizlabs.android.dbflow.structure.ModelAdapter;
 
 /**
- * Author: andrewgrosner
- * Description: Provides helper methods for handling {@link com.raizlabs.android.dbflow.structure.container.ModelContainer} classes.
- * These wrap around {@link com.raizlabs.android.dbflow.structure.Model} to provide more convenient means of interacting with the db.
+ * @see {@link com.raizlabs.android.dbflow.sql.SqlUtils}
+ * @deprecated Now we consolidated methods to elminate duplication. These methods will no longer be updated.
  */
+@Deprecated
 public class ModelContainerUtils {
 
     /**
@@ -35,6 +35,7 @@ public class ModelContainerUtils {
      * @param <ModelClass>   The class that implements {@link com.raizlabs.android.dbflow.structure.Model}
      */
     @SuppressWarnings("unchecked")
+    @Deprecated
     public static <ModelClass extends Model> void sync(boolean async, ModelContainer<ModelClass, ?> modelContainer, ContainerAdapter<ModelClass> containerAdapter, @SqlUtils.SaveMode int mode) {
         if (!async) {
 
@@ -61,7 +62,7 @@ public class ModelContainerUtils {
                 insert(false, modelContainer, containerAdapter);
             }
 
-            if(FlowContentObserver.shouldNotify()) {
+            if (FlowContentObserver.shouldNotify()) {
                 SqlUtils.notifyModelChanged(modelContainer.getTable(), action);
             }
 
@@ -79,6 +80,7 @@ public class ModelContainerUtils {
      * @param <ModelClass>   The class that implements {@link com.raizlabs.android.dbflow.structure.Model}
      */
     @SuppressWarnings("unchecked")
+    @Deprecated
     public static <ModelClass extends Model> void delete(final ModelContainer<ModelClass, ?> modelContainer,
                                                          ContainerAdapter<ModelClass> containerAdapter, boolean async) {
         if (!async) {
@@ -100,6 +102,7 @@ public class ModelContainerUtils {
      * @param modelAdapter   The container adapter to use.
      * @param <ModelClass>   The class that implements {@link com.raizlabs.android.dbflow.structure.Model}
      */
+    @Deprecated
     public static <ModelClass extends Model> void insert(boolean async, ModelContainer<ModelClass, ?> modelContainer, ContainerAdapter<ModelClass> modelAdapter) {
         if (!async) {
             ModelAdapter<ModelClass> modelClassModelAdapter = FlowManager.getModelAdapter(modelContainer.getTable());
@@ -126,6 +129,7 @@ public class ModelContainerUtils {
      * @return true if model was inserted, false if not. Also false could mean that it is placed on the
      * {@link com.raizlabs.android.dbflow.runtime.DBTransactionQueue} using async to true.
      */
+    @Deprecated
     public static <ModelClass extends Model> boolean update(boolean async, ModelContainer<ModelClass, ?> modelContainer, ContainerAdapter<ModelClass> modelClassContainerAdapter) {
         boolean exists = false;
         if (!async) {

--- a/library/src/main/java/com/raizlabs/android/dbflow/structure/container/ModelContainerUtils.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/structure/container/ModelContainerUtils.java
@@ -8,6 +8,7 @@ import android.os.Build;
 import com.raizlabs.android.dbflow.annotation.ConflictAction;
 import com.raizlabs.android.dbflow.config.FlowManager;
 import com.raizlabs.android.dbflow.runtime.DBTransactionInfo;
+import com.raizlabs.android.dbflow.runtime.FlowContentObserver;
 import com.raizlabs.android.dbflow.runtime.TransactionManager;
 import com.raizlabs.android.dbflow.runtime.transaction.process.InsertModelTransaction;
 import com.raizlabs.android.dbflow.runtime.transaction.process.ProcessModelInfo;
@@ -60,7 +61,9 @@ public class ModelContainerUtils {
                 insert(false, modelContainer, containerAdapter);
             }
 
-            //SqlUtils.notifyModelChanged(modelContainer.getTable(), action);
+            if(FlowContentObserver.shouldNotify()) {
+                SqlUtils.notifyModelChanged(modelContainer.getTable(), action);
+            }
 
         } else {
             TransactionManager.getInstance().save(ProcessModelInfo.withModels(modelContainer));
@@ -81,7 +84,9 @@ public class ModelContainerUtils {
         if (!async) {
             new Delete().from(modelContainer.getTable()).where(containerAdapter.getPrimaryModelWhere(modelContainer)).query();
             containerAdapter.updateAutoIncrement(modelContainer, 0);
-            //SqlUtils.notifyModelChanged(modelContainer.getTable(), BaseModel.Action.DELETE);
+            if (FlowContentObserver.shouldNotify()) {
+                SqlUtils.notifyModelChanged(modelContainer.getTable(), BaseModel.Action.DELETE);
+            }
         } else {
             TransactionManager.getInstance().delete(ProcessModelInfo.withModels(modelContainer));
         }
@@ -102,7 +107,9 @@ public class ModelContainerUtils {
             modelAdapter.bindToStatement(insertStatement, modelContainer);
             long id = insertStatement.executeInsert();
             modelAdapter.updateAutoIncrement(modelContainer, id);
-            //SqlUtils.notifyModelChanged(modelAdapter.getModelClass(), BaseModel.Action.INSERT);
+            if (FlowContentObserver.shouldNotify()) {
+                SqlUtils.notifyModelChanged(modelAdapter.getModelClass(), BaseModel.Action.INSERT);
+            }
         } else {
             TransactionManager.getInstance().addTransaction(new InsertModelTransaction<>(ProcessModelInfo.withModels(modelContainer)
                     .info(DBTransactionInfo.createSave())));
@@ -137,8 +144,8 @@ public class ModelContainerUtils {
             if (!exists) {
                 // insert
                 insert(false, modelContainer, modelClassContainerAdapter);
-            } else {
-                //SqlUtils.notifyModelChanged(modelClassModelAdapter.getModelClass(), BaseModel.Action.UPDATE);
+            } else if (FlowContentObserver.shouldNotify()) {
+                SqlUtils.notifyModelChanged(modelClassModelAdapter.getModelClass(), BaseModel.Action.UPDATE);
             }
         } else {
             TransactionManager.getInstance().update(ProcessModelInfo.withModels(modelContainer).info(DBTransactionInfo.createSave()));


### PR DESCRIPTION
1. Discovered a bottleneck when we call  ```SqlUtils.notifyModelChanged()``` even when not listening for changes. Now it only gets called when we register a ```FlowContentObserver```, resulting in ~%60 speed improvement!!!!
2. Consolidated ```ModelContainerUtils``` methods into ```SqlUtils``` due to the adapter improvements in 1.4.2 that enabled the change. Thus ```ModelContainerUtils``` is deprecated.
3. ```SqlUtils.convertToList()``` should be leaner by reusing a model adapter before looping through a ```Cursor```.  