### PR TITLE
Added a Full Featured Model Cache

### DIFF
--- a/compiler/src/main/java/com/raizlabs/android/dbflow/processor/definition/ColumnDefinition.java
+++ b/compiler/src/main/java/com/raizlabs/android/dbflow/processor/definition/ColumnDefinition.java
@@ -140,7 +140,7 @@ public class ColumnDefinition extends BaseDefinition implements FlowWriter {
         return (columnName + "_" + reference.columnName()).toUpperCase();
     }
 
-    protected void writeColumnDefinition(JavaWriter javaWriter, String columnName) throws IOException {
+    public void writeColumnDefinition(JavaWriter javaWriter, String columnName) throws IOException {
         writeColumnDefinition(javaWriter, columnName.toUpperCase(), columnName);
     }
 

--- a/compiler/src/main/java/com/raizlabs/android/dbflow/processor/writer/LoadCursorWriter.java
+++ b/compiler/src/main/java/com/raizlabs/android/dbflow/processor/writer/LoadCursorWriter.java
@@ -87,19 +87,19 @@ public class LoadCursorWriter implements FlowWriter {
                     AdapterQueryBuilder queryBuilder = new AdapterQueryBuilder()
                             .append(ModelUtils.getVariable(isModelContainerDefinition));
 
-                            if(!isModelContainerDefinition) {
-                                queryBuilder.append(".").append(columnDefinition.columnFieldName)
-                                        .append(" = ")
-                                        .appendCast(columnDefinition.columnFieldType)
-                                        .append(params[3]).append(")");
-                            } else {
-                                String containerKeyName = columnDefinition.columnFieldName;
-                                if(columnDefinition.containerKeyName != null) {
-                                    containerKeyName = columnDefinition.containerKeyName;
-                                }
-                                queryBuilder.appendPut(containerKeyName)
-                                        .append(params[3]).append(")");
-                            }
+                    if (!isModelContainerDefinition) {
+                        queryBuilder.append(".").append(columnDefinition.columnFieldName)
+                                .append(" = ")
+                                .appendCast(columnDefinition.columnFieldType)
+                                .append(params[3]).append(")");
+                    } else {
+                        String containerKeyName = columnDefinition.columnFieldName;
+                        if (columnDefinition.containerKeyName != null) {
+                            containerKeyName = columnDefinition.containerKeyName;
+                        }
+                        queryBuilder.appendPut(containerKeyName)
+                                .append(params[3]).append(")");
+                    }
 
                     javaWriter.emitStatement(queryBuilder.getQuery());
                 }
@@ -117,11 +117,11 @@ public class LoadCursorWriter implements FlowWriter {
                             .appendCast("long")
                             .append(ModelUtils.getVariable(isModelContainerDefinition));
 
-                    if(!isModelContainerDefinition) {
+                    if (!isModelContainerDefinition) {
                         queryBuilder.append(".").append(columnDefinition.columnFieldName);
                     } else {
                         String containerKeyName = columnDefinition.columnFieldName;
-                        if(columnDefinition.containerKeyName != null) {
+                        if (columnDefinition.containerKeyName != null) {
                             containerKeyName = columnDefinition.containerKeyName;
                         }
                         queryBuilder.append(".").appendGetValue(containerKeyName);
@@ -131,6 +131,16 @@ public class LoadCursorWriter implements FlowWriter {
                 }
             }, "long", "getAutoIncrementingId", Sets.newHashSet(Modifier.PUBLIC), params2);
 
+            if (!isModelContainerDefinition) {
+                WriterUtils.emitOverriddenMethod(javaWriter, new FlowWriter() {
+                    @Override
+                    public void write(JavaWriter javaWriter) throws IOException {
+                        ColumnDefinition columnDefinition = ((TableDefinition) tableDefinition).autoIncrementDefinition;
+
+                        javaWriter.emitStatement("return %1s.%1s", tableDefinition.getTableSourceClassName(), columnDefinition.columnName.toUpperCase());
+                    }
+                }, "String", "getAutoIncrementingColumnName", Sets.newHashSet(Modifier.PUBLIC));
+            }
         }
     }
 }

--- a/compiler/src/main/java/com/raizlabs/android/dbflow/processor/writer/LoadCursorWriter.java
+++ b/compiler/src/main/java/com/raizlabs/android/dbflow/processor/writer/LoadCursorWriter.java
@@ -104,6 +104,33 @@ public class LoadCursorWriter implements FlowWriter {
                     javaWriter.emitStatement(queryBuilder.getQuery());
                 }
             }, "void", "updateAutoIncrement", Sets.newHashSet(Modifier.PUBLIC), params);
+
+            String[] params2 = new String[2];
+            params2[0] = ModelUtils.getParameter(isModelContainerDefinition, tableDefinition.getModelClassName());
+            params2[1] = ModelUtils.getVariable(isModelContainerDefinition);
+            WriterUtils.emitOverriddenMethod(javaWriter, new FlowWriter() {
+                @Override
+                public void write(JavaWriter javaWriter) throws IOException {
+                    ColumnDefinition columnDefinition = ((TableDefinition) tableDefinition).autoIncrementDefinition;
+                    AdapterQueryBuilder queryBuilder = new AdapterQueryBuilder()
+                            .append("return ")
+                            .appendCast("long")
+                            .append(ModelUtils.getVariable(isModelContainerDefinition));
+
+                    if(!isModelContainerDefinition) {
+                        queryBuilder.append(".").append(columnDefinition.columnFieldName);
+                    } else {
+                        String containerKeyName = columnDefinition.columnFieldName;
+                        if(columnDefinition.containerKeyName != null) {
+                            containerKeyName = columnDefinition.containerKeyName;
+                        }
+                        queryBuilder.append(".").appendGetValue(containerKeyName);
+                    }
+
+                    javaWriter.emitStatement(queryBuilder.append(")").getQuery());
+                }
+            }, "long", "getAutoIncrementingId", Sets.newHashSet(Modifier.PUBLIC), params2);
+
         }
     }
 }

--- a/compiler/src/main/java/com/raizlabs/android/dbflow/processor/writer/LoadCursorWriter.java
+++ b/compiler/src/main/java/com/raizlabs/android/dbflow/processor/writer/LoadCursorWriter.java
@@ -67,7 +67,7 @@ public class LoadCursorWriter implements FlowWriter {
                     columnDefinition.writeLoadFromCursorDefinition(javaWriter, isModelContainerDefinition);
                 }
 
-                if (implementsLoadFromCursorListener) {
+                if (implementsLoadFromCursorListener && !isModelContainerDefinition) {
                     javaWriter.emitStatement("%1s.onLoadFromCursor(%1s)", ModelUtils.getVariable(isModelContainerDefinition),
                             params[1]);
                 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=1.4.5
+VERSION_NAME=1.4.6
 VERSION_CODE=1
 GROUP=com.raizlabs.android
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=1.4.6
+VERSION_NAME=1.5.0
 VERSION_CODE=1
 GROUP=com.raizlabs.android
 

--- a/library/src/androidTest/java/com/raizlabs/android/dbflow/test/structure/CacheableModel.java
+++ b/library/src/androidTest/java/com/raizlabs/android/dbflow/test/structure/CacheableModel.java
@@ -1,0 +1,24 @@
+package com.raizlabs.android.dbflow.test.structure;
+
+import com.raizlabs.android.dbflow.annotation.Column;
+import com.raizlabs.android.dbflow.annotation.Table;
+import com.raizlabs.android.dbflow.structure.cache.BaseCacheableModel;
+import com.raizlabs.android.dbflow.test.TestDatabase;
+
+/**
+ * Description:
+ */
+@Table(databaseName = TestDatabase.NAME)
+public class CacheableModel extends BaseCacheableModel {
+
+    @Column(columnType = Column.PRIMARY_KEY_AUTO_INCREMENT)
+    long id;
+
+    @Column
+    String name;
+
+    @Override
+    public int getCacheSize() {
+        return 1000;
+    }
+}

--- a/library/src/androidTest/java/com/raizlabs/android/dbflow/test/structure/CacheableModelTest.java
+++ b/library/src/androidTest/java/com/raizlabs/android/dbflow/test/structure/CacheableModelTest.java
@@ -24,7 +24,11 @@ public class CacheableModelTest extends FlowTestCase {
                 modelCache = BaseCacheableModel.getCache((Class<CacheableModel>) model.getClass());
             }
 
-            assertNotNull(modelCache.get(model.id));
+            long id = model.id;
+            assertNotNull(modelCache.get(id));
+
+            model.delete(false);
+            assertNull(modelCache.get(id));
         }
 
         Delete.table(CacheableModel.class);

--- a/library/src/androidTest/java/com/raizlabs/android/dbflow/test/structure/CacheableModelTest.java
+++ b/library/src/androidTest/java/com/raizlabs/android/dbflow/test/structure/CacheableModelTest.java
@@ -1,6 +1,7 @@
 package com.raizlabs.android.dbflow.test.structure;
 
 import com.raizlabs.android.dbflow.sql.language.Delete;
+import com.raizlabs.android.dbflow.sql.language.Select;
 import com.raizlabs.android.dbflow.structure.cache.BaseCacheableModel;
 import com.raizlabs.android.dbflow.structure.cache.ModelCache;
 import com.raizlabs.android.dbflow.test.FlowTestCase;
@@ -14,7 +15,7 @@ public class CacheableModelTest extends FlowTestCase {
 
         Delete.table(CacheableModel.class);
 
-        ModelCache<CacheableModel> modelCache = null;
+        ModelCache<CacheableModel, ?> modelCache = null;
         for (int i = 0; i < 1000; i++) {
             CacheableModel model = new CacheableModel();
             model.name = "Test";
@@ -26,6 +27,8 @@ public class CacheableModelTest extends FlowTestCase {
 
             long id = model.id;
             assertNotNull(modelCache.get(id));
+
+            assertEquals(Select.byId(CacheableModel.class, id), modelCache.get(id));
 
             model.delete(false);
             assertNull(modelCache.get(id));

--- a/library/src/androidTest/java/com/raizlabs/android/dbflow/test/structure/CacheableModelTest.java
+++ b/library/src/androidTest/java/com/raizlabs/android/dbflow/test/structure/CacheableModelTest.java
@@ -1,0 +1,32 @@
+package com.raizlabs.android.dbflow.test.structure;
+
+import com.raizlabs.android.dbflow.sql.language.Delete;
+import com.raizlabs.android.dbflow.structure.cache.BaseCacheableModel;
+import com.raizlabs.android.dbflow.structure.cache.ModelCache;
+import com.raizlabs.android.dbflow.test.FlowTestCase;
+
+/**
+ * Description:
+ */
+public class CacheableModelTest extends FlowTestCase {
+
+    public void testCacheableModel() {
+
+        Delete.table(CacheableModel.class);
+
+        ModelCache<CacheableModel> modelCache = null;
+        for (int i = 0; i < 1000; i++) {
+            CacheableModel model = new CacheableModel();
+            model.name = "Test";
+            model.save(false);
+
+            if (modelCache == null) {
+                modelCache = BaseCacheableModel.getCache((Class<CacheableModel>) model.getClass());
+            }
+
+            assertNotNull(modelCache.get(model.id));
+        }
+
+        Delete.table(CacheableModel.class);
+    }
+}

--- a/library/src/main/java/com/raizlabs/android/dbflow/list/FlowCursorList.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/list/FlowCursorList.java
@@ -3,7 +3,6 @@ package com.raizlabs.android.dbflow.list;
 import android.database.ContentObserver;
 import android.database.Cursor;
 import android.os.Handler;
-import android.util.SparseArray;
 
 import com.raizlabs.android.dbflow.runtime.DBTransactionInfo;
 import com.raizlabs.android.dbflow.runtime.TransactionManager;
@@ -14,6 +13,7 @@ import com.raizlabs.android.dbflow.sql.SqlUtils;
 import com.raizlabs.android.dbflow.sql.builder.Condition;
 import com.raizlabs.android.dbflow.sql.language.Select;
 import com.raizlabs.android.dbflow.structure.Model;
+import com.raizlabs.android.dbflow.structure.cache.ModelCache;
 
 import java.util.List;
 
@@ -27,7 +27,7 @@ public class FlowCursorList<ModelClass extends Model> {
 
     private Class<ModelClass> mTable;
 
-    private SparseArray<ModelClass> mModelCache;
+    private ModelCache<ModelClass> mModelCache;
 
     private boolean cacheModels;
 
@@ -35,30 +35,39 @@ public class FlowCursorList<ModelClass extends Model> {
 
     private CursorObserver mObserver;
 
+    private int mCacheSize;
+
+    /**
+     * Constructs an instance of this list with a specified cache size.
+     *
+     * @param cacheSize      The size of models to cache.
+     * @param modelQueriable The SQL where query to use when doing a query.
+     */
+    public FlowCursorList(int cacheSize, ModelQueriable<ModelClass> modelQueriable) {
+        this(false, modelQueriable);
+        setCacheModels(true, cacheSize);
+    }
+
     /**
      * Constructs an instance of this list.
      *
-     * @param cacheModels For every call to {@link #getItem(int)}, do we want to keep a reference to it so
-     *                    we do not need to convert the cursor data back into a {@link ModelClass} again.
-     * @param modelQueriable   The SQL where query to use when doing a query.
+     * @param cacheModels    For every call to {@link #getItem(long)}, we want to keep a reference to it so
+     *                       we do not need to convert the cursor data back into a {@link ModelClass} again.
+     * @param modelQueriable The SQL where query to use when doing a query.
      */
     public FlowCursorList(boolean cacheModels, ModelQueriable<ModelClass> modelQueriable) {
         mQueriable = modelQueriable;
         mCursor = mQueriable.query();
         mTable = modelQueriable.getTable();
         this.cacheModels = cacheModels;
-
-        if (cacheModels) {
-            mModelCache = new SparseArray<>(mCursor.getCount());
-        }
-
         mCursor.registerContentObserver(mObserver = new CursorObserver());
+        setCacheModels(cacheModels);
     }
 
     /**
      * Constructs an instance of this list.
      *
-     * @param cacheModels For every call to {@link #getItem(int)}, do we want to keep a reference to it so
+     * @param cacheModels For every call to {@link #getItem(long)}, do we want to keep a reference to it so
      *                    we do not need to convert the cursor data back into a {@link ModelClass} again.
      * @param table       The table to query from
      * @param conditions  The set of {@link com.raizlabs.android.dbflow.sql.builder.Condition} to query with
@@ -68,17 +77,46 @@ public class FlowCursorList<ModelClass extends Model> {
     }
 
     /**
-     * Sets this list to being caching models. If set to false, this will immediately clear the cache for you.
+     * Constructs an instance of this list with a specified cache size.
      *
-     * @param cacheModels
+     * @param cacheSize  The size of models to cache.
+     * @param table      The table to query from
+     * @param conditions The set of {@link com.raizlabs.android.dbflow.sql.builder.Condition} to query with
+     */
+    public FlowCursorList(int cacheSize, Class<ModelClass> table, Condition... conditions) {
+        this(false, new Select().from(table).where(conditions));
+        setCacheModels(true, cacheSize);
+    }
+
+    /**
+     * Sets this list to being caching models. If set to false, this will immediately clear the cache for you.
+     * The cache size will default to the {@link android.database.Cursor#getCount()}
+     *
+     * @param cacheModels true, will cache models. If false, any and future caching is cleared.
      */
     public void setCacheModels(boolean cacheModels) {
+        if (cacheModels) {
+            throwIfCursorClosed();
+            setCacheModels(true, mCursor.getCount());
+        } else {
+            setCacheModels(false, mCursor.getCount());
+        }
+    }
+
+    /**
+     * Sets this list to cache models. If set to false, it will immediately clear the cache for you.
+     *
+     * @param cacheModels true, will cache models. If false, any and future caching is cleared.
+     * @param cacheSize   The size of models to cache.
+     */
+    public void setCacheModels(boolean cacheModels, int cacheSize) {
         this.cacheModels = cacheModels;
         if (!cacheModels) {
             clearCache();
         } else {
             throwIfCursorClosed();
-            mModelCache = new SparseArray<>(mCursor.getCount());
+            mCacheSize = cacheSize;
+            mModelCache = new ModelCache<>(mCacheSize);
         }
     }
 
@@ -110,18 +148,17 @@ public class FlowCursorList<ModelClass extends Model> {
      * @param position The row number in the {@link android.database.Cursor} to look at
      * @return The {@link ModelClass} converted from the cursor
      */
-    public ModelClass getItem(int position) {
+    public ModelClass getItem(long position) {
         throwIfCursorClosed();
 
-        ModelClass model;
+        ModelClass model = null;
         if (cacheModels) {
             model = mModelCache.get(position);
-            if (model == null && mCursor.moveToPosition(position)) {
+            if (model == null && mCursor.moveToPosition((int) position)) {
                 model = SqlUtils.convertToModel(true, mTable, mCursor);
-                mModelCache.put(position, model);
+                mModelCache.addModel(position, model);
             }
-        } else {
-            mCursor.moveToPosition(position);
+        } else if (mCursor.moveToPosition((int) position)) {
             model = SqlUtils.convertToModel(true, mTable, mCursor);
         }
         return model;
@@ -185,7 +222,7 @@ public class FlowCursorList<ModelClass extends Model> {
     }
 
     private void throwIfCursorClosed() {
-        if(mCursor == null || mCursor.isClosed()) {
+        if (mCursor == null || mCursor.isClosed()) {
             throw new IllegalStateException("Cursor has been closed for FlowCursorList");
         }
     }

--- a/library/src/main/java/com/raizlabs/android/dbflow/list/FlowCursorList.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/list/FlowCursorList.java
@@ -14,6 +14,7 @@ import com.raizlabs.android.dbflow.sql.builder.Condition;
 import com.raizlabs.android.dbflow.sql.language.Select;
 import com.raizlabs.android.dbflow.structure.Model;
 import com.raizlabs.android.dbflow.structure.cache.ModelCache;
+import com.raizlabs.android.dbflow.structure.cache.ModelLruCache;
 
 import java.util.List;
 
@@ -27,7 +28,7 @@ public class FlowCursorList<ModelClass extends Model> {
 
     private Class<ModelClass> mTable;
 
-    private ModelCache<ModelClass> mModelCache;
+    private ModelCache<ModelClass, ?> mModelCache;
 
     private boolean cacheModels;
 
@@ -116,8 +117,12 @@ public class FlowCursorList<ModelClass extends Model> {
         } else {
             throwIfCursorClosed();
             mCacheSize = cacheSize;
-            mModelCache = new ModelCache<>(mCacheSize);
+            mModelCache = getBackingCache();
         }
+    }
+
+    protected ModelCache<ModelClass, ?> getBackingCache() {
+        return new ModelLruCache<>(mCacheSize);
     }
 
     /**

--- a/library/src/main/java/com/raizlabs/android/dbflow/list/FlowTableList.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/list/FlowTableList.java
@@ -21,6 +21,8 @@ import com.raizlabs.android.dbflow.sql.builder.Condition;
 import com.raizlabs.android.dbflow.sql.language.Delete;
 import com.raizlabs.android.dbflow.sql.language.Select;
 import com.raizlabs.android.dbflow.structure.Model;
+import com.raizlabs.android.dbflow.structure.cache.ModelCache;
+import com.raizlabs.android.dbflow.structure.cache.ModelLruCache;
 
 import java.lang.reflect.ParameterizedType;
 import java.util.Arrays;
@@ -74,7 +76,12 @@ public class FlowTableList<ModelClass extends Model> extends ContentObserver imp
      */
     public FlowTableList(Class<ModelClass> table, Condition... conditions) {
         super(null);
-        mCursorList = new FlowCursorList<ModelClass>(true, table, conditions);
+        mCursorList = new FlowCursorList<ModelClass>(true, table, conditions) {
+            @Override
+            protected ModelCache<ModelClass, ?> getBackingCache() {
+                return FlowTableList.this.getBackingCache();
+            }
+        };
     }
 
     /**
@@ -85,6 +92,14 @@ public class FlowTableList<ModelClass extends Model> extends ContentObserver imp
     public FlowTableList(ModelQueriable<ModelClass> modelQueriable) {
         super(null);
         mCursorList = new FlowCursorList<ModelClass>(transact, modelQueriable);
+    }
+
+    /**
+     * @return The cache backing this query. Override to provide a custom {@link com.raizlabs.android.dbflow.structure.cache.ModelCache}
+     * instead.
+     */
+    public ModelCache<ModelClass, ?> getBackingCache() {
+        return new ModelLruCache<>(mCursorList.getCount());
     }
 
     /**

--- a/library/src/main/java/com/raizlabs/android/dbflow/sql/SqlUtils.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/sql/SqlUtils.java
@@ -25,6 +25,7 @@ import com.raizlabs.android.dbflow.structure.InternalAdapter;
 import com.raizlabs.android.dbflow.structure.Model;
 import com.raizlabs.android.dbflow.structure.ModelAdapter;
 import com.raizlabs.android.dbflow.structure.RetrievalAdapter;
+import com.raizlabs.android.dbflow.structure.cache.BaseCacheableModel;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -36,7 +37,9 @@ import java.util.List;
 public class SqlUtils {
 
     @Deprecated
-    public @IntDef @interface SaveMode {
+    public
+    @IntDef
+    @interface SaveMode {
     }
 
     /**
@@ -77,12 +80,41 @@ public class SqlUtils {
      * @param <ModelClass> The class implements {@link com.raizlabs.android.dbflow.structure.Model}
      * @return a list of {@link ModelClass}
      */
+    @SuppressWarnings("unchecked")
     public static <ModelClass extends Model> List<ModelClass> queryList(Class<ModelClass> modelClass, String sql, String... args) {
         BaseDatabaseDefinition flowManager = FlowManager.getDatabaseForTable(modelClass);
         Cursor cursor = flowManager.getWritableDatabase().rawQuery(sql, args);
-        List<ModelClass> list = convertToList(modelClass, cursor);
+        List<ModelClass> list = null;
+        if (BaseCacheableModel.class.isAssignableFrom(modelClass)) {
+            list = (List<ModelClass>) convertToCacheableList((Class<? extends BaseCacheableModel>) modelClass, cursor);
+        } else {
+            list = convertToList(modelClass, cursor);
+        }
         cursor.close();
         return list;
+    }
+
+    private static <CacheableClass extends BaseCacheableModel> List<CacheableClass> convertToCacheableList(Class<CacheableClass> modelClass, Cursor cursor) {
+        final List<CacheableClass> entities = new ArrayList<>();
+        ModelAdapter<CacheableClass> instanceAdapter = FlowManager.getModelAdapter(modelClass);
+        if (instanceAdapter != null) {
+            if (cursor.moveToFirst()) {
+                do {
+                    long id = cursor.getLong(cursor.getColumnIndex(instanceAdapter.getAutoIncrementingFieldName()));
+
+                    // if it exists in cache no matter the query we will use that one
+                    CacheableClass cacheable = BaseCacheableModel.getCache(modelClass).get(id);
+                    if (cacheable != null) {
+                        entities.add(cacheable);
+                    } else {
+                        cacheable = instanceAdapter.newInstance();
+                        instanceAdapter.loadFromCursor(cursor, cacheable);
+                        entities.add(cacheable);
+                    }
+                } while (cursor.moveToNext());
+            }
+        }
+        return entities;
     }
 
     /**
@@ -147,6 +179,34 @@ public class SqlUtils {
     }
 
     /**
+     * Takes a {@link CacheableClass} from either cache (if exists) else it reads from the cursor
+     *
+     * @param dontMoveToFirst  If it's a list or at a specific position, do not reset the cursor
+     * @param table            The model class that we convert the cursor data into.
+     * @param cursor           The cursor from the DB
+     * @param <CacheableClass> The class that implements {@link com.raizlabs.android.dbflow.structure.Model}
+     * @return A model transformed from the {@link android.database.Cursor}
+     */
+    @SuppressWarnings("unchecked")
+    public static <CacheableClass extends BaseCacheableModel> CacheableClass convertToCacheableModel(boolean dontMoveToFirst, Class<CacheableClass> table, Cursor cursor) {
+        CacheableClass model = null;
+        if (dontMoveToFirst || cursor.moveToFirst()) {
+            ModelAdapter<CacheableClass> modelAdapter = FlowManager.getModelAdapter(table);
+
+            if (modelAdapter != null) {
+                long id = cursor.getLong(cursor.getColumnIndex(modelAdapter.getAutoIncrementingFieldName()));
+                model = BaseCacheableModel.getCache(table).get(id);
+                if (model == null) {
+                    model = modelAdapter.newInstance();
+                    modelAdapter.loadFromCursor(cursor, model);
+                }
+            }
+        }
+
+        return model;
+    }
+
+    /**
      * Queries the DB and returns the first {@link com.raizlabs.android.dbflow.structure.Model} it finds. Note:
      * this may return more than one object, but only will return the first item in the list.
      *
@@ -158,9 +218,15 @@ public class SqlUtils {
      * @param <ModelClass> The class implements {@link com.raizlabs.android.dbflow.structure.Model}
      * @return a single {@link ModelClass}
      */
+    @SuppressWarnings("unchecked")
     public static <ModelClass extends Model> ModelClass querySingle(Class<ModelClass> modelClass, String sql, String... args) {
         Cursor cursor = FlowManager.getDatabaseForTable(modelClass).getWritableDatabase().rawQuery(sql, args);
-        ModelClass retModel = convertToModel(false, modelClass, cursor);
+        ModelClass retModel = null;
+        if (BaseCacheableModel.class.isAssignableFrom(modelClass)) {
+            retModel = (ModelClass) convertToCacheableModel(false, (Class<? extends BaseCacheableModel>) modelClass, cursor);
+        } else {
+            retModel = convertToModel(false, modelClass, cursor);
+        }
         cursor.close();
         return retModel;
     }

--- a/library/src/main/java/com/raizlabs/android/dbflow/sql/SqlUtils.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/sql/SqlUtils.java
@@ -100,7 +100,7 @@ public class SqlUtils {
         if (instanceAdapter != null) {
             if (cursor.moveToFirst()) {
                 do {
-                    long id = cursor.getLong(cursor.getColumnIndex(instanceAdapter.getAutoIncrementingFieldName()));
+                    long id = cursor.getLong(cursor.getColumnIndex(instanceAdapter.getAutoIncrementingColumnName()));
 
                     // if it exists in cache no matter the query we will use that one
                     CacheableClass cacheable = BaseCacheableModel.getCache(modelClass).get(id);
@@ -194,7 +194,7 @@ public class SqlUtils {
             ModelAdapter<CacheableClass> modelAdapter = FlowManager.getModelAdapter(table);
 
             if (modelAdapter != null) {
-                long id = cursor.getLong(cursor.getColumnIndex(modelAdapter.getAutoIncrementingFieldName()));
+                long id = cursor.getLong(cursor.getColumnIndex(modelAdapter.getAutoIncrementingColumnName()));
                 model = BaseCacheableModel.getCache(table).get(id);
                 if (model == null) {
                     model = modelAdapter.newInstance();

--- a/library/src/main/java/com/raizlabs/android/dbflow/sql/language/Select.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/sql/language/Select.java
@@ -75,20 +75,6 @@ public class Select implements Query {
     }
 
     /**
-     * Selects a {@link com.raizlabs.android.dbflow.structure.cache.BaseCacheableModel} by id. It will
-     * consult the {@link com.raizlabs.android.dbflow.structure.cache.ModelCache} for the class before loading from the DB.
-     * @param cacheableClass The class of the {@link com.raizlabs.android.dbflow.structure.cache.BaseCacheableModel}
-     * @param id The {@link com.raizlabs.android.dbflow.annotation.Column#PRIMARY_KEY_AUTO_INCREMENT} to use.
-     * @param <CacheableClass> The class that extends {@link com.raizlabs.android.dbflow.structure.cache.BaseCacheableModel}
-     * @return A model from the cache (if it exists), else runs a {@link com.raizlabs.android.dbflow.sql.language.Select} statement to retrieve it.
-     */
-    public static <CacheableClass extends BaseCacheableModel> CacheableClass byCacheableId(Class<CacheableClass> cacheableClass, long id) {
-        ModelCache<CacheableClass> cache = BaseCacheableModel.getCache(cacheableClass);
-        CacheableClass model = cache.get(id);
-        return model != null ? model : byId(cacheableClass, id);
-    }
-
-    /**
      * Selects a single model object with the specified {@link com.raizlabs.android.dbflow.sql.builder.ConditionQueryBuilder}
      *
      * @param conditionQueryBuilder The where query we will use

--- a/library/src/main/java/com/raizlabs/android/dbflow/sql/language/Select.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/sql/language/Select.java
@@ -8,6 +8,8 @@ import com.raizlabs.android.dbflow.sql.builder.Condition;
 import com.raizlabs.android.dbflow.sql.builder.ConditionQueryBuilder;
 import com.raizlabs.android.dbflow.sql.QueryBuilder;
 import com.raizlabs.android.dbflow.structure.Model;
+import com.raizlabs.android.dbflow.structure.cache.BaseCacheableModel;
+import com.raizlabs.android.dbflow.structure.cache.ModelCache;
 
 import java.util.List;
 
@@ -70,6 +72,20 @@ public class Select implements Query {
     public static <ModelClass extends Model> ModelClass byId(Class<ModelClass> tableClass, Object... ids) {
         ConditionQueryBuilder<ModelClass> primaryQuery = FlowManager.getPrimaryWhereQuery(tableClass);
         return withCondition(primaryQuery.replaceEmptyParams(ids));
+    }
+
+    /**
+     * Selects a {@link com.raizlabs.android.dbflow.structure.cache.BaseCacheableModel} by id. It will
+     * consult the {@link com.raizlabs.android.dbflow.structure.cache.ModelCache} for the class before loading from the DB.
+     * @param cacheableClass The class of the {@link com.raizlabs.android.dbflow.structure.cache.BaseCacheableModel}
+     * @param id The {@link com.raizlabs.android.dbflow.annotation.Column#PRIMARY_KEY_AUTO_INCREMENT} to use.
+     * @param <CacheableClass> The class that extends {@link com.raizlabs.android.dbflow.structure.cache.BaseCacheableModel}
+     * @return A model from the cache (if it exists), else runs a {@link com.raizlabs.android.dbflow.sql.language.Select} statement to retrieve it.
+     */
+    public static <CacheableClass extends BaseCacheableModel> CacheableClass byCacheableId(Class<CacheableClass> cacheableClass, long id) {
+        ModelCache<CacheableClass> cache = BaseCacheableModel.getCache(cacheableClass);
+        CacheableClass model = cache.get(id);
+        return model != null ? model : byId(cacheableClass, id);
     }
 
     /**

--- a/library/src/main/java/com/raizlabs/android/dbflow/structure/BaseModel.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/structure/BaseModel.java
@@ -83,4 +83,7 @@ public abstract class BaseModel implements Model {
         return mModelAdapter.exists(this);
     }
 
+    protected ModelAdapter getModelAdapter() {
+        return mModelAdapter;
+    }
 }

--- a/library/src/main/java/com/raizlabs/android/dbflow/structure/ModelAdapter.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/structure/ModelAdapter.java
@@ -112,6 +112,14 @@ public abstract class ModelAdapter<ModelClass extends Model> implements Internal
     }
 
     /**
+     * @return The autoincrement field name for the {@link com.raizlabs.android.dbflow.annotation.Column#PRIMARY_KEY_AUTO_INCREMENT}
+     * if it has the field. This method is overridden when its specified for the {@link ModelClass}
+     */
+    public String getAutoIncrementingFieldName() {
+        return "";
+    }
+
+    /**
      * @return Only created once if doesn't exist, the extended class will return the builder to use.
      */
     protected abstract ConditionQueryBuilder<ModelClass> createPrimaryModelWhere();

--- a/library/src/main/java/com/raizlabs/android/dbflow/structure/ModelAdapter.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/structure/ModelAdapter.java
@@ -112,10 +112,10 @@ public abstract class ModelAdapter<ModelClass extends Model> implements Internal
     }
 
     /**
-     * @return The autoincrement field name for the {@link com.raizlabs.android.dbflow.annotation.Column#PRIMARY_KEY_AUTO_INCREMENT}
+     * @return The autoincrement column name for the {@link com.raizlabs.android.dbflow.annotation.Column#PRIMARY_KEY_AUTO_INCREMENT}
      * if it has the field. This method is overridden when its specified for the {@link ModelClass}
      */
-    public String getAutoIncrementingFieldName() {
+    public String getAutoIncrementingColumnName() {
         return "";
     }
 

--- a/library/src/main/java/com/raizlabs/android/dbflow/structure/cache/BaseCacheableModel.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/structure/cache/BaseCacheableModel.java
@@ -1,0 +1,94 @@
+package com.raizlabs.android.dbflow.structure.cache;
+
+import com.raizlabs.android.dbflow.structure.BaseModel;
+import com.raizlabs.android.dbflow.structure.InvalidDBConfiguration;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Description: Provides a handy way to cache models in memory for even faster data retrieval. Note:
+ * this class must utilize an {@link com.raizlabs.android.dbflow.annotation.Column#PRIMARY_KEY_AUTO_INCREMENT}
+ * primary key. The corresponding {@link com.raizlabs.android.dbflow.structure.ModelAdapter}
+ * describes how to retrieve the Id field so that is why its required.
+ */
+public abstract class BaseCacheableModel extends BaseModel {
+
+    private static Map<Class<? extends BaseCacheableModel>, ModelCache> mCacheMap = new HashMap<>();
+
+    public static ModelCache getCache(Class<? extends BaseCacheableModel> table) {
+        return mCacheMap.get(table);
+    }
+
+    static void putCache(Class<? extends BaseCacheableModel> table, ModelCache modelCache) {
+        mCacheMap.put(table, modelCache);
+    }
+
+    /**
+     * The cache to use
+     */
+    private ModelCache mCache;
+
+    /**
+     * Constructs a new instance, instantiating the {@link com.raizlabs.android.dbflow.structure.cache.ModelCache}
+     * if it does not already exist for this model.
+     */
+    public BaseCacheableModel() {
+        mCache = getCache(getClass());
+        if (mCache == null) {
+            mCache = new ModelCache(getCacheSize());
+            putCache(getClass(), mCache);
+        }
+    }
+
+    @Override
+    public void save(boolean async) {
+        super.save(async);
+        if (!async) {
+            addToCache();
+        }
+    }
+
+    @Override
+    public void delete(boolean async) {
+        super.delete(async);
+        if (!async) {
+            addToCache();
+        }
+    }
+
+    @Override
+    public void update(boolean async) {
+        super.update(async);
+        if (!async) {
+            addToCache();
+        }
+    }
+
+    @Override
+    public void insert(boolean async) {
+        super.insert(async);
+        if (!async) {
+            addToCache();
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    protected void addToCache() {
+        long id = getModelAdapter().getAutoIncrementingId(this);
+        if(id == 0) {
+            throw new InvalidDBConfiguration(String.format("The cacheable model class %1s must contain" +
+                    "an autoincrementing primary key. Although its possible that this method was called" +
+                    "after an insert/update/save failure", getClass()));
+        } else {
+            mCache.addModel(id, this);
+        }
+    }
+
+    /**
+     * @return the size of the cache you wish to maintain for this class. It is only called if
+     * the cache is not created yet.
+     */
+    public abstract int getCacheSize();
+
+}

--- a/library/src/main/java/com/raizlabs/android/dbflow/structure/cache/BaseCacheableModel.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/structure/cache/BaseCacheableModel.java
@@ -34,6 +34,7 @@ public abstract class BaseCacheableModel extends BaseModel {
      * Constructs a new instance, instantiating the {@link com.raizlabs.android.dbflow.structure.cache.ModelCache}
      * if it does not already exist for this model.
      */
+    @SuppressWarnings("unchecked")
     public BaseCacheableModel() {
         mCache = getCache(getClass());
         if (mCache == null) {

--- a/library/src/main/java/com/raizlabs/android/dbflow/structure/cache/BaseCacheableModel.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/structure/cache/BaseCacheableModel.java
@@ -16,11 +16,12 @@ public abstract class BaseCacheableModel extends BaseModel {
 
     private static Map<Class<? extends BaseCacheableModel>, ModelCache> mCacheMap = new HashMap<>();
 
-    public static ModelCache getCache(Class<? extends BaseCacheableModel> table) {
+    @SuppressWarnings("unchecked")
+    public static <CacheClass extends BaseCacheableModel> ModelCache<CacheClass> getCache(Class<CacheClass> table) {
         return mCacheMap.get(table);
     }
 
-    static void putCache(Class<? extends BaseCacheableModel> table, ModelCache modelCache) {
+    static void putCache(Class<? extends BaseCacheableModel> table, ModelCache<? extends BaseCacheableModel> modelCache) {
         mCacheMap.put(table, modelCache);
     }
 
@@ -76,7 +77,7 @@ public abstract class BaseCacheableModel extends BaseModel {
     @SuppressWarnings("unchecked")
     protected void addToCache() {
         long id = getModelAdapter().getAutoIncrementingId(this);
-        if(id == 0) {
+        if (id == 0) {
             throw new InvalidDBConfiguration(String.format("The cacheable model class %1s must contain" +
                     "an autoincrementing primary key. Although its possible that this method was called" +
                     "after an insert/update/save failure", getClass()));
@@ -90,5 +91,6 @@ public abstract class BaseCacheableModel extends BaseModel {
      * the cache is not created yet.
      */
     public abstract int getCacheSize();
+
 
 }

--- a/library/src/main/java/com/raizlabs/android/dbflow/structure/cache/BaseCacheableModel.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/structure/cache/BaseCacheableModel.java
@@ -51,10 +51,12 @@ public abstract class BaseCacheableModel extends BaseModel {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public void delete(boolean async) {
+        long id = getModelAdapter().getAutoIncrementingId(this);
         super.delete(async);
         if (!async) {
-            addToCache();
+            mCache.removeModel(id);
         }
     }
 

--- a/library/src/main/java/com/raizlabs/android/dbflow/structure/cache/BaseCacheableModel.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/structure/cache/BaseCacheableModel.java
@@ -1,7 +1,10 @@
 package com.raizlabs.android.dbflow.structure.cache;
 
+import android.database.Cursor;
+
 import com.raizlabs.android.dbflow.structure.BaseModel;
 import com.raizlabs.android.dbflow.structure.InvalidDBConfiguration;
+import com.raizlabs.android.dbflow.structure.listener.LoadFromCursorListener;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -12,7 +15,7 @@ import java.util.Map;
  * primary key. The corresponding {@link com.raizlabs.android.dbflow.structure.ModelAdapter}
  * describes how to retrieve the Id field so that is why its required.
  */
-public abstract class BaseCacheableModel extends BaseModel {
+public abstract class BaseCacheableModel extends BaseModel implements LoadFromCursorListener {
 
     private static Map<Class<? extends BaseCacheableModel>, ModelCache> mCacheMap = new HashMap<>();
 
@@ -75,6 +78,11 @@ public abstract class BaseCacheableModel extends BaseModel {
         if (!async) {
             addToCache();
         }
+    }
+
+    @Override
+    public void onLoadFromCursor(Cursor cursor) {
+        addToCache();
     }
 
     @SuppressWarnings("unchecked")

--- a/library/src/main/java/com/raizlabs/android/dbflow/structure/cache/BaseCacheableModel.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/structure/cache/BaseCacheableModel.java
@@ -20,11 +20,11 @@ public abstract class BaseCacheableModel extends BaseModel implements LoadFromCu
     private static Map<Class<? extends BaseCacheableModel>, ModelCache> mCacheMap = new HashMap<>();
 
     @SuppressWarnings("unchecked")
-    public static <CacheClass extends BaseCacheableModel> ModelCache<CacheClass> getCache(Class<CacheClass> table) {
+    public static <CacheClass extends BaseCacheableModel> ModelCache<CacheClass, ?> getCache(Class<CacheClass> table) {
         return mCacheMap.get(table);
     }
 
-    static void putCache(Class<? extends BaseCacheableModel> table, ModelCache<? extends BaseCacheableModel> modelCache) {
+    static void putCache(Class<? extends BaseCacheableModel> table, ModelCache<? extends BaseCacheableModel, ?> modelCache) {
         mCacheMap.put(table, modelCache);
     }
 
@@ -41,9 +41,17 @@ public abstract class BaseCacheableModel extends BaseModel implements LoadFromCu
     public BaseCacheableModel() {
         mCache = getCache(getClass());
         if (mCache == null) {
-            mCache = new ModelCache(getCacheSize());
+            mCache = getBackingCache();
             putCache(getClass(), mCache);
         }
+    }
+
+    /**
+     * @return A cache to use for this class statically. Only called if an existing cache does not exist. Override
+     * this method to use your own.
+     */
+    protected ModelCache<? extends BaseCacheableModel, ?> getBackingCache() {
+        return new ModelLruCache<>(getCacheSize());
     }
 
     @Override

--- a/library/src/main/java/com/raizlabs/android/dbflow/structure/cache/LruCache.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/structure/cache/LruCache.java
@@ -1,0 +1,348 @@
+package com.raizlabs.android.dbflow.structure.cache;
+
+/*
+ * Copyright (C) 2011 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Static library version of {@link android.util.LruCache}. Used to write apps
+ * that run on API levels prior to 12. When running on API level 12 or above,
+ * this implementation is still used; it does not try to switch to the
+ * framework's implementation. See the framework SDK documentation for a class
+ * overview.
+ */
+public class LruCache<K, V> {
+    private final LinkedHashMap<K, V> map;
+
+    /**
+     * Size of this cache in units. Not necessarily the number of elements.
+     */
+    private int size;
+    private int maxSize;
+
+    private int putCount;
+    private int createCount;
+    private int evictionCount;
+    private int hitCount;
+    private int missCount;
+
+    /**
+     * @param maxSize for caches that do not override {@link #sizeOf}, this is
+     *                the maximum number of entries in the cache. For all other caches,
+     *                this is the maximum sum of the sizes of the entries in this cache.
+     */
+    public LruCache(int maxSize) {
+        if (maxSize <= 0) {
+            throw new IllegalArgumentException("maxSize <= 0");
+        }
+        this.maxSize = maxSize;
+        this.map = new LinkedHashMap<K, V>(0, 0.75f, true);
+    }
+
+    /**
+     * Sets the size of the cache.
+     *
+     * @param maxSize The new maximum size.
+     */
+    public void resize(int maxSize) {
+        if (maxSize <= 0) {
+            throw new IllegalArgumentException("maxSize <= 0");
+        }
+
+        synchronized (this) {
+            this.maxSize = maxSize;
+        }
+        trimToSize(maxSize);
+    }
+
+    /**
+     * Returns the value for {@code key} if it exists in the cache or can be
+     * created by {@code #create}. If a value was returned, it is moved to the
+     * head of the queue. This returns null if a value is not cached and cannot
+     * be created.
+     */
+    public final V get(K key) {
+        if (key == null) {
+            throw new NullPointerException("key == null");
+        }
+
+        V mapValue;
+        synchronized (this) {
+            mapValue = map.get(key);
+            if (mapValue != null) {
+                hitCount++;
+                return mapValue;
+            }
+            missCount++;
+        }
+
+        /*
+         * Attempt to create a value. This may take a long time, and the map
+         * may be different when create() returns. If a conflicting value was
+         * added to the map while create() was working, we leave that value in
+         * the map and release the created value.
+         */
+
+        V createdValue = create(key);
+        if (createdValue == null) {
+            return null;
+        }
+
+        synchronized (this) {
+            createCount++;
+            mapValue = map.put(key, createdValue);
+
+            if (mapValue != null) {
+                // There was a conflict so undo that last put
+                map.put(key, mapValue);
+            } else {
+                size += safeSizeOf(key, createdValue);
+            }
+        }
+
+        if (mapValue != null) {
+            entryRemoved(false, key, createdValue, mapValue);
+            return mapValue;
+        } else {
+            trimToSize(maxSize);
+            return createdValue;
+        }
+    }
+
+    /**
+     * Caches {@code value} for {@code key}. The value is moved to the head of
+     * the queue.
+     *
+     * @return the previous value mapped by {@code key}.
+     */
+    public final V put(K key, V value) {
+        if (key == null || value == null) {
+            throw new NullPointerException("key == null || value == null");
+        }
+
+        V previous;
+        synchronized (this) {
+            putCount++;
+            size += safeSizeOf(key, value);
+            previous = map.put(key, value);
+            if (previous != null) {
+                size -= safeSizeOf(key, previous);
+            }
+        }
+
+        if (previous != null) {
+            entryRemoved(false, key, previous, value);
+        }
+
+        trimToSize(maxSize);
+        return previous;
+    }
+
+    /**
+     * Remove the eldest entries until the total of remaining entries is at or
+     * below the requested size.
+     *
+     * @param maxSize the maximum size of the cache before returning. May be -1
+     *                to evict even 0-sized elements.
+     */
+    public void trimToSize(int maxSize) {
+        while (true) {
+            K key;
+            V value;
+            synchronized (this) {
+                if (size < 0 || (map.isEmpty() && size != 0)) {
+                    throw new IllegalStateException(getClass().getName()
+                            + ".sizeOf() is reporting inconsistent results!");
+                }
+
+                if (size <= maxSize || map.isEmpty()) {
+                    break;
+                }
+
+                Map.Entry<K, V> toEvict = map.entrySet().iterator().next();
+                key = toEvict.getKey();
+                value = toEvict.getValue();
+                map.remove(key);
+                size -= safeSizeOf(key, value);
+                evictionCount++;
+            }
+
+            entryRemoved(true, key, value, null);
+        }
+    }
+
+    /**
+     * Removes the entry for {@code key} if it exists.
+     *
+     * @return the previous value mapped by {@code key}.
+     */
+    public final V remove(K key) {
+        if (key == null) {
+            throw new NullPointerException("key == null");
+        }
+
+        V previous;
+        synchronized (this) {
+            previous = map.remove(key);
+            if (previous != null) {
+                size -= safeSizeOf(key, previous);
+            }
+        }
+
+        if (previous != null) {
+            entryRemoved(false, key, previous, null);
+        }
+
+        return previous;
+    }
+
+    /**
+     * Called for entries that have been evicted or removed. This method is
+     * invoked when a value is evicted to make space, removed by a call to
+     * {@link #remove}, or replaced by a call to {@link #put}. The default
+     * implementation does nothing.
+     * <p/>
+     * <p>The method is called without synchronization: other threads may
+     * access the cache while this method is executing.
+     *
+     * @param evicted  true if the entry is being removed to make space, false
+     *                 if the removal was caused by a {@link #put} or {@link #remove}.
+     * @param newValue the new value for {@code key}, if it exists. If non-null,
+     *                 this removal was caused by a {@link #put}. Otherwise it was caused by
+     *                 an eviction or a {@link #remove}.
+     */
+    protected void entryRemoved(boolean evicted, K key, V oldValue, V newValue) {
+    }
+
+    /**
+     * Called after a cache miss to compute a value for the corresponding key.
+     * Returns the computed value or null if no value can be computed. The
+     * default implementation returns null.
+     * <p/>
+     * <p>The method is called without synchronization: other threads may
+     * access the cache while this method is executing.
+     * <p/>
+     * <p>If a value for {@code key} exists in the cache when this method
+     * returns, the created value will be released with {@link #entryRemoved}
+     * and discarded. This can occur when multiple threads request the same key
+     * at the same time (causing multiple values to be created), or when one
+     * thread calls {@link #put} while another is creating a value for the same
+     * key.
+     */
+    protected V create(K key) {
+        return null;
+    }
+
+    private int safeSizeOf(K key, V value) {
+        int result = sizeOf(key, value);
+        if (result < 0) {
+            throw new IllegalStateException("Negative size: " + key + "=" + value);
+        }
+        return result;
+    }
+
+    /**
+     * Returns the size of the entry for {@code key} and {@code value} in
+     * user-defined units.  The default implementation returns 1 so that size
+     * is the number of entries and max size is the maximum number of entries.
+     * <p/>
+     * <p>An entry's size must not change while it is in the cache.
+     */
+    protected int sizeOf(K key, V value) {
+        return 1;
+    }
+
+    /**
+     * Clear the cache, calling {@link #entryRemoved} on each removed entry.
+     */
+    public final void evictAll() {
+        trimToSize(-1); // -1 will evict 0-sized elements
+    }
+
+    /**
+     * For caches that do not override {@link #sizeOf}, this returns the number
+     * of entries in the cache. For all other caches, this returns the sum of
+     * the sizes of the entries in this cache.
+     */
+    public synchronized final int size() {
+        return size;
+    }
+
+    /**
+     * For caches that do not override {@link #sizeOf}, this returns the maximum
+     * number of entries in the cache. For all other caches, this returns the
+     * maximum sum of the sizes of the entries in this cache.
+     */
+    public synchronized final int maxSize() {
+        return maxSize;
+    }
+
+    /**
+     * Returns the number of times {@link #get} returned a value that was
+     * already present in the cache.
+     */
+    public synchronized final int hitCount() {
+        return hitCount;
+    }
+
+    /**
+     * Returns the number of times {@link #get} returned null or required a new
+     * value to be created.
+     */
+    public synchronized final int missCount() {
+        return missCount;
+    }
+
+    /**
+     * Returns the number of times {@link #create(Object)} returned a value.
+     */
+    public synchronized final int createCount() {
+        return createCount;
+    }
+
+    /**
+     * Returns the number of times {@link #put} was called.
+     */
+    public synchronized final int putCount() {
+        return putCount;
+    }
+
+    /**
+     * Returns the number of values that have been evicted.
+     */
+    public synchronized final int evictionCount() {
+        return evictionCount;
+    }
+
+    /**
+     * Returns a copy of the current contents of the cache, ordered from least
+     * recently accessed to most recently accessed.
+     */
+    public synchronized final Map<K, V> snapshot() {
+        return new LinkedHashMap<K, V>(map);
+    }
+
+    @Override
+    public synchronized final String toString() {
+        int accesses = hitCount + missCount;
+        int hitPercent = accesses != 0 ? (100 * hitCount / accesses) : 0;
+        return String.format("LruCache[maxSize=%d,hits=%d,misses=%d,hitRate=%d%%]",
+                maxSize, hitCount, missCount, hitPercent);
+    }
+}
+

--- a/library/src/main/java/com/raizlabs/android/dbflow/structure/cache/ModelCache.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/structure/cache/ModelCache.java
@@ -3,36 +3,51 @@ package com.raizlabs.android.dbflow.structure.cache;
 import com.raizlabs.android.dbflow.structure.Model;
 
 /**
- * Description: Wraps around a {@link com.raizlabs.android.dbflow.structure.cache.LruCache}
- * and provides synchronization mechanisms.
+ * Description: A generic cache for models that is implemented or can be implemented to your liking.
  */
-public class ModelCache<ModelClass extends Model> {
+public abstract class ModelCache<ModelClass extends Model, CacheClass> {
 
-    private final LruCache<Long, ModelClass> mCache;
+    private CacheClass mCache;
 
-    public ModelCache(int size) {
-        this.mCache = new LruCache<>(size);
+    /**
+     * Constructs new instance with a cache
+     *
+     * @param cache The arbitrary underlying cache class.
+     */
+    public ModelCache(CacheClass cache) {
+        mCache = cache;
     }
 
-    public void addModel(Long id, ModelClass model) {
-        synchronized (mCache) {
-            mCache.put(id, model);
-        }
-    }
+    /**
+     * Adds a model to this cache.
+     *
+     * @param id    The id of the model to use.
+     * @param model The model to add
+     */
+    public abstract void addModel(Long id, ModelClass model);
 
-    public void removeModel(Long id) {
-        synchronized (mCache) {
-            mCache.remove(id);
-        }
-    }
+    /**
+     * Removes a model from this cache.
+     *
+     * @param id The id of the model to remove.
+     */
+    public abstract ModelClass removeModel(Long id);
 
-    public void clear() {
-        synchronized (mCache) {
-            mCache.evictAll();
-        }
-    }
+    /**
+     * Clears out all models from this cache.
+     */
+    public abstract void clear();
 
-    public ModelClass get(Long id) {
-        return mCache.get(id);
+    /**
+     * @param id The id of the model to retrieve.
+     * @return a model for the specified id. May be null.
+     */
+    public abstract ModelClass get(Long id);
+
+    /**
+     * @return The cache that's backing this cache.
+     */
+    public CacheClass getCache() {
+        return mCache;
     }
 }

--- a/library/src/main/java/com/raizlabs/android/dbflow/structure/cache/ModelCache.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/structure/cache/ModelCache.java
@@ -1,0 +1,38 @@
+package com.raizlabs.android.dbflow.structure.cache;
+
+import com.raizlabs.android.dbflow.structure.Model;
+
+/**
+ * Description: Wraps around a {@link com.raizlabs.android.dbflow.structure.cache.LruCache}
+ * and provides synchronization mechanisms.
+ */
+public class ModelCache<ModelClass extends Model> {
+
+    private final LruCache<Long, ModelClass> mCache;
+
+    public ModelCache(int size) {
+        this.mCache = new LruCache<>(size);
+    }
+
+    public void addModel(Long id, ModelClass model) {
+        synchronized (mCache) {
+            mCache.put(id, model);
+        }
+    }
+
+    public void removeModel(Long id) {
+        synchronized (mCache) {
+            mCache.remove(id);
+        }
+    }
+
+    public void clear() {
+        synchronized (mCache) {
+            mCache.evictAll();
+        }
+    }
+
+    public ModelClass get(Long id) {
+        return mCache.get(id);
+    }
+}

--- a/library/src/main/java/com/raizlabs/android/dbflow/structure/cache/ModelLruCache.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/structure/cache/ModelLruCache.java
@@ -1,0 +1,42 @@
+package com.raizlabs.android.dbflow.structure.cache;
+
+import com.raizlabs.android.dbflow.structure.Model;
+
+/**
+ * Description: Provides an {@link com.raizlabs.android.dbflow.structure.cache.LruCache} under its hood
+ * and provides synchronization mechanisms.
+ */
+public class ModelLruCache<ModelClass extends Model> extends ModelCache<ModelClass, LruCache<Long, ModelClass>>{
+
+    public ModelLruCache(int size) {
+        super(new LruCache<Long, ModelClass>(size));
+    }
+
+    @Override
+    public void addModel(Long id, ModelClass model) {
+        synchronized (getCache()) {
+            getCache().put(id, model);
+        }
+    }
+
+    @Override
+    public ModelClass removeModel(Long id) {
+        ModelClass model = null;
+        synchronized (getCache()) {
+            model = getCache().remove(id);
+        }
+        return model;
+    }
+
+    @Override
+    public void clear() {
+        synchronized (getCache()) {
+            getCache().evictAll();
+        }
+    }
+
+    @Override
+    public ModelClass get(Long id) {
+        return id == null ? null : getCache().get(id);
+    }
+}

--- a/library/src/main/java/com/raizlabs/android/dbflow/structure/cache/SparseArrayBasedCache.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/structure/cache/SparseArrayBasedCache.java
@@ -1,0 +1,54 @@
+package com.raizlabs.android.dbflow.structure.cache;
+
+import android.util.SparseArray;
+
+import com.raizlabs.android.dbflow.structure.Model;
+
+/**
+ * Description: A cache backed by a {@link android.util.SparseArray}
+ */
+public class SparseArrayBasedCache<ModelClass extends Model> extends ModelCache<ModelClass, SparseArray<ModelClass>> {
+    /**
+     * Constructs new instance with a {@link android.util.SparseArray} cache
+     */
+    public SparseArrayBasedCache() {
+        super(new SparseArray<ModelClass>());
+    }
+
+    /**
+     * Constructs new instance with the specified {@link java.util.List}
+     *
+     * @param sparseArray The sparse array to use.
+     */
+    public SparseArrayBasedCache(SparseArray<ModelClass> sparseArray) {
+        super(sparseArray);
+    }
+
+    @Override
+    public void addModel(Long id, ModelClass model) {
+        synchronized (getCache()) {
+            getCache().put(id.intValue(), model);
+        }
+    }
+
+    @Override
+    public ModelClass removeModel(Long id) {
+        ModelClass model = get(id);
+        synchronized (getCache()) {
+            getCache().remove(id.intValue());
+        }
+        return model;
+    }
+
+    @Override
+    public void clear() {
+        synchronized (getCache()) {
+            getCache().clear();
+        }
+    }
+
+    @Override
+    public ModelClass get(Long id) {
+        return id == null ? null : getCache().get(id.intValue());
+    }
+}

--- a/library/src/main/java/com/raizlabs/android/dbflow/structure/container/BaseModelContainer.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/structure/container/BaseModelContainer.java
@@ -61,6 +61,14 @@ public abstract class BaseModelContainer<ModelClass extends Model, DataClass> im
     }
 
     /**
+     * Invalidates the underlying model. In the next {@link #toModel()} call, it will re-query the DB with
+     * the underlying data.
+     */
+    public void invalidateModel() {
+        setModel(null);
+    }
+
+    /**
      * @param inValue     The value of data for a specified field.
      * @param columnClass The class of the specified field/column
      * @return A created instance to be used for fields that are model containers.

--- a/library/src/main/java/com/raizlabs/android/dbflow/structure/container/BaseModelContainer.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/structure/container/BaseModelContainer.java
@@ -1,7 +1,6 @@
 package com.raizlabs.android.dbflow.structure.container;
 
 import com.raizlabs.android.dbflow.config.FlowManager;
-import com.raizlabs.android.dbflow.sql.SqlUtils;
 import com.raizlabs.android.dbflow.structure.InvalidDBConfiguration;
 import com.raizlabs.android.dbflow.structure.Model;
 import com.raizlabs.android.dbflow.structure.ModelAdapter;
@@ -49,6 +48,16 @@ public abstract class BaseModelContainer<ModelClass extends Model, DataClass> im
         }
 
         return mModel;
+    }
+
+    /**
+     * Sets a model to back the container. NOTE: this method invalidates results in any underlying data to
+     * be ignored. To resume using this underlying data, set this method wil a null param.
+     *
+     * @param model
+     */
+    public void setModel(ModelClass model) {
+        mModel = model;
     }
 
     /**

--- a/library/src/main/java/com/raizlabs/android/dbflow/structure/container/ForeignKeyContainer.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/structure/container/ForeignKeyContainer.java
@@ -1,8 +1,11 @@
 package com.raizlabs.android.dbflow.structure.container;
 
+import com.raizlabs.android.dbflow.config.FlowManager;
 import com.raizlabs.android.dbflow.sql.SqlUtils;
 import com.raizlabs.android.dbflow.sql.language.Select;
 import com.raizlabs.android.dbflow.structure.Model;
+import com.raizlabs.android.dbflow.structure.ModelAdapter;
+import com.raizlabs.android.dbflow.structure.cache.BaseCacheableModel;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -22,7 +25,7 @@ public class ForeignKeyContainer<ModelClass extends Model> extends BaseModelCont
      * @param table The table to associate the container with
      */
     public ForeignKeyContainer(Class<ModelClass> table) {
-        super(table, new LinkedHashMap<String, Object>());
+        this(table, new LinkedHashMap<String, Object>());
     }
 
     /**
@@ -31,6 +34,7 @@ public class ForeignKeyContainer<ModelClass extends Model> extends BaseModelCont
      * @param table The table to associate the container with
      * @param data  The data to store in this container
      */
+    @SuppressWarnings("unchecked")
     public ForeignKeyContainer(Class<ModelClass> table, Map<String, Object> data) {
         super(table, data);
     }


### PR DESCRIPTION
1. Can extend ```BaseCacheableModel``` to create an in memory cache for ```Model``` for instant retrieval for any query to the DB if it exists in the cache.
2. Can create your own ```ModelCache```, however this library comes with ```ModelLruCache``` and ```SparseArrayBasedCache```!
3. Can define a custom cache for ```FlowTableList``` and ```FlowCursorList```