### PR TITLE
Version 1.5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Android Weekly](http://img.shields.io/badge/Android%20Weekly-%23129-2CB3E5.svg?style=flat)](http://androidweekly.net/issues/issue-129)
 [![Android Arsenal](https://img.shields.io/badge/Android%20Arsenal-DBFlow-brightgreen.svg?style=flat)](https://android-arsenal.com/details/1/1134) 
-[![Raizlabs Repository](http://img.shields.io/badge/Raizlabs%20Repository-1.5.0-blue.svg?style=flat)](https://github.com/Raizlabs/maven-releases)
+[![Raizlabs Repository](http://img.shields.io/badge/Raizlabs%20Repository-1.5.1-blue.svg?style=flat)](https://github.com/Raizlabs/maven-releases)
 
 DBFlow
 ======
@@ -16,6 +16,15 @@ This library is based on [Active Android](https://github.com/pardom/ActiveAndroi
 What sets this library apart: **every** feature has been unit tested to ensure functionality, baked in support for **multiple** databases seamlessly, powerful and fluid builder logic in expressing SQL statements, **annotation processing** to enable blistering speed, ```ModelContainer``` classes that enable direct to database parsing for data such as JSON, and rich interface classes that enable powerful flexibility.
 
 ## Changelog
+
+#### 1.5.1
+
+1. Adds ```Index``` support and ```IndexMigration``` support!! Fixes #63 
+2. Fixes #76 ```FlowCursorList``` where ```Handler``` was not using main looper 
+3. fixes #72  ```FlowTableList``` where ```LruCache``` does not allow cache size of 0, causing crash. Also now the count can be determined by overriding ```getCacheSize()```
+4. Fixes #71 where ```Migration``` documentation was not fully clear.
+5. Added ```Index``` documentation
+
 
 #### 1.5.0
 
@@ -51,7 +60,7 @@ For more detailed usage, check out these sections:
 
 [Type Converters](https://github.com/Raizlabs/DBFlow/blob/master/usage/TypeConverters.md)
 
-
+[Triggers, Indexes, and More](https://github.com/Raizlabs/DBFlow/blob/master/usage/TriggersIndexesAndMore.md)
 
 
 ## Including in your project

--- a/README.md
+++ b/README.md
@@ -96,8 +96,8 @@ Add the library to the project-level build.gradle, using the [apt plugin](https:
   apply plugin: 'com.raizlabs.griddle'
 
   dependencies {
-    apt 'com.raizlabs.android:DBFlow-Compiler:1.5.0'
-    mod "com.raizlabs.android:{DBFlow-Core, DBFlow}:1.5.0"
+    apt 'com.raizlabs.android:DBFlow-Compiler:1.5.1'
+    mod "com.raizlabs.android:{DBFlow-Core, DBFlow}:1.5.1"
   }
 
 ```

--- a/README.md
+++ b/README.md
@@ -313,27 +313,6 @@ public class TestModelView extends BaseModelView<TestModel2> {
 
 ```
 
-## Triggers
-
-```Trigger``` are actions that are automatically performed before or after some action on the database. For example, we want to log changes for all updates to the name on the ```Friend``` table. 
-
-```java
-
-CompletedTrigger<Friend> trigger = new Trigger<Friend>("NameTrigger")
-                                    .after().update(Friend.class, Friend$Table.NAME)
-                                    .begin(
-                                        new Insert<FriendLog>(FriendLog.class)
-                                          .columns(FriendLog$Table.OLDNAME, FriendLog$Table.NEWNAME, FriendLog$Table.DATE)
-                                          .values("old.Name", "new.Name", System.currentTimeMillis())
-                                          };
- // starts a trigger                                         
- trigger.enable();
- 
- // stops a trigger
- trigger.disable();
-
-```
-
 ## Maintainers
 
 [agrosner](https://github.com/agrosner) ([@agrosner](https://www.twitter.com/agrosner))

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=1.5.0
+VERSION_NAME=1.5.1
 VERSION_CODE=1
 GROUP=com.raizlabs.android
 

--- a/library/src/androidTest/java/com/raizlabs/android/dbflow/test/list/ListTest.java
+++ b/library/src/androidTest/java/com/raizlabs/android/dbflow/test/list/ListTest.java
@@ -46,6 +46,19 @@ public class ListTest extends FlowTestCase {
         assertTrue(flowTableList.size() == 0);
     }
 
+    public void testTableListEmpty() {
+        Delete.table(ListModel.class);
+
+        FlowTableList<ListModel> flowTableList = new FlowTableList<>(ListModel.class);
+        ListModel listModel = new ListModel();
+        listModel.name = "Test";
+        flowTableList.add(listModel);
+
+        assertTrue(flowTableList.size() == 1);
+
+        Delete.table(ListModel.class);
+    }
+
     private class TestModelAdapter extends BaseAdapter {
 
         private FlowCursorList<ListModel> mFlowCursorList;

--- a/library/src/androidTest/java/com/raizlabs/android/dbflow/test/sql/DefaultModel.java
+++ b/library/src/androidTest/java/com/raizlabs/android/dbflow/test/sql/DefaultModel.java
@@ -1,0 +1,16 @@
+package com.raizlabs.android.dbflow.test.sql;
+
+import com.raizlabs.android.dbflow.annotation.Column;
+import com.raizlabs.android.dbflow.annotation.Table;
+import com.raizlabs.android.dbflow.test.TestDatabase;
+import com.raizlabs.android.dbflow.test.structure.TestModel1;
+
+/**
+ * Description:
+ */
+@Table(databaseName = TestDatabase.NAME)
+public class DefaultModel extends TestModel1 {
+
+    @Column(defaultValue = "55")
+    Integer count;
+}

--- a/library/src/androidTest/java/com/raizlabs/android/dbflow/test/sql/DefaultModelTest.java
+++ b/library/src/androidTest/java/com/raizlabs/android/dbflow/test/sql/DefaultModelTest.java
@@ -1,0 +1,17 @@
+package com.raizlabs.android.dbflow.test.sql;
+
+import com.raizlabs.android.dbflow.sql.language.Delete;
+import com.raizlabs.android.dbflow.test.FlowTestCase;
+
+/**
+ * Description:
+ */
+public class DefaultModelTest extends FlowTestCase {
+
+    public void testDefaultModel() {
+        Delete.table(DefaultModel.class);
+        DefaultModel defaultModel = new DefaultModel();
+        defaultModel.name = "Test";
+        defaultModel.save(false);
+    }
+}

--- a/library/src/androidTest/java/com/raizlabs/android/dbflow/test/sql/IndexModel.java
+++ b/library/src/androidTest/java/com/raizlabs/android/dbflow/test/sql/IndexModel.java
@@ -1,0 +1,23 @@
+package com.raizlabs.android.dbflow.test.sql;
+
+import com.raizlabs.android.dbflow.annotation.Column;
+import com.raizlabs.android.dbflow.annotation.Table;
+import com.raizlabs.android.dbflow.structure.BaseModel;
+import com.raizlabs.android.dbflow.test.TestDatabase;
+
+/**
+ * Description:
+ */
+@Table(databaseName = TestDatabase.NAME)
+public class IndexModel extends BaseModel {
+
+    @Column(columnType = Column.PRIMARY_KEY_AUTO_INCREMENT)
+    long id;
+
+    @Column
+    String name;
+
+    @Column
+    long salary;
+
+}

--- a/library/src/androidTest/java/com/raizlabs/android/dbflow/test/sql/IndexTest.java
+++ b/library/src/androidTest/java/com/raizlabs/android/dbflow/test/sql/IndexTest.java
@@ -1,0 +1,49 @@
+package com.raizlabs.android.dbflow.test.sql;
+
+import com.raizlabs.android.dbflow.sql.builder.Condition;
+import com.raizlabs.android.dbflow.sql.index.Index;
+import com.raizlabs.android.dbflow.sql.language.Delete;
+import com.raizlabs.android.dbflow.sql.language.Select;
+import com.raizlabs.android.dbflow.test.FlowTestCase;
+
+import java.util.List;
+
+/**
+ * Description:
+ */
+public class IndexTest extends FlowTestCase {
+
+    public void testIndex() {
+
+        Delete.table(IndexModel.class);
+
+        Index<IndexModel> modelIndex = new Index<IndexModel>("salary_index")
+                .on(IndexModel.class, IndexModel$Table.SALARY);
+        modelIndex.disable();
+
+        assertEquals("CREATE INDEX IF NOT EXISTS `salary_index` ON `IndexModel`(`salary`)", modelIndex.getQuery().trim());
+
+        modelIndex.enable();
+
+        IndexModel indexModel = new IndexModel();
+        indexModel.name = "Index";
+        indexModel.salary = 30000;
+        indexModel.save(false);
+
+        indexModel = new IndexModel();
+        indexModel.name = "Index2";
+        indexModel.salary = 15000;
+        indexModel.save(false);
+
+        List<IndexModel> list = new Select().from(IndexModel.class)
+                .indexedBy(modelIndex.getIndexName())
+                .where(Condition.column(IndexModel$Table.SALARY).greaterThan(20000)).queryList();
+
+        assertTrue(list.size() == 1);
+
+        modelIndex.disable();
+
+        Delete.table(IndexModel.class);
+
+    }
+}

--- a/library/src/androidTest/java/com/raizlabs/android/dbflow/test/sql/MigrationTest.java
+++ b/library/src/androidTest/java/com/raizlabs/android/dbflow/test/sql/MigrationTest.java
@@ -91,7 +91,7 @@ public class MigrationTest extends AndroidTestCase {
         IndexMigration<TestModel3> indexMigration
                 = new IndexMigration<>("MyIndex", TestModel3.class)
                 .addColumn(TestModel3$Table.TYPE);
-        assertEquals("CREATE INDEX IF NOT EXISTS `MyIndex` ON `TestMode3`(`type`)", indexMigration.getIndexQuery().trim());
+        assertEquals("CREATE INDEX IF NOT EXISTS `MyIndex` ON `TestModel3`(`type`)", indexMigration.getIndexQuery().trim());
     }
 
     @Override

--- a/library/src/androidTest/java/com/raizlabs/android/dbflow/test/sql/MigrationTest.java
+++ b/library/src/androidTest/java/com/raizlabs/android/dbflow/test/sql/MigrationTest.java
@@ -91,7 +91,7 @@ public class MigrationTest extends AndroidTestCase {
         IndexMigration<TestModel3> indexMigration
                 = new IndexMigration<>("MyIndex", TestModel3.class)
                 .addColumn(TestModel3$Table.TYPE);
-        assertEquals("CREATE INDEX ON `MyIndex`(`type`)", indexMigration.getIndexQuery().trim());
+        assertEquals("CREATE INDEX IF NOT EXISTS `MyIndex` ON `TestMode3`(`type`)", indexMigration.getIndexQuery().trim());
     }
 
     @Override

--- a/library/src/androidTest/java/com/raizlabs/android/dbflow/test/sql/MigrationTest.java
+++ b/library/src/androidTest/java/com/raizlabs/android/dbflow/test/sql/MigrationTest.java
@@ -8,6 +8,7 @@ import com.raizlabs.android.dbflow.config.FlowManager;
 import com.raizlabs.android.dbflow.sql.language.Select;
 import com.raizlabs.android.dbflow.sql.builder.Condition;
 import com.raizlabs.android.dbflow.sql.migration.AlterTableMigration;
+import com.raizlabs.android.dbflow.sql.migration.IndexMigration;
 import com.raizlabs.android.dbflow.sql.migration.UpdateTableMigration;
 
 import java.util.Arrays;
@@ -84,6 +85,13 @@ public class MigrationTest extends AndroidTestCase {
 
         int addedColumIndex = cursor.getColumnIndex("addedColumn");
         assertFalse(addedColumIndex == -1);
+    }
+
+    public void testIndexMigration() {
+        IndexMigration<TestModel3> indexMigration
+                = new IndexMigration<>("MyIndex", TestModel3.class)
+                .addColumn(TestModel3$Table.TYPE);
+        assertEquals("CREATE INDEX ON `MyIndex`(`type`)", indexMigration.getIndexQuery().trim());
     }
 
     @Override

--- a/library/src/main/java/com/raizlabs/android/dbflow/list/FlowCursorList.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/list/FlowCursorList.java
@@ -3,6 +3,7 @@ package com.raizlabs.android.dbflow.list;
 import android.database.ContentObserver;
 import android.database.Cursor;
 import android.os.Handler;
+import android.os.Looper;
 
 import com.raizlabs.android.dbflow.runtime.DBTransactionInfo;
 import com.raizlabs.android.dbflow.runtime.TransactionManager;
@@ -137,7 +138,7 @@ public class FlowCursorList<ModelClass extends Model> {
     /**
      * Refreshes the data backing this list, and destroys the Model cache.
      */
-    public void refresh() {
+    public synchronized void refresh() {
         mCursor.close();
         mCursor = mQueriable.query();
 
@@ -236,7 +237,7 @@ public class FlowCursorList<ModelClass extends Model> {
     class CursorObserver extends ContentObserver {
 
         CursorObserver() {
-            super(new Handler());
+            super(new Handler(Looper.getMainLooper()));
         }
 
         @Override

--- a/library/src/main/java/com/raizlabs/android/dbflow/list/FlowCursorList.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/list/FlowCursorList.java
@@ -143,6 +143,7 @@ public class FlowCursorList<ModelClass extends Model> {
 
         if (cacheModels) {
             mModelCache.clear();
+            mModelCache = getBackingCache();
         }
     }
 

--- a/library/src/main/java/com/raizlabs/android/dbflow/list/FlowTableList.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/list/FlowTableList.java
@@ -79,7 +79,7 @@ public class FlowTableList<ModelClass extends Model> extends ContentObserver imp
         mCursorList = new FlowCursorList<ModelClass>(true, table, conditions) {
             @Override
             protected ModelCache<ModelClass, ?> getBackingCache() {
-                return FlowTableList.this.getBackingCache(getCount());
+                return FlowTableList.this.getBackingCache(getCacheSize());
             }
         };
     }
@@ -94,7 +94,7 @@ public class FlowTableList<ModelClass extends Model> extends ContentObserver imp
         mCursorList = new FlowCursorList<ModelClass>(transact, modelQueriable) {
             @Override
             protected ModelCache<ModelClass, ?> getBackingCache() {
-                return FlowTableList.this.getBackingCache(getCount());
+                return FlowTableList.this.getBackingCache(getCacheSize());
             }
         };
     }
@@ -106,14 +106,15 @@ public class FlowTableList<ModelClass extends Model> extends ContentObserver imp
      * If you override this method, be careful to call an empty cache to the {@link com.raizlabs.android.dbflow.structure.cache.ModelLruCache}
      */
     public ModelCache<ModelClass, ?> getBackingCache(int count) {
-        return new ModelLruCache<>(count == 0 ? getEmptyCacheSize() : count);
+        return new ModelLruCache<>(count);
     }
 
     /**
-     * Called when the count for the default, underlying cache is empty.
+     * Called when the count for the underlying cache is needed.
+     *
      * @return 50 as default. Override for different.
      */
-    public int getEmptyCacheSize() {
+    public int getCacheSize() {
         return 50;
     }
 

--- a/library/src/main/java/com/raizlabs/android/dbflow/list/FlowTableList.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/list/FlowTableList.java
@@ -79,7 +79,7 @@ public class FlowTableList<ModelClass extends Model> extends ContentObserver imp
         mCursorList = new FlowCursorList<ModelClass>(true, table, conditions) {
             @Override
             protected ModelCache<ModelClass, ?> getBackingCache() {
-                return FlowTableList.this.getBackingCache();
+                return FlowTableList.this.getBackingCache(getCount());
             }
         };
     }
@@ -95,11 +95,12 @@ public class FlowTableList<ModelClass extends Model> extends ContentObserver imp
     }
 
     /**
+     * @param count The size of the underlying {@link com.raizlabs.android.dbflow.list.FlowCursorList}
      * @return The cache backing this query. Override to provide a custom {@link com.raizlabs.android.dbflow.structure.cache.ModelCache}
      * instead.
      */
-    public ModelCache<ModelClass, ?> getBackingCache() {
-        return new ModelLruCache<>(mCursorList.getCount());
+    public ModelCache<ModelClass, ?> getBackingCache(int count) {
+        return new ModelLruCache<>(count);
     }
 
     /**

--- a/library/src/main/java/com/raizlabs/android/dbflow/list/FlowTableList.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/list/FlowTableList.java
@@ -91,16 +91,30 @@ public class FlowTableList<ModelClass extends Model> extends ContentObserver imp
      */
     public FlowTableList(ModelQueriable<ModelClass> modelQueriable) {
         super(null);
-        mCursorList = new FlowCursorList<ModelClass>(transact, modelQueriable);
+        mCursorList = new FlowCursorList<ModelClass>(transact, modelQueriable) {
+            @Override
+            protected ModelCache<ModelClass, ?> getBackingCache() {
+                return FlowTableList.this.getBackingCache(getCount());
+            }
+        };
     }
 
     /**
      * @param count The size of the underlying {@link com.raizlabs.android.dbflow.list.FlowCursorList}
      * @return The cache backing this query. Override to provide a custom {@link com.raizlabs.android.dbflow.structure.cache.ModelCache}
-     * instead.
+     * instead. If the count is somehow 0, it will default to a size of 50.
+     * If you override this method, be careful to call an empty cache to the {@link com.raizlabs.android.dbflow.structure.cache.ModelLruCache}
      */
     public ModelCache<ModelClass, ?> getBackingCache(int count) {
-        return new ModelLruCache<>(count);
+        return new ModelLruCache<>(count == 0 ? getEmptyCacheSize() : count);
+    }
+
+    /**
+     * Called when the count for the default, underlying cache is empty.
+     * @return 50 as default. Override for different.
+     */
+    public int getEmptyCacheSize() {
+        return 50;
     }
 
     /**

--- a/library/src/main/java/com/raizlabs/android/dbflow/sql/SqlUtils.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/sql/SqlUtils.java
@@ -453,7 +453,7 @@ public class SqlUtils {
      */
     public static <ModelClass extends Model> void dropIndex(Class<ModelClass> mOnTable, String indexName) {
         QueryBuilder queryBuilder = new QueryBuilder("DROP INDEX IF EXISTS ")
-                .append(indexName);
+                .appendQuoted(indexName);
         FlowManager.getDatabaseForTable(mOnTable).getWritableDatabase().execSQL(queryBuilder.getQuery());
     }
 }

--- a/library/src/main/java/com/raizlabs/android/dbflow/sql/SqlUtils.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/sql/SqlUtils.java
@@ -435,13 +435,25 @@ public class SqlUtils {
      * Drops an active TRIGGER by specifying the onTable and triggerName
      *
      * @param mOnTable     The table that this trigger runs on
-     * @param mTriggerName The name of the trigger
+     * @param triggerName  The name of the trigger
      * @param <ModelClass> The class that implements {@link com.raizlabs.android.dbflow.structure.Model}
      */
-    public static <ModelClass extends Model> void dropTrigger(Class<ModelClass> mOnTable, String mTriggerName) {
-        BaseDatabaseDefinition databaseDefinition = FlowManager.getDatabaseForTable(mOnTable);
+    public static <ModelClass extends Model> void dropTrigger(Class<ModelClass> mOnTable, String triggerName) {
         QueryBuilder queryBuilder = new QueryBuilder("DROP TRIGGER IF EXISTS ")
-                .append(mTriggerName);
-        databaseDefinition.getWritableDatabase().execSQL(queryBuilder.getQuery());
+                .append(triggerName);
+        FlowManager.getDatabaseForTable(mOnTable).getWritableDatabase().execSQL(queryBuilder.getQuery());
+    }
+
+    /**
+     * Drops an active INDEX by specifying the onTable and indexName
+     *
+     * @param mOnTable     The table that this index runs on
+     * @param indexName    The name of the index.
+     * @param <ModelClass> The class that implements {@link com.raizlabs.android.dbflow.structure.Model}
+     */
+    public static <ModelClass extends Model> void dropIndex(Class<ModelClass> mOnTable, String indexName) {
+        QueryBuilder queryBuilder = new QueryBuilder("DROP INDEX IF EXISTS ")
+                .append(indexName);
+        FlowManager.getDatabaseForTable(mOnTable).getWritableDatabase().execSQL(queryBuilder.getQuery());
     }
 }

--- a/library/src/main/java/com/raizlabs/android/dbflow/sql/index/Index.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/sql/index/Index.java
@@ -102,7 +102,7 @@ public class Index<ModelClass extends Model> implements Query {
 
         if (mTable == null) {
             throw new IllegalStateException("Please call on() to set a table to use this index on.");
-        } else if (mColumns == null || mColumns.length == 0) {
+        } else if (mColumns == null || mColumns.isEmpty()) {
             throw new IllegalStateException("There should be at least one column in this index");
         }
 
@@ -118,12 +118,13 @@ public class Index<ModelClass extends Model> implements Query {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public String getQuery() {
         return new QueryBuilder("CREATE ")
                 .append(isUnique ? "UNIQUE " : "")
                 .append("INDEX IF NOT EXISTS ")
                 .appendQuoted(mIndex)
                 .append(" ON ").appendQuoted(FlowManager.getTableName(mTable))
-                .append("(").appendQuotedArray(mColumns).append(")").getQuery();
+                .append("(").appendList(mColumns).append(")").getQuery();
     }
 }

--- a/library/src/main/java/com/raizlabs/android/dbflow/sql/index/Index.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/sql/index/Index.java
@@ -9,6 +9,9 @@ import com.raizlabs.android.dbflow.sql.QueryBuilder;
 import com.raizlabs.android.dbflow.sql.SqlUtils;
 import com.raizlabs.android.dbflow.structure.Model;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * Description: Describes a SQLite Index
  */
@@ -18,7 +21,7 @@ public class Index<ModelClass extends Model> implements Query {
 
     private Class<ModelClass> mTable;
 
-    private String[] mColumns;
+    private List<String> mColumns;
 
     private boolean isUnique = false;
 
@@ -29,6 +32,7 @@ public class Index<ModelClass extends Model> implements Query {
      */
     public Index(@NonNull String indexName) {
         mIndex = indexName;
+        mColumns = new ArrayList<>();
     }
 
     /**
@@ -51,7 +55,22 @@ public class Index<ModelClass extends Model> implements Query {
      */
     public Index<ModelClass> on(@NonNull Class<ModelClass> table, String... columns) {
         mTable = table;
-        mColumns = columns;
+        for (String column : columns) {
+            and(column);
+        }
+        return this;
+    }
+
+    /**
+     * Appends a column to this index list.
+     *
+     * @param columnName The name of the column. If already exists, this column will not be added
+     * @return This instance.
+     */
+    public Index<ModelClass> and(String columnName) {
+        if (!mColumns.contains(columnName)) {
+            mColumns.add(columnName);
+        }
         return this;
     }
 

--- a/library/src/main/java/com/raizlabs/android/dbflow/sql/index/Index.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/sql/index/Index.java
@@ -125,6 +125,6 @@ public class Index<ModelClass extends Model> implements Query {
                 .append("INDEX IF NOT EXISTS ")
                 .appendQuoted(mIndex)
                 .append(" ON ").appendQuoted(FlowManager.getTableName(mTable))
-                .append("(").appendList(mColumns).append(")").getQuery();
+                .append("(").appendQuotedList(mColumns).append(")").getQuery();
     }
 }

--- a/library/src/main/java/com/raizlabs/android/dbflow/sql/index/Index.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/sql/index/Index.java
@@ -4,6 +4,7 @@ import android.support.annotation.NonNull;
 
 import com.raizlabs.android.dbflow.config.BaseDatabaseDefinition;
 import com.raizlabs.android.dbflow.config.FlowManager;
+import com.raizlabs.android.dbflow.sql.Query;
 import com.raizlabs.android.dbflow.sql.QueryBuilder;
 import com.raizlabs.android.dbflow.sql.SqlUtils;
 import com.raizlabs.android.dbflow.structure.Model;
@@ -11,7 +12,7 @@ import com.raizlabs.android.dbflow.structure.Model;
 /**
  * Description: Describes a SQLite Index
  */
-public class Index<ModelClass extends Model> {
+public class Index<ModelClass extends Model> implements Query {
 
     private final String mIndex;
 
@@ -66,13 +67,7 @@ public class Index<ModelClass extends Model> {
         }
 
         BaseDatabaseDefinition databaseDefinition = FlowManager.getDatabaseForTable(mTable);
-        QueryBuilder query = new QueryBuilder("CREATE ")
-                .append(isUnique ? "UNIQUE" : "")
-                .append(" INDEX")
-                .appendSpaceSeparated(mIndex)
-                .append("ON").appendSpaceSeparated(FlowManager.getTableName(mTable))
-                .append("(").appendArray(mColumns).append(")");
-        databaseDefinition.getWritableDatabase().execSQL(query.getQuery());
+        databaseDefinition.getWritableDatabase().execSQL(getQuery());
     }
 
     /**
@@ -82,4 +77,13 @@ public class Index<ModelClass extends Model> {
         SqlUtils.dropIndex(mTable, mIndex);
     }
 
+    @Override
+    public String getQuery() {
+        return new QueryBuilder("CREATE ")
+                .append(isUnique ? "UNIQUE" : "")
+                .append(" INDEX ")
+                .appendQuoted(mIndex)
+                .append(" ON ").appendQuoted(FlowManager.getTableName(mTable))
+                .append("(").appendQuotedArray(mColumns).append(")").getQuery();
+    }
 }

--- a/library/src/main/java/com/raizlabs/android/dbflow/sql/index/Index.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/sql/index/Index.java
@@ -56,6 +56,27 @@ public class Index<ModelClass extends Model> implements Query {
     }
 
     /**
+     * @return The name of this index.
+     */
+    public String getIndexName() {
+        return mIndex;
+    }
+
+    /**
+     * @return The table this INDEX belongs to.
+     */
+    public Class<ModelClass> getTable() {
+        return mTable;
+    }
+
+    /**
+     * @return true if the index is unique
+     */
+    public boolean isUnique() {
+        return isUnique;
+    }
+
+    /**
      * Enables the TRIGGER.
      */
     public void enable() {
@@ -80,8 +101,8 @@ public class Index<ModelClass extends Model> implements Query {
     @Override
     public String getQuery() {
         return new QueryBuilder("CREATE ")
-                .append(isUnique ? "UNIQUE" : "")
-                .append(" INDEX ")
+                .append(isUnique ? "UNIQUE " : "")
+                .append("INDEX IF NOT EXISTS ")
                 .appendQuoted(mIndex)
                 .append(" ON ").appendQuoted(FlowManager.getTableName(mTable))
                 .append("(").appendQuotedArray(mColumns).append(")").getQuery();

--- a/library/src/main/java/com/raizlabs/android/dbflow/sql/index/Index.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/sql/index/Index.java
@@ -1,0 +1,85 @@
+package com.raizlabs.android.dbflow.sql.index;
+
+import android.support.annotation.NonNull;
+
+import com.raizlabs.android.dbflow.config.BaseDatabaseDefinition;
+import com.raizlabs.android.dbflow.config.FlowManager;
+import com.raizlabs.android.dbflow.sql.QueryBuilder;
+import com.raizlabs.android.dbflow.sql.SqlUtils;
+import com.raizlabs.android.dbflow.structure.Model;
+
+/**
+ * Description: Describes a SQLite Index
+ */
+public class Index<ModelClass extends Model> {
+
+    private final String mIndex;
+
+    private Class<ModelClass> mTable;
+
+    private String[] mColumns;
+
+    private boolean isUnique = false;
+
+    /**
+     * Creates a new index with the specified name
+     *
+     * @param indexName The name of this index.
+     */
+    public Index(@NonNull String indexName) {
+        mIndex = indexName;
+    }
+
+    /**
+     * If true, will append the UNIQUE statement to this trigger.
+     *
+     * @param unique true if unique. If created again, a {@link android.database.SQLException} is thrown.
+     * @return This instance.
+     */
+    public Index<ModelClass> unique(boolean unique) {
+        isUnique = unique;
+        return this;
+    }
+
+    /**
+     * The table to execute this Index on.
+     *
+     * @param table   The table to execute index on.
+     * @param columns The columns to create an index for.
+     * @return This instance.
+     */
+    public Index<ModelClass> on(@NonNull Class<ModelClass> table, String... columns) {
+        mTable = table;
+        mColumns = columns;
+        return this;
+    }
+
+    /**
+     * Enables the TRIGGER.
+     */
+    public void enable() {
+
+        if (mTable == null) {
+            throw new IllegalStateException("Please call on() to set a table to use this index on.");
+        } else if (mColumns == null || mColumns.length == 0) {
+            throw new IllegalStateException("There should be at least one column in this index");
+        }
+
+        BaseDatabaseDefinition databaseDefinition = FlowManager.getDatabaseForTable(mTable);
+        QueryBuilder query = new QueryBuilder("CREATE ")
+                .append(isUnique ? "UNIQUE" : "")
+                .append(" INDEX")
+                .appendSpaceSeparated(mIndex)
+                .append("ON").appendSpaceSeparated(FlowManager.getTableName(mTable))
+                .append("(").appendArray(mColumns).append(")");
+        databaseDefinition.getWritableDatabase().execSQL(query.getQuery());
+    }
+
+    /**
+     * Disables the TRIGGER
+     */
+    public void disable() {
+        SqlUtils.dropIndex(mTable, mIndex);
+    }
+
+}

--- a/library/src/main/java/com/raizlabs/android/dbflow/sql/language/From.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/sql/language/From.java
@@ -96,8 +96,8 @@ public class From<ModelClass extends Model> implements WhereBase<ModelClass>, Mo
     /**
      * Returns a {@link Where} statement with the specified {@link com.raizlabs.android.dbflow.sql.builder.ConditionQueryBuilder}
      *
-     * @param conditionQueryBuilder
-     * @return
+     * @param conditionQueryBuilder The builder of a specific set of conditions used in this query
+     * @return A where statement.
      */
     public Where<ModelClass> where(ConditionQueryBuilder<ModelClass> conditionQueryBuilder) {
         return where().whereQuery(conditionQueryBuilder);
@@ -107,7 +107,7 @@ public class From<ModelClass extends Model> implements WhereBase<ModelClass>, Mo
      * Returns a {@link Where} statement with the specified array of {@link com.raizlabs.android.dbflow.sql.builder.Condition}
      *
      * @param conditions The array of conditions that define this WHERE statement
-     * @return
+     * @return A where statement.
      */
     public Where<ModelClass> where(Condition... conditions) {
         return where().andThese(conditions);

--- a/library/src/main/java/com/raizlabs/android/dbflow/sql/language/From.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/sql/language/From.java
@@ -193,6 +193,16 @@ public class From<ModelClass extends Model> implements WhereBase<ModelClass>, Mo
         return set().conditionQuery(conditionQueryBuilder);
     }
 
+    /**
+     * Begins an INDEXED BY piece of this query with the specified name.
+     *
+     * @param indexName The name of the index.
+     * @return An INDEXED BY piece of this statement
+     */
+    public IndexedBy<ModelClass> indexedBy(String indexName) {
+        return new IndexedBy<>(indexName, this);
+    }
+
     @Override
     public String toString() {
         return getQuery();

--- a/library/src/main/java/com/raizlabs/android/dbflow/sql/language/IndexedBy.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/sql/language/IndexedBy.java
@@ -1,0 +1,81 @@
+package com.raizlabs.android.dbflow.sql.language;
+
+import android.database.Cursor;
+import android.support.annotation.NonNull;
+
+import com.raizlabs.android.dbflow.config.FlowManager;
+import com.raizlabs.android.dbflow.list.FlowCursorList;
+import com.raizlabs.android.dbflow.list.FlowTableList;
+import com.raizlabs.android.dbflow.sql.ModelQueriable;
+import com.raizlabs.android.dbflow.sql.Query;
+import com.raizlabs.android.dbflow.sql.QueryBuilder;
+import com.raizlabs.android.dbflow.sql.SqlUtils;
+import com.raizlabs.android.dbflow.structure.Model;
+
+import java.util.List;
+
+/**
+ * Description: The INDEXED BY part of a SELECT/UPDATE/DELETE
+ */
+public class IndexedBy<ModelClass extends Model> implements ModelQueriable<ModelClass>, Query {
+
+    private final String mIndexName;
+
+    private final WhereBase<ModelClass> mWhereBase;
+
+    /**
+     * Creates the INDEXED BY part of the clause.
+     *
+     * @param mIndexName The name of the index
+     * @param whereBase  The base piece of this query
+     */
+    IndexedBy(@NonNull String mIndexName, WhereBase<ModelClass> whereBase) {
+        this.mIndexName = mIndexName;
+        this.mWhereBase = whereBase;
+    }
+
+    @Override
+    public List<ModelClass> queryList() {
+        return SqlUtils.convertToList(getTable(), query());
+    }
+
+    @Override
+    public ModelClass querySingle() {
+        return SqlUtils.convertToModel(false, getTable(), query());
+    }
+
+    @Override
+    public Class<ModelClass> getTable() {
+        return mWhereBase.getTable();
+    }
+
+    @Override
+    public FlowCursorList<ModelClass> queryCursorList() {
+        return new FlowCursorList<>(false, this);
+    }
+
+    @Override
+    public FlowTableList<ModelClass> queryTableList() {
+        return new FlowTableList<>(this);
+    }
+
+    @Override
+    public Cursor query() {
+        return FlowManager.getDatabaseForTable(getTable()).getWritableDatabase().rawQuery(getQuery(), null);
+    }
+
+    @Override
+    public void queryClose() {
+        Cursor cursor = query();
+        if (cursor != null) {
+            cursor.close();
+        }
+    }
+
+    @Override
+    public String getQuery() {
+        QueryBuilder queryBuilder = new QueryBuilder(mWhereBase.getQuery())
+                .append("INDEXED BY").appendSpaceSeparated(mIndexName);
+        return queryBuilder.getQuery();
+    }
+}

--- a/library/src/main/java/com/raizlabs/android/dbflow/sql/migration/IndexMigration.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/sql/migration/IndexMigration.java
@@ -25,6 +25,11 @@ public class IndexMigration<ModelClass extends Model> extends BaseMigration {
     private Class<ModelClass> mOnTable;
 
     /**
+     * Whether to create a UNIQUE index.
+     */
+    private boolean isUnique = false;
+
+    /**
      * The name of this index
      */
     private String mName;
@@ -59,12 +64,18 @@ public class IndexMigration<ModelClass extends Model> extends BaseMigration {
         return this;
     }
 
+    public IndexMigration<ModelClass> unique() {
+        isUnique = true;
+        return this;
+    }
+
     /**
      * @return The index object based on the contents of this migration.
      */
     public Index<ModelClass> getIndex() {
         return new Index<ModelClass>(mName)
-                .on(mOnTable, mColumns.toArray(new String[mColumns.size()]));
+                .on(mOnTable, mColumns.toArray(new String[mColumns.size()]))
+                .unique(isUnique);
     }
 
     /**

--- a/library/src/main/java/com/raizlabs/android/dbflow/sql/migration/IndexMigration.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/sql/migration/IndexMigration.java
@@ -36,9 +36,14 @@ public class IndexMigration<ModelClass extends Model> extends BaseMigration {
 
     @Override
     public void migrate(SQLiteDatabase database) {
-        Index<ModelClass> index = new Index<ModelClass>(mName)
-                .on(mOnTable, mColumns.toArray(new String[mColumns.size()]));
-        index.enable();
+        getIndex().enable();
+    }
+
+    @Override
+    public void onPostMigrate() {
+        mColumns = null;
+        mOnTable = null;
+        mName = null;
     }
 
     /**
@@ -47,11 +52,26 @@ public class IndexMigration<ModelClass extends Model> extends BaseMigration {
      * @param columnName The name of the column to add to the Index
      * @return This migration
      */
-    public IndexMigration addColumn(String columnName) {
+    public IndexMigration<ModelClass> addColumn(String columnName) {
         if (!mColumns.contains(columnName)) {
             mColumns.add(columnName);
         }
         return this;
+    }
+
+    /**
+     * @return The index object based on the contents of this migration.
+     */
+    public Index<ModelClass> getIndex() {
+        return new Index<ModelClass>(mName)
+                .on(mOnTable, mColumns.toArray(new String[mColumns.size()]));
+    }
+
+    /**
+     * @return the query backing this migration.
+     */
+    public String getIndexQuery() {
+        return getIndex().getQuery();
     }
 
 }

--- a/library/src/main/java/com/raizlabs/android/dbflow/sql/migration/IndexMigration.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/sql/migration/IndexMigration.java
@@ -34,8 +34,7 @@ public class IndexMigration<ModelClass extends Model> extends BaseMigration {
     @Override
     public void onPreMigrate() {
         super.onPreMigrate();
-
-        mIndex = new Index<ModelClass>(mName).on(mOnTable);
+        mIndex = getIndex();
     }
 
     @Override
@@ -57,7 +56,7 @@ public class IndexMigration<ModelClass extends Model> extends BaseMigration {
      * @return This migration
      */
     public IndexMigration<ModelClass> addColumn(String columnName) {
-        mIndex.and(columnName);
+        getIndex().and(columnName);
         return this;
     }
 
@@ -67,7 +66,7 @@ public class IndexMigration<ModelClass extends Model> extends BaseMigration {
      * @return This migration.
      */
     public IndexMigration<ModelClass> unique() {
-        mIndex.unique(true);
+        getIndex().unique(true);
         return this;
     }
 
@@ -75,6 +74,9 @@ public class IndexMigration<ModelClass extends Model> extends BaseMigration {
      * @return The index object based on the contents of this migration.
      */
     public Index<ModelClass> getIndex() {
+        if(mIndex == null) {
+            mIndex = new Index<ModelClass>(mName).on(mOnTable);
+        }
         return mIndex;
     }
 

--- a/library/src/main/java/com/raizlabs/android/dbflow/sql/migration/IndexMigration.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/sql/migration/IndexMigration.java
@@ -1,0 +1,57 @@
+package com.raizlabs.android.dbflow.sql.migration;
+
+import android.database.sqlite.SQLiteDatabase;
+import android.support.annotation.NonNull;
+
+import com.raizlabs.android.dbflow.sql.index.Index;
+import com.raizlabs.android.dbflow.structure.Model;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Description: Defines and enables an Index structurally through a migration.
+ */
+public class IndexMigration<ModelClass extends Model> extends BaseMigration {
+
+    /**
+     * The list of columns to add
+     */
+    private List<String> mColumns = new ArrayList<>();
+
+    /**
+     * The table to index on
+     */
+    private Class<ModelClass> mOnTable;
+
+    /**
+     * The name of this index
+     */
+    private String mName;
+
+    public IndexMigration(@NonNull String name, @NonNull Class<ModelClass> mOnTable) {
+        this.mOnTable = mOnTable;
+        this.mName = name;
+    }
+
+    @Override
+    public void migrate(SQLiteDatabase database) {
+        Index<ModelClass> index = new Index<ModelClass>(mName)
+                .on(mOnTable, mColumns.toArray(new String[mColumns.size()]));
+        index.enable();
+    }
+
+    /**
+     * Adds a column to the underlying INDEX
+     *
+     * @param columnName The name of the column to add to the Index
+     * @return This migration
+     */
+    public IndexMigration addColumn(String columnName) {
+        if (!mColumns.contains(columnName)) {
+            mColumns.add(columnName);
+        }
+        return this;
+    }
+
+}

--- a/library/src/main/java/com/raizlabs/android/dbflow/structure/cache/ModelCache.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/structure/cache/ModelCache.java
@@ -45,6 +45,13 @@ public abstract class ModelCache<ModelClass extends Model, CacheClass> {
     public abstract ModelClass get(Long id);
 
     /**
+     * Sets a new size for the underlying cache (if applicable) and may destroy the cache.
+     *
+     * @param size The size of cache to set to
+     */
+    public abstract void setCacheSize(int size);
+
+    /**
      * @return The cache that's backing this cache.
      */
     public CacheClass getCache() {

--- a/library/src/main/java/com/raizlabs/android/dbflow/structure/cache/ModelLruCache.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/structure/cache/ModelLruCache.java
@@ -36,6 +36,11 @@ public class ModelLruCache<ModelClass extends Model> extends ModelCache<ModelCla
     }
 
     @Override
+    public void setCacheSize(int size) {
+        getCache().resize(size);
+    }
+
+    @Override
     public ModelClass get(Long id) {
         return id == null ? null : getCache().get(id);
     }

--- a/library/src/main/java/com/raizlabs/android/dbflow/structure/cache/SparseArrayBasedCache.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/structure/cache/SparseArrayBasedCache.java
@@ -2,17 +2,28 @@ package com.raizlabs.android.dbflow.structure.cache;
 
 import android.util.SparseArray;
 
+import com.raizlabs.android.dbflow.config.FlowLog;
 import com.raizlabs.android.dbflow.structure.Model;
 
 /**
  * Description: A cache backed by a {@link android.util.SparseArray}
  */
 public class SparseArrayBasedCache<ModelClass extends Model> extends ModelCache<ModelClass, SparseArray<ModelClass>> {
+
     /**
      * Constructs new instance with a {@link android.util.SparseArray} cache
      */
     public SparseArrayBasedCache() {
         super(new SparseArray<ModelClass>());
+    }
+
+    /**
+     * Constructs new instance with a {@link android.util.SparseArray} cache
+     *
+     * @param initialCapacity The initial capacity of the sparse array
+     */
+    public SparseArrayBasedCache(int initialCapacity) {
+        super(new SparseArray<ModelClass>(initialCapacity));
     }
 
     /**
@@ -45,6 +56,11 @@ public class SparseArrayBasedCache<ModelClass extends Model> extends ModelCache<
         synchronized (getCache()) {
             getCache().clear();
         }
+    }
+
+    @Override
+    public void setCacheSize(int size) {
+        FlowLog.log(FlowLog.Level.I, "The cache size for " + SparseArrayBasedCache.class.getSimpleName() + " is not re-configurable.");
     }
 
     @Override

--- a/usage/Migrations.md
+++ b/usage/Migrations.md
@@ -2,7 +2,7 @@
 
 Whenever you modify the DB schema you need to increment the DB version through within the ```@Database``` class it corresponds to. Also you need to add a ```Migration``` to the configuration or define the migration via ```/assets/migrations/{DatabaseName}/{versionName.sql}```. 
 
-**Note** any provided subclass such as ```AlterTableMigration``` and ```UpdateTableMigration``` should only override ```onPreMigrate()``` and **call super.onPreMigrate()** so it's instantiated properly. 
+**Note** any provided subclass such as ```AlterTableMigration```, ```UpdateTableMigration```, and ```IndexMigration``` should only override ```onPreMigrate()``` and **call super.onPreMigrate()** so it's instantiated properly. 
 
 ## Migration Classes
 

--- a/usage/TriggersIndexesAndMore.md
+++ b/usage/TriggersIndexesAndMore.md
@@ -1,0 +1,56 @@
+# Triggers, Indexes, and More
+
+This section contains more advance usage of SQLite. These features are very useful and can be used to improve DB and app performance.
+
+## Triggers
+
+```Trigger``` are actions that are automatically performed before or after some action on the database. For example, we want to log changes for all updates to the name on the ```Friend``` table. 
+
+```java
+
+CompletedTrigger<Friend> trigger = new Trigger<Friend>("NameTrigger")
+                                    .after().update(Friend.class, Friend$Table.NAME)
+                                    .begin(
+                                        new Insert<FriendLog>(FriendLog.class)
+                                          .columns(FriendLog$Table.OLDNAME, FriendLog$Table.NEWNAME, FriendLog$Table.DATE)
+                                          .values("old.Name", "new.Name", System.currentTimeMillis())
+                                          };
+ // starts a trigger                                         
+ trigger.enable();
+ 
+ // stops a trigger
+ trigger.disable();
+
+```
+
+## Indexes
+
+```Index``` are pointers to specific columns in a table that enable super-fast retrieval. The trade-off of using these is that the database 
+size significantly increases, however if performance is more important, the tradeoff is worth it.
+
+```java
+
+Index<Friend> index = new Index<Friend>("index_friendName")
+                      .on(Friend.class, Friend$Table.NAME);
+                      
+// begins an index
+index.enable();
+
+// drops an index
+index.disable();
+
+```
+
+### INDEXED BY
+
+As of 1.5.1, the ```INDEXED BY``` clause is now supported. Using the previous ```Index``` statement, we can now utilize the power
+of indexes in a query.
+
+```java
+
+List<Friend> friends = new Select()
+                      .from(Friend.class)
+                      .indexedBy("index_friendName")
+                      .where(Condition.column(Friend$Table.NAME).like("Andrew%")).queryList();
+
+```


### PR DESCRIPTION
1. Fixes #76 
2. Adds ```Index``` support and ```IndexMigration``` support!! Fixes #63 
3. Fixes #76 ```FlowCursorList``` where ```Handler``` was not using main looper 
4. fixes #72  ```FlowTableList``` where ```LruCache``` does not allow cache size of 0, causing crash. Also now the count can be determined by overriding ```getCacheSize()```
5. Fixes #71 