### PR TITLE
Version 1.6.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Android Weekly](http://img.shields.io/badge/Android%20Weekly-%23129-2CB3E5.svg?style=flat)](http://androidweekly.net/issues/issue-129)
 [![Android Arsenal](https://img.shields.io/badge/Android%20Arsenal-DBFlow-brightgreen.svg?style=flat)](https://android-arsenal.com/details/1/1134) 
-[![Raizlabs Repository](http://img.shields.io/badge/Raizlabs%20Repository-1.6.1-blue.svg?style=flat)](https://github.com/Raizlabs/maven-releases)
+[![Raizlabs Repository](http://img.shields.io/badge/Raizlabs%20Repository-1.6.2-blue.svg?style=flat)](https://github.com/Raizlabs/maven-releases)
 
 DBFlow
 ======
@@ -24,6 +24,10 @@ What sets this library apart:
   8. ```ContentProvider``` generation using annotations
 
 ## Changelog
+
+#### 1.6.2
+
+Fixes a ```StackOverflowError``` when using ```BaseCacheableModel```
 
 #### 1.6.1
 
@@ -107,8 +111,8 @@ Add the library to the project-level build.gradle, using the [apt plugin](https:
   apply plugin: 'com.raizlabs.griddle'
 
   dependencies {
-    apt 'com.raizlabs.android:DBFlow-Compiler:1.6.1'
-    mod "com.raizlabs.android:{DBFlow-Core, DBFlow}:1.6.1"
+    apt 'com.raizlabs.android:DBFlow-Compiler:1.6.2'
+    mod "com.raizlabs.android:{DBFlow-Core, DBFlow}:1.6.2"
   }
 
 ```
@@ -120,9 +124,9 @@ or by standard Gradle use (without linking sources support):
   apply plugin: 'com.neenbedankt.android-apt'
 
   dependencies {
-    apt 'com.raizlabs.android:DBFlow-Compiler:1.6.1'
-    compile "com.raizlabs.android:DBFlow-Core:1.6.1"
-    compile "com.raizlabs.android:DBFlow:1.6.1"
+    apt 'com.raizlabs.android:DBFlow-Compiler:1.6.2'
+    compile "com.raizlabs.android:DBFlow-Core:1.6.2"
+    compile "com.raizlabs.android:DBFlow:1.6.2"
   }
 
 ```

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=1.6.1
+VERSION_NAME=1.6.2
 VERSION_CODE=1
 GROUP=com.raizlabs.android
 

--- a/library/src/main/java/com/raizlabs/android/dbflow/structure/cache/BaseCacheableModel.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/structure/cache/BaseCacheableModel.java
@@ -62,7 +62,7 @@ public abstract class BaseCacheableModel extends BaseModel implements LoadFromCu
      */
     @SuppressWarnings("unchecked")
     public BaseCacheableModel() {
-        mCache = getCache(getClass());
+        mCache = mCacheMap.get(getClass());
         if (mCache == null) {
             mCache = getBackingCache();
             putCache(getClass(), mCache);


### PR DESCRIPTION
Fixes ```StackOverflowError``` when using a ```BaseCacheableModel```.