### PR TITLE
Version 1.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,29 +25,15 @@ What sets this library apart:
 
 ## Changelog
 
-#### 1.6.2
+#### 1.7.0
 
-Fixes a ```StackOverflowError``` when using ```BaseCacheableModel```
-
-#### 1.6.1
-
-1. #106 Empty model list will cause a crash in ProcessModelInfo
-2. #101 Fixes issue where removeAll(Collection) crashes in certain scenarios where the list is a subclass with generic parameters. Now
-will explicitly fail with ClassCastException if of wrong type.
-3. #86 Now can force notifying content observer changes across different processes
-
-#### 1.6.0
-
-1. Adds annotation processing for creating ```ContentProvider``` access classes
-2. Generates ContentProviders for you
-3. Decent amount of features including connecting ```Model``` classes to a ContentProvider so you don't need to write ```ContentValues```.
-4. Based on [schematic](https://github.com/SimonVT/schematic)
-5. Adds and condenses some adapter code generation as well as adds support for methods needed for them.
-6. Fixes all tests so they can run successfully without clearing data.
-7. Added usage docs for this new major feature!
-8. #95 where a ```JSONObject.NULL``` was not recognized as a proper ```null```.
-9. Added support for non-autoincrementing primary keys as model cache key. Allows for single ```int``` or ```long``` ```PRIMARY_KEY``` field to be a caching id. 
-10. Fixes an issue where a method in ```count()``` for non-SELECT statements was called in pre-honeycomb devices anyways. Now it uses a raw query statement for compatibility.
+1. Added unique columns support by using ```@UniqueGroup``` for columns to enable multiple different groups of columns #117 
+2. Fixes an issue where autoincrement update methods do not pass in the id of the object, possibly touching other rows unintentionally
+3. Added global configurable defaults for ```insertConfict()``` and ```updateConflict()```in a ```@Database``` for any table that does not define a ```ConflictAction``` #104 
+4. Added ```bulkInsert``` support to the ```@ContentProvider``` and corresponding method in ```ContentUtils``` #108 
+5. Added Kotlin support! just change the ```generatedClassSeparator()``` for a ```@Database``` to Kotlin compatible. #90 
+6. Added usage guide for databases
+7. Adds better null loading, as in it prevents loading null values into the object when it's not null. #128 
 
 for older changes, from other xx.xx versions, check it out [here](https://github.com/Raizlabs/DBFlow/wiki)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Android Weekly](http://img.shields.io/badge/Android%20Weekly-%23129-2CB3E5.svg?style=flat)](http://androidweekly.net/issues/issue-129)
 [![Android Arsenal](https://img.shields.io/badge/Android%20Arsenal-DBFlow-brightgreen.svg?style=flat)](https://android-arsenal.com/details/1/1134) 
-[![Raizlabs Repository](http://img.shields.io/badge/Raizlabs%20Repository-1.6.1-blue.svg?style=flat)](https://github.com/Raizlabs/maven-releases)
+[![Raizlabs Repository](http://img.shields.io/badge/Raizlabs%20Repository-1.6.2-blue.svg?style=flat)](https://github.com/Raizlabs/maven-releases)
 
 DBFlow
 ======
@@ -24,6 +24,10 @@ What sets this library apart:
   8. ```ContentProvider``` generation using annotations
 
 ## Changelog
+
+#### 1.6.2
+
+Fixes a ```StackOverflowError``` when using ```BaseCacheableModel```
 
 #### 1.6.1
 
@@ -107,8 +111,8 @@ Add the library to the project-level build.gradle, using the [apt plugin](https:
   apply plugin: 'com.raizlabs.griddle'
 
   dependencies {
-    apt 'com.raizlabs.android:DBFlow-Compiler:1.6.1'
-    mod "com.raizlabs.android:{DBFlow-Core, DBFlow}:1.6.1"
+    apt 'com.raizlabs.android:DBFlow-Compiler:1.6.2'
+    mod "com.raizlabs.android:{DBFlow-Core, DBFlow}:1.6.2"
   }
 
 ```
@@ -120,9 +124,9 @@ or by standard Gradle use (without linking sources support):
   apply plugin: 'com.neenbedankt.android-apt'
 
   dependencies {
-    apt 'com.raizlabs.android:DBFlow-Compiler:1.6.1'
-    compile "com.raizlabs.android:DBFlow-Core:1.6.1"
-    compile "com.raizlabs.android:DBFlow:1.6.1"
+    apt 'com.raizlabs.android:DBFlow-Compiler:1.6.2'
+    compile "com.raizlabs.android:DBFlow-Core:1.6.2"
+    compile "com.raizlabs.android:DBFlow:1.6.2"
   }
 
 ```

--- a/compiler/src/main/java/com/raizlabs/android/dbflow/processor/Classes.java
+++ b/compiler/src/main/java/com/raizlabs/android/dbflow/processor/Classes.java
@@ -59,7 +59,7 @@ public class Classes {
 
     public static final String FLOW_MANAGER_PACKAGE = "com.raizlabs.android.dbflow.config";
 
-    public static final String DATABASE_HOLDER_STATIC_CLASS_NAME = "Database$Holder";
+    public static final String DATABASE_HOLDER_STATIC_CLASS_NAME = "GeneratedDatabaseHolder";
 
     public static final String BASE_DATABASE_DEFINITION = "BaseDatabaseDefinition";
 

--- a/compiler/src/main/java/com/raizlabs/android/dbflow/processor/DBFlowProcessor.java
+++ b/compiler/src/main/java/com/raizlabs/android/dbflow/processor/DBFlowProcessor.java
@@ -83,10 +83,13 @@ public class DBFlowProcessor extends AbstractProcessor {
     @Override
     public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
 
-        ArrayList<Element> elements = new ArrayList<Element>(roundEnv.getElementsAnnotatedWith(Database.class));
-        if(elements.size() > 0) {
-            Database database = elements.get(0).getAnnotation(Database.class);
-            DEFAULT_DB_NAME = database.name();
+        Set<? extends Element> elements = roundEnv.getElementsAnnotatedWith(Database.class);
+        for(Element element: elements) {
+            Database database = element.getAnnotation(Database.class);
+            if(database != null) {
+                DEFAULT_DB_NAME = database.name();
+                break;
+            }
         }
         manager.handle(manager, roundEnv);
 

--- a/compiler/src/main/java/com/raizlabs/android/dbflow/processor/DBFlowProcessor.java
+++ b/compiler/src/main/java/com/raizlabs/android/dbflow/processor/DBFlowProcessor.java
@@ -72,12 +72,12 @@ public class DBFlowProcessor extends AbstractProcessor {
         manager.addHandlers(
                 new MigrationHandler(),
                 new TypeConverterHandler(),
+                new DatabaseHandler(),
                 new TableHandler(),
                 new ModelContainerHandler(),
                 new ModelViewHandler(),
                 new ContentProviderHandler(),
-                new TableEndpointHandler(),
-                new FlowManagerHandler());
+                new TableEndpointHandler());
     }
 
     @Override

--- a/compiler/src/main/java/com/raizlabs/android/dbflow/processor/definition/BaseTableDefinition.java
+++ b/compiler/src/main/java/com/raizlabs/android/dbflow/processor/definition/BaseTableDefinition.java
@@ -1,6 +1,7 @@
 package com.raizlabs.android.dbflow.processor.definition;
 
 import com.raizlabs.android.dbflow.processor.model.ProcessorManager;
+import com.raizlabs.android.dbflow.processor.writer.DatabaseWriter;
 
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
@@ -15,6 +16,7 @@ public abstract class BaseTableDefinition extends BaseDefinition {
     protected List<ColumnDefinition> columnDefinitions;
 
     private String modelClassName;
+    public DatabaseWriter databaseWriter;
 
     public BaseTableDefinition(Element typeElement, ProcessorManager processorManager) {
         super(typeElement, processorManager);

--- a/compiler/src/main/java/com/raizlabs/android/dbflow/processor/definition/ColumnDefinition.java
+++ b/compiler/src/main/java/com/raizlabs/android/dbflow/processor/definition/ColumnDefinition.java
@@ -73,6 +73,8 @@ public class ColumnDefinition extends BaseDefinition implements FlowWriter {
 
     public boolean unique = false;
 
+    public List<Integer> uniqueGroups = new ArrayList<>();
+
     public ConflictAction onUniqueConflict;
 
     public String collate;
@@ -90,6 +92,12 @@ public class ColumnDefinition extends BaseDefinition implements FlowWriter {
             this.saveModelForeignKey = column.saveForeignKeyModel();
             length = column.length();
             unique = column.unique();
+            if(unique) {
+                int[] groups = column.uniqueGroups();
+                for(int group: groups) {
+                    uniqueGroups.add(group);
+                }
+            }
             onUniqueConflict = column.onUniqueConflict();
             notNull = column.notNull();
             onNullConflict = column.onNullConflict();

--- a/compiler/src/main/java/com/raizlabs/android/dbflow/processor/definition/MigrationDefinition.java
+++ b/compiler/src/main/java/com/raizlabs/android/dbflow/processor/definition/MigrationDefinition.java
@@ -15,8 +15,6 @@ import java.io.IOException;
 public class MigrationDefinition extends BaseDefinition implements FlowWriter {
 
 
-    public static final String DBFLOW_MIGRATION_CONTAINER_TAG = "$Migrations";
-
     public String databaseName;
 
     public Integer version;

--- a/compiler/src/main/java/com/raizlabs/android/dbflow/processor/definition/ModelContainerDefinition.java
+++ b/compiler/src/main/java/com/raizlabs/android/dbflow/processor/definition/ModelContainerDefinition.java
@@ -16,7 +16,7 @@ import java.io.IOException;
  */
 public class ModelContainerDefinition extends BaseDefinition {
 
-    public static final String DBFLOW_MODEL_CONTAINER_TAG = "$Container";
+    public static final String DBFLOW_MODEL_CONTAINER_TAG = "Container";
 
     private FlowWriter[] mMethodWriters;
 
@@ -24,10 +24,9 @@ public class ModelContainerDefinition extends BaseDefinition {
 
     public ModelContainerDefinition(TypeElement classElement, ProcessorManager manager) {
         super(classElement, manager);
-        setDefinitionClassName(DBFLOW_MODEL_CONTAINER_TAG);
-
         tableDefinition = manager.getTableDefinition(manager.getDatabase(classElement.getSimpleName().toString()), classElement);
 
+        setDefinitionClassName(tableDefinition.databaseWriter.classSeparator + DBFLOW_MODEL_CONTAINER_TAG);
 
         mMethodWriters = new FlowWriter[]{
                 new SQLiteStatementWriter(tableDefinition, true, tableDefinition.implementsSqlStatementListener,
@@ -87,7 +86,7 @@ public class ModelContainerDefinition extends BaseDefinition {
         }, "Class<?>", "getClassForColumn", Sets.newHashSet(Modifier.PUBLIC, Modifier.FINAL), "String", "columnName");
 
         InternalAdapterHelper.writeGetModelClass(javaWriter, getModelClassQualifiedName());
-        InternalAdapterHelper.writeGetTableName(javaWriter, elementClassName + TableDefinition.DBFLOW_TABLE_TAG);
+        InternalAdapterHelper.writeGetTableName(javaWriter, elementClassName + tableDefinition.databaseWriter.classSeparator + TableDefinition.DBFLOW_TABLE_TAG);
 
 
 

--- a/compiler/src/main/java/com/raizlabs/android/dbflow/processor/definition/ModelViewDefinition.java
+++ b/compiler/src/main/java/com/raizlabs/android/dbflow/processor/definition/ModelViewDefinition.java
@@ -9,11 +9,15 @@ import com.raizlabs.android.dbflow.processor.ProcessorUtils;
 import com.raizlabs.android.dbflow.processor.handler.DatabaseHandler;
 import com.raizlabs.android.dbflow.processor.model.ProcessorManager;
 import com.raizlabs.android.dbflow.processor.utils.WriterUtils;
+import com.raizlabs.android.dbflow.processor.writer.DatabaseWriter;
 import com.raizlabs.android.dbflow.processor.writer.ExistenceWriter;
 import com.raizlabs.android.dbflow.processor.writer.FlowWriter;
 import com.raizlabs.android.dbflow.processor.writer.LoadCursorWriter;
 import com.raizlabs.android.dbflow.processor.writer.WhereQueryWriter;
 import com.squareup.javawriter.JavaWriter;
+
+import java.io.IOException;
+import java.util.List;
 
 import javax.lang.model.element.Element;
 import javax.lang.model.element.Modifier;
@@ -22,15 +26,13 @@ import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeMirror;
 import javax.tools.Diagnostic;
-import java.io.IOException;
-import java.util.List;
 
 /**
  * Description: Used in writing ModelViewAdapters
  */
 public class ModelViewDefinition extends BaseTableDefinition implements FlowWriter {
 
-    private static final String DBFLOW_MODEL_VIEW_TAG = "$View";
+    private static final String DBFLOW_MODEL_VIEW_TAG = "View";
 
     final boolean implementsLoadFromCursorListener;
 
@@ -46,17 +48,20 @@ public class ModelViewDefinition extends BaseTableDefinition implements FlowWrit
 
     public ModelViewDefinition(ProcessorManager manager, Element element) {
         super(element, manager);
-        setDefinitionClassName(DBFLOW_MODEL_VIEW_TAG);
 
         ModelView modelView = element.getAnnotation(ModelView.class);
         this.query = modelView.query();
         this.databaseName = modelView.databaseName();
-        if(databaseName == null || databaseName.isEmpty()) {
+        if (databaseName == null || databaseName.isEmpty()) {
             databaseName = DBFlowProcessor.DEFAULT_DB_NAME;
         }
 
+        databaseWriter = manager.getDatabaseWriter(databaseName);
+        setDefinitionClassName(databaseWriter.classSeparator + DBFLOW_MODEL_VIEW_TAG);
+
+
         this.name = modelView.name();
-        if(name == null || name.isEmpty()) {
+        if (name == null || name.isEmpty()) {
             name = getModelClassName();
         }
 
@@ -84,7 +89,7 @@ public class ModelViewDefinition extends BaseTableDefinition implements FlowWrit
         implementsLoadFromCursorListener = ProcessorUtils.implementsClass(manager.getProcessingEnvironment(),
                 Classes.LOAD_FROM_CURSOR_LISTENER, (TypeElement) element);
 
-        mMethodWriters = new FlowWriter[] {
+        mMethodWriters = new FlowWriter[]{
                 new LoadCursorWriter(this, false, implementsLoadFromCursorListener),
                 new ExistenceWriter(this, false),
                 new WhereQueryWriter(this, false)
@@ -94,12 +99,12 @@ public class ModelViewDefinition extends BaseTableDefinition implements FlowWrit
     @Override
     protected void createColumnDefinitions(TypeElement typeElement) {
         List<? extends Element> variableElements = manager.getElements().getAllMembers(typeElement);
-        for(Element variableElement: variableElements) {
-            if(variableElement.getAnnotation(Column.class) != null) {
+        for (Element variableElement : variableElements) {
+            if (variableElement.getAnnotation(Column.class) != null) {
                 ColumnDefinition columnDefinition = new ColumnDefinition(manager, (VariableElement) variableElement);
                 columnDefinitions.add(columnDefinition);
 
-                if(columnDefinition.columnType == Column.PRIMARY_KEY || columnDefinition.columnType == Column.FOREIGN_KEY) {
+                if (columnDefinition.columnType == Column.PRIMARY_KEY || columnDefinition.columnType == Column.FOREIGN_KEY) {
                     manager.getMessager().printMessage(Diagnostic.Kind.ERROR, "ModelViews cannot have primary or foreign keys");
                 }
             }
@@ -117,12 +122,12 @@ public class ModelViewDefinition extends BaseTableDefinition implements FlowWrit
 
     @Override
     public String getTableSourceClassName() {
-        return modelReferenceClass + TableDefinition.DBFLOW_TABLE_TAG;
+        return modelReferenceClass + databaseWriter.classSeparator + TableDefinition.DBFLOW_TABLE_TAG;
     }
 
     @Override
     protected String[] getImports() {
-        return new String[] {
+        return new String[]{
                 Classes.CURSOR, Classes.SELECT, Classes.CONDITION_QUERY_BUILDER,
                 Classes.CONDITION
         };
@@ -135,7 +140,7 @@ public class ModelViewDefinition extends BaseTableDefinition implements FlowWrit
 
     @Override
     public void onWriteDefinition(JavaWriter javaWriter) throws IOException {
-        for (FlowWriter writer: mMethodWriters) {
+        for (FlowWriter writer : mMethodWriters) {
             writer.write(javaWriter);
         }
 
@@ -146,7 +151,7 @@ public class ModelViewDefinition extends BaseTableDefinition implements FlowWrit
             public void write(JavaWriter javaWriter) throws IOException {
                 javaWriter.emitStatement("return \"%1s\"", query);
             }
-        }, "String" , "getCreationQuery", DatabaseHandler.METHOD_MODIFIERS);
+        }, "String", "getCreationQuery", DatabaseHandler.METHOD_MODIFIERS);
 
         javaWriter.emitEmptyLine();
         javaWriter.emitAnnotation(Override.class);
@@ -155,7 +160,7 @@ public class ModelViewDefinition extends BaseTableDefinition implements FlowWrit
             public void write(JavaWriter javaWriter) throws IOException {
                 javaWriter.emitStatement("return \"%1s\"", name);
             }
-        }, "String" , "getViewName", DatabaseHandler.METHOD_MODIFIERS);
+        }, "String", "getViewName", DatabaseHandler.METHOD_MODIFIERS);
 
         WriterUtils.emitOverriddenMethod(javaWriter, new FlowWriter() {
             @Override

--- a/compiler/src/main/java/com/raizlabs/android/dbflow/processor/definition/ModelViewDefinition.java
+++ b/compiler/src/main/java/com/raizlabs/android/dbflow/processor/definition/ModelViewDefinition.java
@@ -6,7 +6,7 @@ import com.raizlabs.android.dbflow.annotation.ModelView;
 import com.raizlabs.android.dbflow.processor.Classes;
 import com.raizlabs.android.dbflow.processor.DBFlowProcessor;
 import com.raizlabs.android.dbflow.processor.ProcessorUtils;
-import com.raizlabs.android.dbflow.processor.handler.FlowManagerHandler;
+import com.raizlabs.android.dbflow.processor.handler.DatabaseHandler;
 import com.raizlabs.android.dbflow.processor.model.ProcessorManager;
 import com.raizlabs.android.dbflow.processor.utils.WriterUtils;
 import com.raizlabs.android.dbflow.processor.writer.ExistenceWriter;
@@ -146,7 +146,7 @@ public class ModelViewDefinition extends BaseTableDefinition implements FlowWrit
             public void write(JavaWriter javaWriter) throws IOException {
                 javaWriter.emitStatement("return \"%1s\"", query);
             }
-        }, "String" , "getCreationQuery", FlowManagerHandler.METHOD_MODIFIERS);
+        }, "String" , "getCreationQuery", DatabaseHandler.METHOD_MODIFIERS);
 
         javaWriter.emitEmptyLine();
         javaWriter.emitAnnotation(Override.class);
@@ -155,7 +155,7 @@ public class ModelViewDefinition extends BaseTableDefinition implements FlowWrit
             public void write(JavaWriter javaWriter) throws IOException {
                 javaWriter.emitStatement("return \"%1s\"", name);
             }
-        }, "String" , "getViewName", FlowManagerHandler.METHOD_MODIFIERS);
+        }, "String" , "getViewName", DatabaseHandler.METHOD_MODIFIERS);
 
         WriterUtils.emitOverriddenMethod(javaWriter, new FlowWriter() {
             @Override

--- a/compiler/src/main/java/com/raizlabs/android/dbflow/processor/definition/TableDefinition.java
+++ b/compiler/src/main/java/com/raizlabs/android/dbflow/processor/definition/TableDefinition.java
@@ -73,6 +73,8 @@ public class TableDefinition extends BaseTableDefinition implements FlowWriter {
 
     public Map<String, ColumnDefinition> mColumnMap = Maps.newHashMap();
 
+    public Map<Integer, List<ColumnDefinition>> mColumnUniqueMap = Maps.newHashMap();
+
     public TableDefinition(ProcessorManager manager, Element element) {
         super(element, manager);
         setDefinitionClassName(DBFLOW_TABLE_TAG);
@@ -160,6 +162,20 @@ public class TableDefinition extends BaseTableDefinition implements FlowWriter {
                     } else if (columnDefinition.columnType == Column.PRIMARY_KEY_AUTO_INCREMENT) {
                         autoIncrementDefinition = columnDefinition;
                         hasAutoIncrement = true;
+                    }
+
+                    if(columnDefinition.unique && !columnDefinition.uniqueGroups.isEmpty()) {
+                        List<Integer> groups = columnDefinition.uniqueGroups;
+                        for(int group: groups) {
+                            List<ColumnDefinition> groupList = mColumnUniqueMap.get(group);
+                            if(groupList == null) {
+                                groupList = new ArrayList<>();
+                                mColumnUniqueMap.put(group, groupList);
+                            }
+                            if(!groupList.contains(columnDefinition)) {
+                                groupList.add(columnDefinition);
+                            }
+                        }
                     }
                 }
             }

--- a/compiler/src/main/java/com/raizlabs/android/dbflow/processor/definition/TableDefinition.java
+++ b/compiler/src/main/java/com/raizlabs/android/dbflow/processor/definition/TableDefinition.java
@@ -14,6 +14,7 @@ import com.raizlabs.android.dbflow.processor.model.ProcessorManager;
 import com.raizlabs.android.dbflow.processor.utils.WriterUtils;
 import com.raizlabs.android.dbflow.processor.validator.ColumnValidator;
 import com.raizlabs.android.dbflow.processor.writer.CreationQueryWriter;
+import com.raizlabs.android.dbflow.processor.writer.DatabaseWriter;
 import com.raizlabs.android.dbflow.processor.writer.ExistenceWriter;
 import com.raizlabs.android.dbflow.processor.writer.FlowWriter;
 import com.raizlabs.android.dbflow.processor.writer.LoadCursorWriter;
@@ -89,10 +90,24 @@ public class TableDefinition extends BaseTableDefinition implements FlowWriter {
         if (databaseName == null || databaseName.isEmpty()) {
             databaseName = DBFlowProcessor.DEFAULT_DB_NAME;
         }
-        insertConflictActionName = table.insertConflict().equals(ConflictAction.NONE) ? ""
-                : table.insertConflict().name();
-        updateConflicationActionName = table.updateConflict().equals(ConflictAction.NONE) ? ""
-                : table.insertConflict().name();
+
+        DatabaseWriter databaseWriter = manager.getDatabaseWriter(databaseName);
+
+        // globular default
+        ConflictAction insertConflict = table.insertConflict();
+        if(insertConflict.equals(ConflictAction.NONE) && !databaseWriter.insertConflict.equals(ConflictAction.NONE)) {
+            insertConflict = databaseWriter.insertConflict;
+        }
+
+        ConflictAction updateConflict = table.updateConflict();
+        if(updateConflict.equals(ConflictAction.NONE) && !databaseWriter.updateConflict.equals(ConflictAction.NONE)) {
+            updateConflict = databaseWriter.updateConflict;
+        }
+
+        insertConflictActionName = insertConflict.equals(ConflictAction.NONE) ? ""
+                : insertConflict.name();
+        updateConflicationActionName = updateConflict.equals(ConflictAction.NONE) ? ""
+                : updateConflict.name();
 
         allFields = table.allFields();
 

--- a/compiler/src/main/java/com/raizlabs/android/dbflow/processor/definition/TableDefinition.java
+++ b/compiler/src/main/java/com/raizlabs/android/dbflow/processor/definition/TableDefinition.java
@@ -39,9 +39,9 @@ import javax.lang.model.element.VariableElement;
  */
 public class TableDefinition extends BaseTableDefinition implements FlowWriter {
 
-    public static final String DBFLOW_TABLE_TAG = "$Table";
+    public static final String DBFLOW_TABLE_TAG = "Table";
 
-    public static final String DBFLOW_TABLE_ADAPTER = "$Adapter";
+    public static final String DBFLOW_TABLE_ADAPTER = "Adapter";
 
     public String tableName;
 
@@ -81,8 +81,6 @@ public class TableDefinition extends BaseTableDefinition implements FlowWriter {
 
     public TableDefinition(ProcessorManager manager, Element element) {
         super(element, manager);
-        setDefinitionClassName(DBFLOW_TABLE_TAG);
-        this.adapterName = getModelClassName() + DBFLOW_TABLE_ADAPTER;
 
         Table table = element.getAnnotation(Table.class);
         this.tableName = table.value();
@@ -91,16 +89,23 @@ public class TableDefinition extends BaseTableDefinition implements FlowWriter {
             databaseName = DBFlowProcessor.DEFAULT_DB_NAME;
         }
 
-        DatabaseWriter databaseWriter = manager.getDatabaseWriter(databaseName);
+        databaseWriter = manager.getDatabaseWriter(databaseName);
+        if (databaseWriter == null) {
+            manager.logError("Databasewriter was null for : " + tableName);
+        }
+
+        setDefinitionClassName(databaseWriter.classSeparator + DBFLOW_TABLE_TAG);
+        this.adapterName = getModelClassName() + databaseWriter.classSeparator + DBFLOW_TABLE_ADAPTER;
+
 
         // globular default
         ConflictAction insertConflict = table.insertConflict();
-        if(insertConflict.equals(ConflictAction.NONE) && !databaseWriter.insertConflict.equals(ConflictAction.NONE)) {
+        if (insertConflict.equals(ConflictAction.NONE) && !databaseWriter.insertConflict.equals(ConflictAction.NONE)) {
             insertConflict = databaseWriter.insertConflict;
         }
 
         ConflictAction updateConflict = table.updateConflict();
-        if(updateConflict.equals(ConflictAction.NONE) && !databaseWriter.updateConflict.equals(ConflictAction.NONE)) {
+        if (updateConflict.equals(ConflictAction.NONE) && !databaseWriter.updateConflict.equals(ConflictAction.NONE)) {
             updateConflict = databaseWriter.updateConflict;
         }
 

--- a/compiler/src/main/java/com/raizlabs/android/dbflow/processor/definition/TableDefinition.java
+++ b/compiler/src/main/java/com/raizlabs/android/dbflow/processor/definition/TableDefinition.java
@@ -164,7 +164,7 @@ public class TableDefinition extends BaseTableDefinition implements FlowWriter {
                         hasAutoIncrement = true;
                     }
 
-                    if(columnDefinition.unique && !columnDefinition.uniqueGroups.isEmpty()) {
+                    if(!columnDefinition.uniqueGroups.isEmpty()) {
                         List<Integer> groups = columnDefinition.uniqueGroups;
                         for(int group: groups) {
                             List<ColumnDefinition> groupList = mColumnUniqueMap.get(group);

--- a/compiler/src/main/java/com/raizlabs/android/dbflow/processor/handler/DatabaseHandler.java
+++ b/compiler/src/main/java/com/raizlabs/android/dbflow/processor/handler/DatabaseHandler.java
@@ -2,16 +2,11 @@ package com.raizlabs.android.dbflow.processor.handler;
 
 import com.google.common.collect.Sets;
 import com.raizlabs.android.dbflow.annotation.Database;
-import com.raizlabs.android.dbflow.processor.Classes;
 import com.raizlabs.android.dbflow.processor.model.ProcessorManager;
 import com.raizlabs.android.dbflow.processor.writer.DatabaseWriter;
-import com.raizlabs.android.dbflow.processor.writer.FlowManagerHolderWriter;
-import com.squareup.javawriter.JavaWriter;
 
-import java.io.IOException;
 import java.util.Set;
 
-import javax.annotation.processing.RoundEnvironment;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.Modifier;
 
@@ -46,16 +41,7 @@ public class DatabaseHandler extends BaseContainerHandler<Database> {
 
     @Override
     protected void onProcessElement(ProcessorManager processorManager, Element element) {
-        try {
-
-            DatabaseWriter managerWriter = new DatabaseWriter(processorManager, element);
-            JavaWriter javaWriter = new JavaWriter(processorManager.getProcessingEnvironment().getFiler()
-                    .createSourceFile(managerWriter.getSourceFileName()).openWriter());
-            managerWriter.write(javaWriter);
-            javaWriter.close();
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
-
+        DatabaseWriter managerWriter = new DatabaseWriter(processorManager, element);
+        processorManager.addFlowManagerWriter(managerWriter);
     }
 }

--- a/compiler/src/main/java/com/raizlabs/android/dbflow/processor/handler/DatabaseHandler.java
+++ b/compiler/src/main/java/com/raizlabs/android/dbflow/processor/handler/DatabaseHandler.java
@@ -8,16 +8,17 @@ import com.raizlabs.android.dbflow.processor.writer.DatabaseWriter;
 import com.raizlabs.android.dbflow.processor.writer.FlowManagerHolderWriter;
 import com.squareup.javawriter.JavaWriter;
 
+import java.io.IOException;
+import java.util.Set;
+
 import javax.annotation.processing.RoundEnvironment;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.Modifier;
-import java.io.IOException;
-import java.util.Set;
 
 /**
  * Description: Deals with writing database definitions
  */
-public class FlowManagerHandler extends BaseContainerHandler<Database> {
+public class DatabaseHandler extends BaseContainerHandler<Database> {
 
 
     public static final Set<Modifier> FIELD_MODIFIERS = Sets.newHashSet(Modifier.PRIVATE, Modifier.FINAL);
@@ -31,32 +32,11 @@ public class FlowManagerHandler extends BaseContainerHandler<Database> {
     public static final String MODEL_CONTAINER_ADAPTER_MAP_FIELD_NAME = "mModelContainerAdapters";
     public static final String TYPE_CONVERTER_MAP_FIELD_NAME = "mTypeConverters";
     public static final String MODEL_VIEW_FIELD_NAME = "mModelViews";
-    public static final String FLOW_SQL_LITE_OPEN_HELPER_FIELD_NAME = "mHelper";
-    public static final String IS_RESETTING = "isResetting";
-    public static final String MANAGER_MAP_NAME = "mManagerMap";
-    public static final String MANAGER_NAME_MAP = "mManagerNameMap";
     public static final String MIGRATION_FIELD_NAME = "mMigrationMap";
 
     public static final String MODEL_VIEW_ADAPTER_MAP_FIELD_NAME = "mModelViewAdapterMap";
 
     public static final String MODEL_NAME_MAP = "mModelTableNames";
-
-    @Override
-    public void handle(ProcessorManager processorManager, RoundEnvironment roundEnvironment) {
-        super.handle(processorManager, roundEnvironment);
-        if (roundEnvironment.processingOver()) {
-            try {
-                JavaWriter staticFlowManager = new JavaWriter(processorManager.getProcessingEnvironment().getFiler()
-                        .createSourceFile(Classes.FLOW_MANAGER_PACKAGE + "." + Classes.DATABASE_HOLDER_STATIC_CLASS_NAME).openWriter());
-                new FlowManagerHolderWriter(processorManager).write(staticFlowManager);
-
-                staticFlowManager.close();
-            } catch (IOException e) {
-                e.printStackTrace();
-            }
-        }
-
-    }
 
     @Override
     protected Class<Database> getAnnotationClass() {

--- a/compiler/src/main/java/com/raizlabs/android/dbflow/processor/model/ProcessorManager.java
+++ b/compiler/src/main/java/com/raizlabs/android/dbflow/processor/model/ProcessorManager.java
@@ -3,6 +3,7 @@ package com.raizlabs.android.dbflow.processor.model;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import com.raizlabs.android.dbflow.annotation.Database;
 import com.raizlabs.android.dbflow.processor.Classes;
 import com.raizlabs.android.dbflow.processor.definition.ContentProviderDefinition;
 import com.raizlabs.android.dbflow.processor.definition.MigrationDefinition;
@@ -153,7 +154,7 @@ public class ProcessorManager implements Handler {
             mTableDefinitions.put(tableDefinition.databaseName, tableDefinitionMap);
         }
         Map<String, TableDefinition> tableNameMap = mTableNameDefinitionMap.get(tableDefinition.databaseName);
-        if(tableNameMap == null) {
+        if (tableNameMap == null) {
             tableNameMap = Maps.newHashMap();
             mTableNameDefinitionMap.put(tableDefinition.databaseName, tableNameMap);
         }
@@ -267,6 +268,17 @@ public class ProcessorManager implements Handler {
         for (ContentProviderDefinition contentProviderDefinition : contentProviderDefinitions) {
             if (validator.validate(processorManager, contentProviderDefinition)) {
                 WriterUtils.writeBaseDefinition(contentProviderDefinition, processorManager);
+            }
+        }
+        List<DatabaseWriter> databaseWriters = getManagerWriters();
+        for(DatabaseWriter databaseWriter: databaseWriters) {
+            try {
+                JavaWriter javaWriter = new JavaWriter(processorManager.getProcessingEnvironment().getFiler()
+                        .createSourceFile(databaseWriter.getSourceFileName()).openWriter());
+                databaseWriter.write(javaWriter);
+                javaWriter.close();
+            } catch (IOException e) {
+                e.printStackTrace();
             }
         }
 

--- a/compiler/src/main/java/com/raizlabs/android/dbflow/processor/model/ProcessorManager.java
+++ b/compiler/src/main/java/com/raizlabs/android/dbflow/processor/model/ProcessorManager.java
@@ -3,6 +3,7 @@ package com.raizlabs.android.dbflow.processor.model;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import com.raizlabs.android.dbflow.processor.Classes;
 import com.raizlabs.android.dbflow.processor.definition.ContentProviderDefinition;
 import com.raizlabs.android.dbflow.processor.definition.MigrationDefinition;
 import com.raizlabs.android.dbflow.processor.definition.ModelContainerDefinition;
@@ -15,7 +16,10 @@ import com.raizlabs.android.dbflow.processor.handler.Handler;
 import com.raizlabs.android.dbflow.processor.utils.WriterUtils;
 import com.raizlabs.android.dbflow.processor.validator.ContentProviderValidator;
 import com.raizlabs.android.dbflow.processor.writer.DatabaseWriter;
+import com.raizlabs.android.dbflow.processor.writer.FlowManagerHolderWriter;
+import com.squareup.javawriter.JavaWriter;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -55,7 +59,7 @@ public class ProcessorManager implements Handler {
 
     private Map<String, Map<Integer, List<MigrationDefinition>>> mMigrations = Maps.newHashMap();
 
-    private List<DatabaseWriter> mManagerWriters = Lists.newArrayList();
+    private Map<String, DatabaseWriter> mManagerWriters = Maps.newHashMap();
 
     private List<BaseContainerHandler> mHandlers = new ArrayList<>();
 
@@ -100,11 +104,15 @@ public class ProcessorManager implements Handler {
     }
 
     public void addFlowManagerWriter(DatabaseWriter databaseWriter) {
-        mManagerWriters.add(databaseWriter);
+        mManagerWriters.put(databaseWriter.databaseName, databaseWriter);
     }
 
     public List<DatabaseWriter> getManagerWriters() {
-        return mManagerWriters;
+        return new ArrayList<>(mManagerWriters.values());
+    }
+
+    public DatabaseWriter getDatabaseWriter(String databaseName) {
+        return mManagerWriters.get(databaseName);
     }
 
     public void addTypeConverterDefinition(TypeConverterDefinition definition) {
@@ -259,6 +267,18 @@ public class ProcessorManager implements Handler {
         for (ContentProviderDefinition contentProviderDefinition : contentProviderDefinitions) {
             if (validator.validate(processorManager, contentProviderDefinition)) {
                 WriterUtils.writeBaseDefinition(contentProviderDefinition, processorManager);
+            }
+        }
+
+        if (roundEnvironment.processingOver()) {
+            try {
+                JavaWriter staticFlowManager = new JavaWriter(processorManager.getProcessingEnvironment().getFiler()
+                        .createSourceFile(Classes.FLOW_MANAGER_PACKAGE + "." + Classes.DATABASE_HOLDER_STATIC_CLASS_NAME).openWriter());
+                new FlowManagerHolderWriter(processorManager).write(staticFlowManager);
+
+                staticFlowManager.close();
+            } catch (IOException e) {
+                e.printStackTrace();
             }
         }
     }

--- a/compiler/src/main/java/com/raizlabs/android/dbflow/processor/model/builder/TableCreationQueryBuilder.java
+++ b/compiler/src/main/java/com/raizlabs/android/dbflow/processor/model/builder/TableCreationQueryBuilder.java
@@ -38,7 +38,7 @@ public class TableCreationQueryBuilder extends QueryBuilder<TableCreationQueryBu
                     .append(column.onNullConflict.toString());
         }
 
-        if (column.unique) {
+        if (column.unique && column.uniqueGroups.isEmpty()) {
             appendSpaceSeparated("UNIQUE ON CONFLICT")
                     .append(column.onUniqueConflict.toString());
         }

--- a/compiler/src/main/java/com/raizlabs/android/dbflow/processor/model/builder/TableCreationQueryBuilder.java
+++ b/compiler/src/main/java/com/raizlabs/android/dbflow/processor/model/builder/TableCreationQueryBuilder.java
@@ -38,7 +38,7 @@ public class TableCreationQueryBuilder extends QueryBuilder<TableCreationQueryBu
                     .append(column.onNullConflict.toString());
         }
 
-        if (column.unique && column.uniqueGroups.isEmpty()) {
+        if (column.unique) {
             appendSpaceSeparated("UNIQUE ON CONFLICT")
                     .append(column.onUniqueConflict.toString());
         }

--- a/compiler/src/main/java/com/raizlabs/android/dbflow/processor/writer/CreationQueryWriter.java
+++ b/compiler/src/main/java/com/raizlabs/android/dbflow/processor/writer/CreationQueryWriter.java
@@ -97,7 +97,7 @@ public class CreationQueryWriter implements FlowWriter {
                             ConflictAction conflictAction = ConflictAction.FAIL;
                             boolean hasGroup = false;
                             if (tableDefinition.mUniqueGroupMap.containsKey(group)) {
-                                conflictAction = tableDefinition.mUniqueGroupMap.get(group).onUniqueConflict();
+                                conflictAction = tableDefinition.mUniqueGroupMap.get(group).uniqueConflict();
                                 hasGroup = true;
                             }
                             List<String> columnNames = Lists.newArrayList();

--- a/compiler/src/main/java/com/raizlabs/android/dbflow/processor/writer/CreationQueryWriter.java
+++ b/compiler/src/main/java/com/raizlabs/android/dbflow/processor/writer/CreationQueryWriter.java
@@ -88,17 +88,25 @@ public class CreationQueryWriter implements FlowWriter {
                 if (!isModelView) {
 
                     Map<Integer, List<ColumnDefinition>> uniqueGroups = tableDefinition.mColumnUniqueMap;
-                    if(!uniqueGroups.isEmpty()) {
+                    if (!uniqueGroups.isEmpty()) {
                         Set<Integer> groupSet = uniqueGroups.keySet();
-                        for(Integer group: groupSet) {
+                        for (Integer group : groupSet) {
                             List<ColumnDefinition> columnDefinitions = uniqueGroups.get(group);
 
                             // take first one we find
                             ConflictAction conflictAction = ConflictAction.FAIL;
+                            boolean hasGroup = false;
+                            if (tableDefinition.mUniqueGroupMap.containsKey(group)) {
+                                conflictAction = tableDefinition.mUniqueGroupMap.get(group).onUniqueConflict();
+                                hasGroup = true;
+                            }
                             List<String> columnNames = Lists.newArrayList();
-                            for(ColumnDefinition columnDefinition: columnDefinitions) {
+                            for (ColumnDefinition columnDefinition : columnDefinitions) {
                                 columnNames.add(columnDefinition.columnName);
-                                if(!columnDefinition.onUniqueConflict.equals(ConflictAction.FAIL)) {
+
+                                // without group found on table annotation, we take the first column we find.
+                                if (!columnDefinition.onUniqueConflict.equals(ConflictAction.FAIL)
+                                        && !hasGroup) {
                                     conflictAction = columnDefinition.onUniqueConflict;
                                 }
                             }

--- a/compiler/src/main/java/com/raizlabs/android/dbflow/processor/writer/DatabaseWriter.java
+++ b/compiler/src/main/java/com/raizlabs/android/dbflow/processor/writer/DatabaseWriter.java
@@ -65,8 +65,6 @@ public class DatabaseWriter extends BaseDefinition implements FlowWriter {
 
         insertConflict = database.insertConflict();
         updateConflict = database.updateConflict();
-
-        manager.addFlowManagerWriter(this);
     }
 
     @Override

--- a/compiler/src/main/java/com/raizlabs/android/dbflow/processor/writer/DatabaseWriter.java
+++ b/compiler/src/main/java/com/raizlabs/android/dbflow/processor/writer/DatabaseWriter.java
@@ -45,6 +45,8 @@ public class DatabaseWriter extends BaseDefinition implements FlowWriter {
 
     public ConflictAction updateConflict;
 
+    public String classSeparator;
+
     public DatabaseWriter(ProcessorManager manager, Element element) {
         super(element, manager);
         packageName = Classes.FLOW_MANAGER_PACKAGE;
@@ -58,13 +60,16 @@ public class DatabaseWriter extends BaseDefinition implements FlowWriter {
         consistencyChecksEnabled = database.consistencyCheckEnabled();
         backupEnabled = database.backupEnabled();
 
-        definitionClassName = databaseName + "$Database";
+        classSeparator = database.generatedClassSeparator();
+
+        definitionClassName = databaseName + classSeparator + "Database";
 
         databaseVersion = database.version();
         foreignKeysSupported = database.foreignKeysSupported();
 
         insertConflict = database.insertConflict();
         updateConflict = database.updateConflict();
+
     }
 
     @Override

--- a/compiler/src/main/java/com/raizlabs/android/dbflow/processor/writer/FlowManagerHolderWriter.java
+++ b/compiler/src/main/java/com/raizlabs/android/dbflow/processor/writer/FlowManagerHolderWriter.java
@@ -3,10 +3,9 @@ package com.raizlabs.android.dbflow.processor.writer;
 import com.google.common.collect.Sets;
 import com.raizlabs.android.dbflow.processor.Classes;
 import com.raizlabs.android.dbflow.processor.definition.TypeConverterDefinition;
-import com.raizlabs.android.dbflow.processor.handler.FlowManagerHandler;
+import com.raizlabs.android.dbflow.processor.handler.DatabaseHandler;
 import com.raizlabs.android.dbflow.processor.model.ProcessorManager;
 import com.raizlabs.android.dbflow.processor.utils.ModelUtils;
-import com.raizlabs.android.dbflow.processor.utils.WriterUtils;
 import com.squareup.javawriter.JavaWriter;
 
 import javax.lang.model.element.Modifier;
@@ -42,7 +41,7 @@ public class FlowManagerHolderWriter implements FlowWriter {
         staticFlowManager.beginInitializer(true);
 
         for (TypeConverterDefinition typeConverterDefinition: processorManager.getTypeConverters()) {
-            staticFlowManager.emitStatement(FlowManagerHandler.TYPE_CONVERTER_MAP_FIELD_NAME + ".put(%1s, new %1s())", ModelUtils.getFieldClass(typeConverterDefinition.getModelClassQualifiedName()),
+            staticFlowManager.emitStatement(DatabaseHandler.TYPE_CONVERTER_MAP_FIELD_NAME + ".put(%1s, new %1s())", ModelUtils.getFieldClass(typeConverterDefinition.getModelClassQualifiedName()),
                     typeConverterDefinition.getQualifiedName());
         }
 

--- a/compiler/src/main/java/com/raizlabs/android/dbflow/processor/writer/LoadCursorWriter.java
+++ b/compiler/src/main/java/com/raizlabs/android/dbflow/processor/writer/LoadCursorWriter.java
@@ -64,7 +64,7 @@ public class LoadCursorWriter implements FlowWriter {
             public void write(JavaWriter javaWriter) throws IOException {
 
                 for (ColumnDefinition columnDefinition : baseTableDefinition.getColumnDefinitions()) {
-                    columnDefinition.writeLoadFromCursorDefinition(javaWriter, isModelContainerDefinition);
+                    columnDefinition.writeLoadFromCursorDefinition(baseTableDefinition, javaWriter, isModelContainerDefinition);
                 }
 
                 if (implementsLoadFromCursorListener && !isModelContainerDefinition) {

--- a/compiler/src/main/java/com/raizlabs/android/dbflow/processor/writer/SQLiteStatementWriter.java
+++ b/compiler/src/main/java/com/raizlabs/android/dbflow/processor/writer/SQLiteStatementWriter.java
@@ -69,9 +69,7 @@ public class SQLiteStatementWriter implements FlowWriter {
                 AtomicInteger columnCounter = new AtomicInteger(1);
                 for (int i = 0; i < tableDefinition.getColumnDefinitions().size(); i++) {
                     ColumnDefinition columnDefinition = tableDefinition.getColumnDefinitions().get(i);
-                    if(columnDefinition.columnType != Column.PRIMARY_KEY_AUTO_INCREMENT) {
-                        columnDefinition.writeSaveDefinition(javaWriter, isModelContainer, true, columnCounter);
-                    }
+                    columnDefinition.writeSaveDefinition(javaWriter, isModelContainer, true, columnCounter);
 
                     if(implementsContentValuesListener) {
                         javaWriter.emitStatement("%1s.onBindToContentValues(%1s)", args[3], args[1]);

--- a/flowcore/src/main/java/com/raizlabs/android/dbflow/annotation/Column.java
+++ b/flowcore/src/main/java/com/raizlabs/android/dbflow/annotation/Column.java
@@ -76,6 +76,12 @@ public @interface Column {
     boolean unique() default false;
 
     /**
+     * @return Marks a unique field as part of a unique group. For every unique number entered,
+     * it will generate a UNIQUE() column statement.
+     */
+    int[] uniqueGroups() default {};
+
+    /**
      * @return Marks the field as having a specified collation to use in it's creation.
      */
     String collate() default "";

--- a/flowcore/src/main/java/com/raizlabs/android/dbflow/annotation/Database.java
+++ b/flowcore/src/main/java/com/raizlabs/android/dbflow/annotation/Database.java
@@ -9,15 +9,13 @@ import java.lang.annotation.Target;
  * Author: andrewgrosner
  * Description: Creates a new database to use in the application.
  * <p>
- *     If we specify one DB, then all models do not need to specify a DB. As soon as we specify two, then each
- *     model needs to define what DB it points to.
+ * If we specify one DB, then all models do not need to specify a DB. As soon as we specify two, then each
+ * model needs to define what DB it points to.
  * </p>
- *
  * <p>
- *     Models will specify which DB it belongs to,
- *     but they currently can only belong to one DB.
+ * Models will specify which DB it belongs to,
+ * but they currently can only belong to one DB.
  * </p>
- *
  */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.SOURCE)
@@ -62,4 +60,10 @@ public @interface Database {
      * {@link ConflictAction} as NONE
      */
     ConflictAction updateConflict() default ConflictAction.NONE;
+
+    /**
+     * @return Marks all generated classes within this database with this character. For example
+     * "TestTable" becomes "TestTable$Table" for a "$" separator.
+     */
+    String generatedClassSeparator() default "$";
 }

--- a/flowcore/src/main/java/com/raizlabs/android/dbflow/annotation/Database.java
+++ b/flowcore/src/main/java/com/raizlabs/android/dbflow/annotation/Database.java
@@ -50,4 +50,16 @@ public @interface Database {
      * replace the corrupted DB
      */
     boolean backupEnabled() default false;
+
+    /**
+     * @return Global default insert conflict that can be applied to any table when it leaves
+     * its {@link ConflictAction} as NONE.
+     */
+    ConflictAction insertConflict() default ConflictAction.NONE;
+
+    /**
+     * @return Global update conflict that can be applied to any table when it leaves its
+     * {@link ConflictAction} as NONE
+     */
+    ConflictAction updateConflict() default ConflictAction.NONE;
 }

--- a/flowcore/src/main/java/com/raizlabs/android/dbflow/annotation/Table.java
+++ b/flowcore/src/main/java/com/raizlabs/android/dbflow/annotation/Table.java
@@ -42,4 +42,10 @@ public @interface Table {
      */
     boolean allFields() default false;
 
+    /**
+     * @return Declares a set of UNIQUE columns with the corresponding {@link ConflictAction}. A {@link Column}
+     * will point to this group using {@link Column#uniqueGroups()}
+     */
+    UniqueGroup[] uniqueColumnGroups() default {};
+
 }

--- a/flowcore/src/main/java/com/raizlabs/android/dbflow/annotation/Table.java
+++ b/flowcore/src/main/java/com/raizlabs/android/dbflow/annotation/Table.java
@@ -36,7 +36,7 @@ public @interface Table {
     ConflictAction insertConflict() default ConflictAction.NONE;
 
     /**
-     * @return When true, all fields of the reference class are considered as {@link com.raizlabs.android.dbflow.annotation.Column} .
+     * @return When true, all public, package-private , non-static, and non-final fields of the reference class are considered as {@link com.raizlabs.android.dbflow.annotation.Column} .
      * The only required annotated field becomes The {@link com.raizlabs.android.dbflow.annotation.Column#PRIMARY_KEY}
      * or {@link com.raizlabs.android.dbflow.annotation.Column#PRIMARY_KEY_AUTO_INCREMENT}.
      */

--- a/flowcore/src/main/java/com/raizlabs/android/dbflow/annotation/UniqueGroup.java
+++ b/flowcore/src/main/java/com/raizlabs/android/dbflow/annotation/UniqueGroup.java
@@ -20,5 +20,5 @@ public @interface UniqueGroup {
     /**
      * @return The conflict action that this group takes.
      */
-    ConflictAction onUniqueConflict() default ConflictAction.FAIL;
+    ConflictAction uniqueConflict() default ConflictAction.FAIL;
 }

--- a/flowcore/src/main/java/com/raizlabs/android/dbflow/annotation/UniqueGroup.java
+++ b/flowcore/src/main/java/com/raizlabs/android/dbflow/annotation/UniqueGroup.java
@@ -1,0 +1,24 @@
+package com.raizlabs.android.dbflow.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Description:
+ */
+@Target(ElementType.ANNOTATION_TYPE)
+@Retention(RetentionPolicy.SOURCE)
+public @interface UniqueGroup {
+
+    /**
+     * @return The number that columns point to to use this group
+     */
+    int groupNumber();
+
+    /**
+     * @return The conflict action that this group takes.
+     */
+    ConflictAction onUniqueConflict() default ConflictAction.FAIL;
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=1.6.2
+VERSION_NAME=1.7.0
 VERSION_CODE=1
 GROUP=com.raizlabs.android
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=1.6.1
+VERSION_NAME=1.6.2
 VERSION_CODE=1
 GROUP=com.raizlabs.android
 

--- a/library/src/androidTest/java/com/raizlabs/android/dbflow/test/global/GlobalDatabase.java
+++ b/library/src/androidTest/java/com/raizlabs/android/dbflow/test/global/GlobalDatabase.java
@@ -1,0 +1,17 @@
+package com.raizlabs.android.dbflow.test.global;
+
+import com.raizlabs.android.dbflow.annotation.ConflictAction;
+import com.raizlabs.android.dbflow.annotation.Database;
+
+/**
+ * Description:
+ */
+@Database(name = GlobalDatabase.NAME, version = GlobalDatabase.VERSION,
+    insertConflict = ConflictAction.REPLACE,
+    updateConflict = ConflictAction.REPLACE)
+public class GlobalDatabase {
+
+    public static final String NAME = "GlobalDatabase";
+
+    public static final int VERSION = 1;
+}

--- a/library/src/androidTest/java/com/raizlabs/android/dbflow/test/global/GlobalModel.java
+++ b/library/src/androidTest/java/com/raizlabs/android/dbflow/test/global/GlobalModel.java
@@ -1,0 +1,19 @@
+package com.raizlabs.android.dbflow.test.global;
+
+import com.raizlabs.android.dbflow.annotation.Column;
+import com.raizlabs.android.dbflow.annotation.ConflictAction;
+import com.raizlabs.android.dbflow.annotation.Table;
+import com.raizlabs.android.dbflow.structure.BaseModel;
+
+/**
+ * Description:
+ */
+@Table(databaseName = GlobalDatabase.NAME, updateConflict = ConflictAction.IGNORE)
+public class GlobalModel extends BaseModel {
+
+    @Column(columnType = Column.PRIMARY_KEY_AUTO_INCREMENT)
+    int id;
+
+    @Column
+    String name;
+}

--- a/library/src/androidTest/java/com/raizlabs/android/dbflow/test/kotlin/KotlinClass.java
+++ b/library/src/androidTest/java/com/raizlabs/android/dbflow/test/kotlin/KotlinClass.java
@@ -1,0 +1,15 @@
+package com.raizlabs.android.dbflow.test.kotlin;
+
+import com.raizlabs.android.dbflow.annotation.Column;
+import com.raizlabs.android.dbflow.annotation.Table;
+import com.raizlabs.android.dbflow.structure.BaseModel;
+
+/**
+ * Description:
+ */
+@Table(databaseName = KotlinDatabase.NAME)
+public class KotlinClass extends BaseModel {
+
+    @Column(columnType = Column.PRIMARY_KEY)
+    String name;
+}

--- a/library/src/androidTest/java/com/raizlabs/android/dbflow/test/kotlin/KotlinDatabase.java
+++ b/library/src/androidTest/java/com/raizlabs/android/dbflow/test/kotlin/KotlinDatabase.java
@@ -1,0 +1,15 @@
+package com.raizlabs.android.dbflow.test.kotlin;
+
+import com.raizlabs.android.dbflow.annotation.Database;
+
+/**
+ * Description: Shows example for support for Kotlin
+ */
+@Database(version = KotlinDatabase.VERSION, name = KotlinDatabase.NAME,
+        generatedClassSeparator = "_")
+public class KotlinDatabase {
+
+    public static final String NAME = "KotlinDatabase";
+
+    public static final int VERSION = 1;
+}

--- a/library/src/androidTest/java/com/raizlabs/android/dbflow/test/sql/UniqueModel.java
+++ b/library/src/androidTest/java/com/raizlabs/android/dbflow/test/sql/UniqueModel.java
@@ -11,8 +11,8 @@ import com.raizlabs.android.dbflow.test.TestDatabase;
  * Description:
  */
 @Table(databaseName = TestDatabase.NAME,
-        uniqueColumnGroups = {@UniqueGroup(groupNumber = 1, onUniqueConflict = ConflictAction.ROLLBACK),
-        @UniqueGroup(groupNumber = 2, onUniqueConflict = ConflictAction.REPLACE)})
+        uniqueColumnGroups = {@UniqueGroup(groupNumber = 1, uniqueConflict = ConflictAction.ROLLBACK),
+        @UniqueGroup(groupNumber = 2, uniqueConflict = ConflictAction.REPLACE)})
 public class UniqueModel extends BaseModel {
 
     @Column(columnType = Column.PRIMARY_KEY_AUTO_INCREMENT)

--- a/library/src/androidTest/java/com/raizlabs/android/dbflow/test/sql/UniqueModel.java
+++ b/library/src/androidTest/java/com/raizlabs/android/dbflow/test/sql/UniqueModel.java
@@ -1,0 +1,25 @@
+package com.raizlabs.android.dbflow.test.sql;
+
+import com.raizlabs.android.dbflow.annotation.Column;
+import com.raizlabs.android.dbflow.annotation.Table;
+import com.raizlabs.android.dbflow.structure.BaseModel;
+import com.raizlabs.android.dbflow.test.TestDatabase;
+
+/**
+ * Description:
+ */
+@Table(databaseName = TestDatabase.NAME)
+public class UniqueModel extends BaseModel {
+
+    @Column(columnType = Column.PRIMARY_KEY_AUTO_INCREMENT)
+    long id;
+
+    @Column(unique = true, uniqueGroups = 1)
+    String uniqueName;
+
+    @Column(unique = true, uniqueGroups = 2)
+    String anotherUnique;
+
+    @Column(unique = true, uniqueGroups = {1, 2})
+    String sharedUnique;
+}

--- a/library/src/androidTest/java/com/raizlabs/android/dbflow/test/sql/UniqueModel.java
+++ b/library/src/androidTest/java/com/raizlabs/android/dbflow/test/sql/UniqueModel.java
@@ -1,6 +1,7 @@
 package com.raizlabs.android.dbflow.test.sql;
 
 import com.raizlabs.android.dbflow.annotation.Column;
+import com.raizlabs.android.dbflow.annotation.ConflictAction;
 import com.raizlabs.android.dbflow.annotation.Table;
 import com.raizlabs.android.dbflow.structure.BaseModel;
 import com.raizlabs.android.dbflow.test.TestDatabase;
@@ -14,10 +15,10 @@ public class UniqueModel extends BaseModel {
     @Column(columnType = Column.PRIMARY_KEY_AUTO_INCREMENT)
     long id;
 
-    @Column(unique = true, uniqueGroups = 1)
+    @Column(unique = true, uniqueGroups = 1, onUniqueConflict = ConflictAction.REPLACE)
     String uniqueName;
 
-    @Column(unique = true, uniqueGroups = 2)
+    @Column(unique = true, uniqueGroups = 2, onUniqueConflict = ConflictAction.ROLLBACK)
     String anotherUnique;
 
     @Column(unique = true, uniqueGroups = {1, 2})

--- a/library/src/androidTest/java/com/raizlabs/android/dbflow/test/sql/UniqueModel.java
+++ b/library/src/androidTest/java/com/raizlabs/android/dbflow/test/sql/UniqueModel.java
@@ -3,13 +3,16 @@ package com.raizlabs.android.dbflow.test.sql;
 import com.raizlabs.android.dbflow.annotation.Column;
 import com.raizlabs.android.dbflow.annotation.ConflictAction;
 import com.raizlabs.android.dbflow.annotation.Table;
+import com.raizlabs.android.dbflow.annotation.UniqueGroup;
 import com.raizlabs.android.dbflow.structure.BaseModel;
 import com.raizlabs.android.dbflow.test.TestDatabase;
 
 /**
  * Description:
  */
-@Table(databaseName = TestDatabase.NAME)
+@Table(databaseName = TestDatabase.NAME,
+        uniqueColumnGroups = {@UniqueGroup(groupNumber = 1, onUniqueConflict = ConflictAction.ROLLBACK),
+        @UniqueGroup(groupNumber = 2, onUniqueConflict = ConflictAction.REPLACE)})
 public class UniqueModel extends BaseModel {
 
     @Column(columnType = Column.PRIMARY_KEY_AUTO_INCREMENT)

--- a/library/src/androidTest/java/com/raizlabs/android/dbflow/test/structure/ModelAutoIncrementTest.java
+++ b/library/src/androidTest/java/com/raizlabs/android/dbflow/test/structure/ModelAutoIncrementTest.java
@@ -1,6 +1,7 @@
 package com.raizlabs.android.dbflow.test.structure;
 
 import com.raizlabs.android.dbflow.config.FlowManager;
+import com.raizlabs.android.dbflow.sql.language.Select;
 import com.raizlabs.android.dbflow.test.FlowTestCase;
 import com.raizlabs.android.dbflow.test.TestDatabase;
 
@@ -13,9 +14,17 @@ public class ModelAutoIncrementTest extends FlowTestCase {
     public void testModelAutoIncrement() {
         TestModelAI testModelAI = new TestModelAI();
         testModelAI.name = "Test";
-        testModelAI.save(false);
+        testModelAI.insert(false);
 
         assertTrue(testModelAI.exists());
+
+        TestModelAI testModelAI2 = new TestModelAI();
+        testModelAI2.id = testModelAI.id;
+        testModelAI2.name = "Test2";
+        testModelAI2.update(false);
+
+        TestModelAI testModelAI3 = Select.byId(TestModelAI.class, testModelAI.id);
+        assertEquals(testModelAI3.name, testModelAI2.name);
 
         testModelAI.delete(false);
         assertTrue(!testModelAI.exists());

--- a/library/src/main/java/com/raizlabs/android/dbflow/config/FlowManager.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/config/FlowManager.java
@@ -104,7 +104,7 @@ public class FlowManager {
     protected static DatabaseHolder getDatabaseHolder() {
         if (mDatabaseHolder == null) {
             try {
-                mDatabaseHolder = (DatabaseHolder) Class.forName("com.raizlabs.android.dbflow.config.Database$Holder").newInstance();
+                mDatabaseHolder = (DatabaseHolder) Class.forName("com.raizlabs.android.dbflow.config.GeneratedDatabaseHolder").newInstance();
             } catch (Throwable e) {
                 throw new RuntimeException(e);
             }

--- a/library/src/main/java/com/raizlabs/android/dbflow/runtime/BaseContentProvider.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/runtime/BaseContentProvider.java
@@ -1,6 +1,8 @@
 package com.raizlabs.android.dbflow.runtime;
 
 import android.content.ContentProvider;
+import android.content.ContentValues;
+import android.net.Uri;
 
 import com.raizlabs.android.dbflow.config.BaseDatabaseDefinition;
 import com.raizlabs.android.dbflow.config.FlowManager;
@@ -20,5 +22,21 @@ public abstract class BaseContentProvider extends ContentProvider {
 
     protected abstract String getDatabaseName();
 
+    @Override
+    public int bulkInsert(final Uri uri, final ContentValues[] values) {
+        final int[] count = {0};
+        TransactionManager.transact(database.getWritableDatabase(), new Runnable() {
+            @Override
+            public void run() {
+                for (ContentValues contentValues : values) {
+                    count[0] += bulkInsert(uri, contentValues);
+                }
+            }
+        });
+        getContext().getContentResolver().notifyChange(uri, null);
+        return count[0];
+    }
+
+    protected abstract int bulkInsert(Uri uri, ContentValues contentValues);
 
 }

--- a/library/src/main/java/com/raizlabs/android/dbflow/runtime/transaction/process/ProcessModelInfo.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/runtime/transaction/process/ProcessModelInfo.java
@@ -18,7 +18,7 @@ public class ProcessModelInfo<ModelClass extends Model> {
 
     List<ModelClass> mModels = new ArrayList<ModelClass>();
 
-    TransactionListener<List<ModelClass>> mReceiver;
+    TransactionListener<List<ModelClass>> mTransactionListener;
 
     DBTransactionInfo mInfo;
 
@@ -107,7 +107,7 @@ public class ProcessModelInfo<ModelClass extends Model> {
      * @return This instance.
      */
     public ProcessModelInfo<ModelClass> result(TransactionListener<List<ModelClass>> transactionListener) {
-        mReceiver = transactionListener;
+        mTransactionListener = transactionListener;
         return this;
     }
 

--- a/library/src/main/java/com/raizlabs/android/dbflow/runtime/transaction/process/ProcessModelTransaction.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/runtime/transaction/process/ProcessModelTransaction.java
@@ -19,7 +19,7 @@ public abstract class ProcessModelTransaction<ModelClass extends Model> extends 
      * @param modelInfo Holds information about this process request
      */
     public ProcessModelTransaction(ProcessModelInfo<ModelClass> modelInfo) {
-        super(modelInfo.getInfo(), modelInfo.mReceiver);
+        super(modelInfo.getInfo(), modelInfo.mTransactionListener);
         mModelInfo = modelInfo;
     }
 

--- a/library/src/main/java/com/raizlabs/android/dbflow/structure/cache/BaseCacheableModel.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/structure/cache/BaseCacheableModel.java
@@ -62,7 +62,7 @@ public abstract class BaseCacheableModel extends BaseModel implements LoadFromCu
      */
     @SuppressWarnings("unchecked")
     public BaseCacheableModel() {
-        mCache = getCache(getClass());
+        mCache = mCacheMap.get(getClass());
         if (mCache == null) {
             mCache = getBackingCache();
             putCache(getClass(), mCache);

--- a/library/src/main/java/com/raizlabs/android/dbflow/structure/provider/ContentUtils.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/structure/provider/ContentUtils.java
@@ -86,6 +86,48 @@ public class ContentUtils {
     }
 
     /**
+     * Inserts the list of model into the {@link ContentResolver}. Binds all of the models to {@link ContentValues}
+     * and runs the {@link ContentResolver#bulkInsert(Uri, ContentValues[])} method. Note: if any of these use
+     * autoincrementing primary keys the ROWID will not be properly updated from this method. If you care
+     * use {@link #insert(ContentResolver, Uri, Model)} instead.
+     *
+     * @param contentResolver The content resolver to use (if different from {@link com.raizlabs.android.dbflow.config.FlowManager#getContext()})
+     * @param bulkInsertUri   The URI to bulk insert with
+     * @param table           The table to insert into
+     * @param models          The models to insert.
+     * @param <TableClass>    The class that implements {@link Model}
+     * @return The count of the rows affected by the insert.
+     */
+    public static <TableClass extends Model> int bulkInsert(ContentResolver contentResolver, Uri bulkInsertUri, Class<TableClass> table, List<TableClass> models) {
+        ContentValues[] contentValues = new ContentValues[models == null ? 0 : models.size()];
+        ModelAdapter<TableClass> adapter = FlowManager.getModelAdapter(table);
+
+        if (models != null) {
+            for (int i = 0; i < contentValues.length; i++) {
+                contentValues[i] = new ContentValues();
+                adapter.bindToContentValues(contentValues[i], models.get(i));
+            }
+        }
+        return contentResolver.bulkInsert(bulkInsertUri, contentValues);
+    }
+
+    /**
+     * Inserts the list of model into the {@link ContentResolver}. Binds all of the models to {@link ContentValues}
+     * and runs the {@link ContentResolver#bulkInsert(Uri, ContentValues[])} method. Note: if any of these use
+     * autoincrementing primary keys the ROWID will not be properly updated from this method. If you care
+     * use {@link #insert(Uri, Model)} instead.
+     *
+     * @param bulkInsertUri The URI to bulk insert with
+     * @param table         The table to insert into
+     * @param models        The models to insert.
+     * @param <TableClass>  The class that implements {@link Model}
+     * @return The count of the rows affected by the insert.
+     */
+    public static <TableClass extends Model> int bulkInsert(Uri bulkInsertUri, Class<TableClass> table, List<TableClass> models) {
+        return bulkInsert(FlowManager.getContext().getContentResolver(), bulkInsertUri, table, models);
+    }
+
+    /**
      * Updates the model through the {@link android.content.ContentResolver}. Uses the updateUri to
      * resolve the reference and the model to convert its data in {@link android.content.ContentValues}
      *

--- a/usage/DBStructure.md
+++ b/usage/DBStructure.md
@@ -75,7 +75,7 @@ A limitations on using ```Model```:
 This is an example of a ```Model``` class with a primary key (at least one is required) and another field.
 
 ```java
-@Table
+@Table(databaseName = AppDatabase.NAME)
 public class TestModel extends BaseModel {
 
     // All tables must have a least one primary key
@@ -110,7 +110,7 @@ Given a standard ```Model```:
 
 ```java
 
-@Table
+@Table(databaseName = AppDatabase.NAME)
 public class AModel extends BaseModel {
 
     @Column(columnType = Column.PRIMARY_KEY)
@@ -135,7 +135,8 @@ We can create  ```VIEW``` based off of it as such:
 
 ```java
 
-@ModelView(query = "SELECT time from AModel where time > 0")
+@ModelView(query = "SELECT time from AModel where time > 0",
+  databaseName = AppDatabase.NAME)
 public class AModelView extends BaseModelView<AModel> {
 
     @Column
@@ -199,7 +200,7 @@ Following from our previous sample, the preferred method of retrieval is through
 
 ```java
 
-@Table
+@Table(databaseName = AppDatabase.NAME)
 public class TestModel extends BaseModel {
 
     // All tables must have a least one primary key

--- a/usage/DBStructure.md
+++ b/usage/DBStructure.md
@@ -1,29 +1,78 @@
 # Creating Tables and Database Structure
 
+## Creating Your Database
+
+Creating databases are _dead-simple_ with DBFlow. Simply define a placeholder ```@Database``` class:
+
+```java
+
+@Database(name = AppDatabase.NAME, version = AppDatabase.VERSION)
+public class AppDatabase {
+
+  public static final String NAME = "AppDatabase";
+
+  public static final int VERSION = 1;
+}
+
+
+```
+
+_P.S._ you can define as many ```@Database``` as you like as long as the names are unique.
+
+### Global insertConflict and updateConflict
+
+You can apply global values to each table (when not explicitly specified) by defining the ```insertConflict()``` and ```updateConflict()```
+
+### Kotlin Support
+
+To support Kotlin, you can define a ```generatedClassSeparator()```
+that works for it. Simply add:
+
+```java
+
+@Database(generatedClassSeparator = "_", ...)
+
+```
+
+#### Advanced Usage
+
+There are some advanced features that you can utilize:
+
+```consistencyChecksEnabled()``` will run a ```PRAGMA quick_check(1)``` whenever the database is opened. If it fails, it will attempt to copy a prepackaged database.
+
+```backupEnabled()``` enables back up on the database by calling
+```
+FlowManager.getDatabaseForTable(table).backupDB()
+```
+
+Note: This creates a temporary _third_ database in case of a failed backup.
+
+
+
 ## Model & Creation
 
 Add the ```@Table``` annotation and extend the ```BaseModel``` class. Also you may implement ```Model``` if you want to provide your own
-custom implementation. As a convenience, the library provides the ```BaseModel``` class that contains the default implementation for ```Model```. 
+custom implementation. As a convenience, the library provides the ```BaseModel``` class that contains the default implementation for ```Model```.
 
 Features:
   1. Nested ```Model``` defined as a ```Column.FOREIGN_KEY``` enables 1-1 relationships
   2. Any default java class is supported such as the primitives, boxed primitives, and ```String```.
-  3. A non-default object with a ```TypeConverter``` is also saveable. 
+  3. A non-default object with a ```TypeConverter``` is also saveable.
   4. Multiple primary keys are supported (composite primary key)
 
 A limitations on using ```Model```:
   1. All ```Model``` **MUST HAVE A DEFAULT CONSTRUCTOR**. We will load the data into the ```Model``` and use the default constructor.
-  2. Subclassing works as one would expect: the library gathers all inherited fields annotated with ```@Column``` and count those as rows in the current class's database. 
-    _Note: If you request an option to turn this off, I may add that in a further release._ 
+  2. Subclassing works as one would expect: the library gathers all inherited fields annotated with ```@Column``` and count those as rows in the current class's database.
+    _Note: If you request an option to turn this off, I may add that in a further release._
   3. Column names default to the field name as a convenience, but if the name of your fields change you will need to specify the column name.
-  4. All fields must be ```public``` or package private as the ```ModelAdapter``` class needs access to them. 
+  4. All fields must be ```public``` or package private as the ```ModelAdapter``` class needs access to them.
   _If anyone knows how to manipulate byte-code to allow private classes, let me know_
   5. All model class definitions must be top-level (in their own file) and ```public``` or package private.
 
 
 ### Sample Model
 
-This is an example of a ```Model``` class with a primary key (at least one is required) and another field. 
+This is an example of a ```Model``` class with a primary key (at least one is required) and another field.
 
 ```java
 @Table
@@ -48,12 +97,12 @@ public class TestModel extends BaseModel {
 They contain some SQLite and library limitations:
   1. The fields must be identical to the fields in the corresponding ```Model```.
   2. The ```query()``` clause must be defined in the ```@ModelView``` annotation
-  3. You cannot **INSERT**, **UPDATE**, or **DELETE**. They are read-only in SQLite. 
-  Any call to ```insert(async)```, ```update(async)```, ```save(async)```, or ```delete(async)``` will throw 
+  3. You cannot **INSERT**, **UPDATE**, or **DELETE**. They are read-only in SQLite.
+  Any call to ```insert(async)```, ```update(async)```, ```save(async)```, or ```delete(async)``` will throw
   an ```InvalidSqlViewOperationException```
   4. Cannot have any kind of keys, primary or foreign, thus nested ```Model``` objects will not work.
-  
-```BaseModelView``` implements ```Model``` so that it can be used in other instances on equal footing. 
+
+```BaseModelView``` implements ```Model``` so that it can be used in other instances on equal footing.
 
 #### Example
 
@@ -100,7 +149,7 @@ Unfortunately, for now, we cannot use the generated ```$Table``` classes within 
 ## Utilizing a Relational Database
 
 In this library we currently only officially support 1-1 relationships using the ```Column.FOREIGN_KEY``` property on the ```@Column``` annotation.
-For 1 to many, we suggest using lazy-loading for maximum performance. 
+For 1 to many, we suggest using lazy-loading for maximum performance.
 
 ## One To One
 
@@ -108,8 +157,8 @@ Use the ```ColumnType.FOREIGN_KEY``` to enable **one-to-one** relationships. For
 
 ```java
 
-  @Column(columnType = Column.FOREIGN_KEY, 
-    references = {@ForeignKeyReference(columnName = "columnInTable", columnType = String.class, foreignColumnName = "columnInForeignKeyTable"), 
+  @Column(columnType = Column.FOREIGN_KEY,
+    references = {@ForeignKeyReference(columnName = "columnInTable", columnType = String.class, foreignColumnName = "columnInForeignKeyTable"),
                  @ForeignKeyReference(columnName = "column2InTable", columnType = String.class, foreignColumnName = "column2InForeignKeyTable")})
   SomeOtherTable object;
 
@@ -121,19 +170,19 @@ We strongly prefer you use a ```ForeignKeyContainer``` and ```saveForeignKeyMode
 
 ```java
 
-  @Column(columnType = Column.FOREIGN_KEY, 
-    references = {@ForeignKeyReference(columnName = "columnInTable", columnType = String.class, foreignColumnName = "columnInForeignKeyTable"), 
+  @Column(columnType = Column.FOREIGN_KEY,
+    references = {@ForeignKeyReference(columnName = "columnInTable", columnType = String.class, foreignColumnName = "columnInForeignKeyTable"),
                  @ForeignKeyReference(columnName = "column2InTable", columnType = String.class, foreignColumnName = "column2InForeignKeyTable")},
     saveForeignKeyModel = false)
   ForeignKeyContainer<SomeOtherTable> object;
 
 ```
 
-To lazy-retrieve the ```Model```, call ```object.toModel()```. 
+To lazy-retrieve the ```Model```, call ```object.toModel()```.
 
 ### ForeignKeyReference
 
-Note that the number of ```@ForeignKeyReference``` must match the number of primary keys in the foreign table. 
+Note that the number of ```@ForeignKeyReference``` must match the number of primary keys in the foreign table.
 
 ```@ForeignKeyReference``` describes three fields:
   1. columnName: The name of the current table's column for this field
@@ -146,7 +195,7 @@ In the original example, this field will load the foreign field up automatically
 
 In order to support **one-to-many**, create a method to retrieve the list of ```Model``` objects from the DB using lazy-loading.
 
-Following from our previous sample, the preferred method of retrieval is through **lazy-instantiation**. Adding this to the original class: 
+Following from our previous sample, the preferred method of retrieval is through **lazy-instantiation**. Adding this to the original class:
 
 ```java
 
@@ -165,7 +214,7 @@ public class TestModel extends BaseModel {
 
     public List<TestManyModel> getTestManyModels() {
        if(testManyModels == null) {
-         testManyModels = Select.all(TestManyModels.class, 
+         testManyModels = Select.all(TestManyModels.class,
                           Condition.column(TestManyModels$Table.TESTMODELNAME).is(name));
        }
        return testManyModels;
@@ -173,4 +222,3 @@ public class TestModel extends BaseModel {
 }
 
 ```
-


### PR DESCRIPTION
1. Added unique columns support by using ```@UniqueGroup``` for columns to enable multiple different groups of columns #117 
2. Fixes an issue where autoincrement update methods do not pass in the id of the object, possibly touching other rows unintentionally
3. Added global configurable defaults for ```insertConfict()``` and ```updateConflict()```in a ```@Database``` for any table that does not define a ```ConflictAction``` #104 
4. Added ```bulkInsert``` support to the ```@ContentProvider``` and corresponding method in ```ContentUtils``` #108 
5. Added Kotlin support! just change the ```generatedClassSeparator()``` for a ```@Database``` to Kotlin compatible. #90 
6. Added usage guide for databases
7. Adds better null loading, as in it prevents loading null values into the object when it's not null. #128 