### PR TITLE
Allow null values to make it to nullable database columns in provided TypeConverter impls

### DIFF
--- a/flowcore/src/main/java/com/raizlabs/android/dbflow/converter/BooleanConverter.java
+++ b/flowcore/src/main/java/com/raizlabs/android/dbflow/converter/BooleanConverter.java
@@ -11,6 +11,6 @@ public class BooleanConverter extends TypeConverter<Integer, Boolean> {
 
     @Override
     public Boolean getModelValue(Integer data) {
-        return data != null && data == 1;
+        return data == null ? null : data == 1;
     }
 }

--- a/library/src/androidTest/java/com/raizlabs/android/dbflow/test/typeconverter/LocationConverter.java
+++ b/library/src/androidTest/java/com/raizlabs/android/dbflow/test/typeconverter/LocationConverter.java
@@ -1,6 +1,7 @@
 package com.raizlabs.android.dbflow.test.typeconverter;
 
 import android.location.Location;
+
 import com.raizlabs.android.dbflow.converter.TypeConverter;
 
 /**
@@ -15,6 +16,9 @@ public class LocationConverter extends TypeConverter<String, Location> {
 
     @Override
     public Location getModelValue(String data) {
+        if (data == null) {
+            return null;
+        }
         String[] values = data.split(",");
         Location location = new Location("");
         location.setLatitude(Double.valueOf(values[0]));

--- a/library/src/androidTest/java/com/raizlabs/android/dbflow/test/typeconverter/LocationConverter.java
+++ b/library/src/androidTest/java/com/raizlabs/android/dbflow/test/typeconverter/LocationConverter.java
@@ -1,7 +1,6 @@
 package com.raizlabs.android.dbflow.test.typeconverter;
 
 import android.location.Location;
-
 import com.raizlabs.android.dbflow.converter.TypeConverter;
 
 /**

--- a/library/src/androidTest/java/com/raizlabs/android/dbflow/test/typeconverter/TestType.java
+++ b/library/src/androidTest/java/com/raizlabs/android/dbflow/test/typeconverter/TestType.java
@@ -1,12 +1,10 @@
 package com.raizlabs.android.dbflow.test.typeconverter;
 
 import android.location.Location;
-
 import com.raizlabs.android.dbflow.annotation.Column;
 import com.raizlabs.android.dbflow.annotation.Table;
 import com.raizlabs.android.dbflow.test.TestDatabase;
 import com.raizlabs.android.dbflow.test.structure.TestModel1;
-
 import org.json.JSONObject;
 
 import java.util.Calendar;

--- a/library/src/androidTest/java/com/raizlabs/android/dbflow/test/typeconverter/TestType.java
+++ b/library/src/androidTest/java/com/raizlabs/android/dbflow/test/typeconverter/TestType.java
@@ -1,10 +1,12 @@
 package com.raizlabs.android.dbflow.test.typeconverter;
 
 import android.location.Location;
+
 import com.raizlabs.android.dbflow.annotation.Column;
 import com.raizlabs.android.dbflow.annotation.Table;
 import com.raizlabs.android.dbflow.test.TestDatabase;
 import com.raizlabs.android.dbflow.test.structure.TestModel1;
+
 import org.json.JSONObject;
 
 import java.util.Calendar;
@@ -17,6 +19,10 @@ import java.util.Date;
 */
 @Table(databaseName = TestDatabase.NAME)
 public class TestType extends TestModel1 {
+
+    @Column
+    Boolean aBoolean;
+
     @Column
     Calendar calendar;
 

--- a/library/src/androidTest/java/com/raizlabs/android/dbflow/test/typeconverter/TestType.java
+++ b/library/src/androidTest/java/com/raizlabs/android/dbflow/test/typeconverter/TestType.java
@@ -21,6 +21,9 @@ import java.util.Date;
 public class TestType extends TestModel1 {
 
     @Column
+    boolean nativeBoolean;
+
+    @Column
     Boolean aBoolean;
 
     @Column

--- a/library/src/androidTest/java/com/raizlabs/android/dbflow/test/typeconverter/TypeConverterTest.java
+++ b/library/src/androidTest/java/com/raizlabs/android/dbflow/test/typeconverter/TypeConverterTest.java
@@ -74,4 +74,25 @@ public class TypeConverterTest extends FlowTestCase {
 
     }
 
+    /**
+     * Nullable database columns need to be allowed to receive null values.
+     */
+    public void testConvertersNullValues() {
+        new Delete().from(TestType.class).where().query();
+
+        TestType testType = new TestType();
+        testType.name = "Name";
+        testType.save(false);
+
+        TestType retrieved = Select.byId(TestType.class, "Name");
+        assertNotNull(retrieved);
+
+        assertNull(retrieved.aBoolean);
+        assertNull(retrieved.calendar);
+        assertNull(retrieved.date);
+        assertNull(retrieved.sqlDate);
+        assertNull(retrieved.json);
+        assertNull(retrieved.location);
+    }
+
 }

--- a/library/src/androidTest/java/com/raizlabs/android/dbflow/test/typeconverter/TypeConverterTest.java
+++ b/library/src/androidTest/java/com/raizlabs/android/dbflow/test/typeconverter/TypeConverterTest.java
@@ -2,8 +2,10 @@ package com.raizlabs.android.dbflow.test.typeconverter;
 
 import android.location.Location;
 
+import com.raizlabs.android.dbflow.sql.builder.Condition;
 import com.raizlabs.android.dbflow.sql.language.Delete;
 import com.raizlabs.android.dbflow.sql.language.Select;
+import com.raizlabs.android.dbflow.sql.language.Update;
 import com.raizlabs.android.dbflow.test.FlowTestCase;
 
 import org.json.JSONException;
@@ -93,6 +95,34 @@ public class TypeConverterTest extends FlowTestCase {
         assertNull(retrieved.sqlDate);
         assertNull(retrieved.json);
         assertNull(retrieved.location);
+    }
+
+    /**
+     * Type converters that autobox to native types need to have their behavior checked
+     * when null values are present in the database.
+     */
+    public void testConvertersNullDatabaseConversionValues() {
+        new Delete().from(TestType.class).where().query();
+
+        TestType testType = new TestType();
+        testType.name = "Name";
+        testType.save(false);
+
+        /*
+         * NOTE: We don't want to engage the type converter here since we are attempting to test
+         * the read behavior of pre-existing null database values and not the write behavior of
+         * the type converter.
+         */
+        new Update()
+                .table(TestType.class)
+                .set(TestType$Table.NATIVEBOOLEAN + " = null")
+                .where(Condition.column(TestType$Table.NAME).eq(testType.name))
+                .queryClose();
+
+        TestType retrieved = Select.byId(TestType.class, "Name");
+        assertNotNull(retrieved);
+
+        assertFalse(retrieved.nativeBoolean);
     }
 
 }


### PR DESCRIPTION
This change makes the TypeConverter implementations provided by the DBFlow core behave consistently with respect to how null values are represented at read-time.