### PR TITLE
Version 1.7.1

### DIFF
--- a/compiler/src/main/java/com/raizlabs/android/dbflow/processor/definition/ColumnDefinition.java
+++ b/compiler/src/main/java/com/raizlabs/android/dbflow/processor/definition/ColumnDefinition.java
@@ -92,12 +92,9 @@ public class ColumnDefinition extends BaseDefinition implements FlowWriter {
             this.columnName = column.name().equals("") ? element.getSimpleName().toString() : column.name();
             this.saveModelForeignKey = column.saveForeignKeyModel();
             length = column.length();
-            unique = column.unique();
-            if (unique) {
-                int[] groups = column.uniqueGroups();
-                for (int group : groups) {
-                    uniqueGroups.add(group);
-                }
+            int[] groups = column.uniqueGroups();
+            for (int group : groups) {
+                uniqueGroups.add(group);
             }
             onUniqueConflict = column.onUniqueConflict();
             notNull = column.notNull();

--- a/compiler/src/main/java/com/raizlabs/android/dbflow/processor/utils/ModelUtils.java
+++ b/compiler/src/main/java/com/raizlabs/android/dbflow/processor/utils/ModelUtils.java
@@ -87,7 +87,11 @@ public class ModelUtils {
         AdapterQueryBuilder contentValue = new AdapterQueryBuilder();
 
         if (!requiresTypeConverter) {
-            contentValue.appendCast(castedClass);
+            if(castedClass != null) {
+                contentValue.appendCast(castedClass);
+            } else {
+                contentValue.append("(");
+            }
         }
         contentValue.appendVariable(isContainer).append(".");
         if (isContainer) {

--- a/compiler/src/main/java/com/raizlabs/android/dbflow/processor/writer/ExistenceWriter.java
+++ b/compiler/src/main/java/com/raizlabs/android/dbflow/processor/writer/ExistenceWriter.java
@@ -31,9 +31,15 @@ public class ExistenceWriter implements FlowWriter {
             @Override
             public void write(JavaWriter javaWriter) throws IOException {
                 if(tableDefinition instanceof TableDefinition && ((TableDefinition) tableDefinition).hasAutoIncrement) {
-                    javaWriter.emitStatement("return %1s > 0", ModelUtils.getAccessStatement(((TableDefinition) tableDefinition).autoIncrementDefinition.columnName,
+                    String access =  ModelUtils.getAccessStatement(((TableDefinition) tableDefinition).autoIncrementDefinition.columnName,
                             long.class.getSimpleName(), ((TableDefinition) tableDefinition).autoIncrementDefinition.columnName, ((TableDefinition) tableDefinition).autoIncrementDefinition.containerKeyName,
-                            isModelContainer, false, false, ((TableDefinition) tableDefinition).autoIncrementDefinition.hasTypeConverter));
+                            isModelContainer, false, false, ((TableDefinition) tableDefinition).autoIncrementDefinition.hasTypeConverter);
+                    String accessNoCast =  ModelUtils.getAccessStatement(((TableDefinition) tableDefinition).autoIncrementDefinition.columnName,
+                            null, ((TableDefinition) tableDefinition).autoIncrementDefinition.columnName, ((TableDefinition) tableDefinition).autoIncrementDefinition.containerKeyName,
+                            isModelContainer, false, false, ((TableDefinition) tableDefinition).autoIncrementDefinition.hasTypeConverter);
+                    javaWriter.emitStatement("return %1s%1s > 0",
+                            ((TableDefinition) tableDefinition).autoIncrementDefinition.columnFieldIsPrimitive ? "" : (accessNoCast + "!=null && "),
+                            access);
                 } else {
                     javaWriter.emitStatement("return new Select().from(%1s).where(getPrimaryModelWhere(%1s)).hasData()",
                             ModelUtils.getFieldClass(tableDefinition.getModelClassName()), ModelUtils.getVariable(isModelContainer));

--- a/compiler/src/main/java/com/raizlabs/android/dbflow/processor/writer/ExistenceWriter.java
+++ b/compiler/src/main/java/com/raizlabs/android/dbflow/processor/writer/ExistenceWriter.java
@@ -31,11 +31,11 @@ public class ExistenceWriter implements FlowWriter {
             @Override
             public void write(JavaWriter javaWriter) throws IOException {
                 if(tableDefinition instanceof TableDefinition && ((TableDefinition) tableDefinition).hasAutoIncrement) {
-                    String access =  ModelUtils.getAccessStatement(((TableDefinition) tableDefinition).autoIncrementDefinition.columnName,
-                            long.class.getSimpleName(), ((TableDefinition) tableDefinition).autoIncrementDefinition.columnName, ((TableDefinition) tableDefinition).autoIncrementDefinition.containerKeyName,
+                    String access =  ModelUtils.getAccessStatement(((TableDefinition) tableDefinition).autoIncrementDefinition.columnFieldName,
+                            long.class.getSimpleName(), ((TableDefinition) tableDefinition).autoIncrementDefinition.columnFieldName, ((TableDefinition) tableDefinition).autoIncrementDefinition.containerKeyName,
                             isModelContainer, false, false, ((TableDefinition) tableDefinition).autoIncrementDefinition.hasTypeConverter);
-                    String accessNoCast =  ModelUtils.getAccessStatement(((TableDefinition) tableDefinition).autoIncrementDefinition.columnName,
-                            null, ((TableDefinition) tableDefinition).autoIncrementDefinition.columnName, ((TableDefinition) tableDefinition).autoIncrementDefinition.containerKeyName,
+                    String accessNoCast =  ModelUtils.getAccessStatement(((TableDefinition) tableDefinition).autoIncrementDefinition.columnFieldName,
+                            null, ((TableDefinition) tableDefinition).autoIncrementDefinition.columnFieldName, ((TableDefinition) tableDefinition).autoIncrementDefinition.containerKeyName,
                             isModelContainer, false, false, ((TableDefinition) tableDefinition).autoIncrementDefinition.hasTypeConverter);
                     javaWriter.emitStatement("return %1s%1s > 0",
                             ((TableDefinition) tableDefinition).autoIncrementDefinition.columnFieldIsPrimitive ? "" : (accessNoCast + "!=null && "),

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=1.7.0
+VERSION_NAME=1.7.1
 VERSION_CODE=1
 GROUP=com.raizlabs.android
 

--- a/library/src/androidTest/java/com/raizlabs/android/dbflow/test/sql/UniqueModel2.java
+++ b/library/src/androidTest/java/com/raizlabs/android/dbflow/test/sql/UniqueModel2.java
@@ -1,0 +1,24 @@
+package com.raizlabs.android.dbflow.test.sql;
+
+import com.raizlabs.android.dbflow.annotation.Column;
+import com.raizlabs.android.dbflow.annotation.ConflictAction;
+import com.raizlabs.android.dbflow.annotation.Table;
+import com.raizlabs.android.dbflow.annotation.UniqueGroup;
+import com.raizlabs.android.dbflow.structure.BaseModel;
+import com.raizlabs.android.dbflow.test.TestDatabase;
+
+@Table(databaseName = TestDatabase.NAME,
+        uniqueColumnGroups = {@UniqueGroup(groupNumber = 1, uniqueConflict = ConflictAction.FAIL),
+                @UniqueGroup(groupNumber = 2, uniqueConflict = ConflictAction.ROLLBACK)})
+public class UniqueModel2 extends BaseModel {
+
+    @Column(columnType = Column.PRIMARY_KEY, uniqueGroups = {1, 2})
+    String name;
+
+    @Column(uniqueGroups = 1)
+    String number;
+
+    @Column(uniqueGroups = 2)
+    String address;
+
+}

--- a/library/src/androidTest/java/com/raizlabs/android/dbflow/test/structure/ForeignKeyTest.java
+++ b/library/src/androidTest/java/com/raizlabs/android/dbflow/test/structure/ForeignKeyTest.java
@@ -2,6 +2,7 @@ package com.raizlabs.android.dbflow.test.structure;
 
 import com.raizlabs.android.dbflow.sql.language.Select;
 import com.raizlabs.android.dbflow.test.FlowTestCase;
+import com.raizlabs.android.dbflow.test.structure.autoincrement.TestModelAI;
 
 /**
  * Description:

--- a/library/src/androidTest/java/com/raizlabs/android/dbflow/test/structure/ForeignModel2.java
+++ b/library/src/androidTest/java/com/raizlabs/android/dbflow/test/structure/ForeignModel2.java
@@ -4,6 +4,7 @@ import com.raizlabs.android.dbflow.annotation.Column;
 import com.raizlabs.android.dbflow.annotation.ForeignKeyReference;
 import com.raizlabs.android.dbflow.annotation.Table;
 import com.raizlabs.android.dbflow.test.TestDatabase;
+import com.raizlabs.android.dbflow.test.structure.autoincrement.TestModelAI;
 
 /**
  * Description:

--- a/library/src/androidTest/java/com/raizlabs/android/dbflow/test/structure/autoincrement/ModelAutoIncrementTest.java
+++ b/library/src/androidTest/java/com/raizlabs/android/dbflow/test/structure/autoincrement/ModelAutoIncrementTest.java
@@ -1,4 +1,4 @@
-package com.raizlabs.android.dbflow.test.structure;
+package com.raizlabs.android.dbflow.test.structure.autoincrement;
 
 import com.raizlabs.android.dbflow.config.FlowManager;
 import com.raizlabs.android.dbflow.sql.language.Select;

--- a/library/src/androidTest/java/com/raizlabs/android/dbflow/test/structure/autoincrement/TestModelAI.java
+++ b/library/src/androidTest/java/com/raizlabs/android/dbflow/test/structure/autoincrement/TestModelAI.java
@@ -1,4 +1,4 @@
-package com.raizlabs.android.dbflow.test.structure;
+package com.raizlabs.android.dbflow.test.structure.autoincrement;
 
 import com.raizlabs.android.dbflow.annotation.Column;
 import com.raizlabs.android.dbflow.annotation.ContainerAdapter;
@@ -16,10 +16,10 @@ public class TestModelAI extends BaseModel {
 
     @ContainerKey("_id")
     @Column(columnType = Column.PRIMARY_KEY_AUTO_INCREMENT)
-    long id;
+    public long id;
 
     @Column
-    String name;
+    public String name;
 
     @Override
     public boolean equals(Object o) {

--- a/library/src/androidTest/java/com/raizlabs/android/dbflow/test/structure/autoincrement/TestModelAI2.java
+++ b/library/src/androidTest/java/com/raizlabs/android/dbflow/test/structure/autoincrement/TestModelAI2.java
@@ -1,6 +1,7 @@
 package com.raizlabs.android.dbflow.test.structure.autoincrement;
 
 import com.raizlabs.android.dbflow.annotation.Column;
+import com.raizlabs.android.dbflow.annotation.ContainerAdapter;
 import com.raizlabs.android.dbflow.annotation.Table;
 import com.raizlabs.android.dbflow.structure.BaseModel;
 import com.raizlabs.android.dbflow.test.TestDatabase;
@@ -8,10 +9,11 @@ import com.raizlabs.android.dbflow.test.TestDatabase;
 /**
  * Description:
  */
+@ContainerAdapter
 @Table(databaseName = TestDatabase.NAME)
 public class TestModelAI2 extends BaseModel {
 
-    @Column(columnType = Column.PRIMARY_KEY_AUTO_INCREMENT)
+    @Column(columnType = Column.PRIMARY_KEY_AUTO_INCREMENT, name = "_id")
     Long id;
 
     @Column

--- a/library/src/androidTest/java/com/raizlabs/android/dbflow/test/structure/autoincrement/TestModelAI2.java
+++ b/library/src/androidTest/java/com/raizlabs/android/dbflow/test/structure/autoincrement/TestModelAI2.java
@@ -1,0 +1,19 @@
+package com.raizlabs.android.dbflow.test.structure.autoincrement;
+
+import com.raizlabs.android.dbflow.annotation.Column;
+import com.raizlabs.android.dbflow.annotation.Table;
+import com.raizlabs.android.dbflow.structure.BaseModel;
+import com.raizlabs.android.dbflow.test.TestDatabase;
+
+/**
+ * Description:
+ */
+@Table(databaseName = TestDatabase.NAME)
+public class TestModelAI2 extends BaseModel {
+
+    @Column(columnType = Column.PRIMARY_KEY_AUTO_INCREMENT)
+    Long id;
+
+    @Column
+    String name;
+}

--- a/library/src/main/java/com/raizlabs/android/dbflow/sql/ModelQueriable.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/sql/ModelQueriable.java
@@ -2,12 +2,15 @@ package com.raizlabs.android.dbflow.sql;
 
 import com.raizlabs.android.dbflow.list.FlowCursorList;
 import com.raizlabs.android.dbflow.list.FlowTableList;
+import com.raizlabs.android.dbflow.sql.language.From;
+import com.raizlabs.android.dbflow.sql.language.Where;
 import com.raizlabs.android.dbflow.structure.Model;
 
 import java.util.List;
 
 /**
  * Description: An interface for query objects to enable you to query from the database in a structured way.
+ * Examples of such statements are: {@link From}, {@link Where}, {@link StringQuery}
  */
 public interface ModelQueriable<ModelClass extends Model> extends Queriable {
 

--- a/library/src/main/java/com/raizlabs/android/dbflow/sql/Queriable.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/sql/Queriable.java
@@ -2,8 +2,13 @@ package com.raizlabs.android.dbflow.sql;
 
 import android.database.Cursor;
 
+import com.raizlabs.android.dbflow.sql.language.Insert;
+import com.raizlabs.android.dbflow.sql.language.Set;
+
 /**
- * Description:
+ * Description: The most basic interface that some of the classes such as {@link Insert}, {@link ModelQueriable},
+ * {@link Set}, and more implement for convenience.
+ * {@link }
  */
 public interface Queriable {
 

--- a/library/src/main/java/com/raizlabs/android/dbflow/sql/StringQuery.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/sql/StringQuery.java
@@ -10,8 +10,8 @@ import com.raizlabs.android.dbflow.structure.Model;
 import java.util.List;
 
 /**
- * Author: andrewgrosner
- * Description: Provides a very basic query mechanism for strings. It runs a modification query and will only run
+ * Description: Provides a very basic query mechanism for strings. Allows you to easily perform custom SQL query string
+ * code where this library does not provide. It only runs a
  * {@link android.database.sqlite.SQLiteDatabase#rawQuery(String, String[])}.
  */
 public class StringQuery<ModelClass extends Model> implements Query, ModelQueriable<ModelClass> {
@@ -65,12 +65,12 @@ public class StringQuery<ModelClass extends Model> implements Query, ModelQueria
 
     @Override
     public FlowCursorList<ModelClass> queryCursorList() {
-        return new FlowCursorList<ModelClass>(false, this);
+        return new FlowCursorList<>(false, this);
     }
 
     @Override
     public FlowTableList<ModelClass> queryTableList() {
-        return new FlowTableList<ModelClass>(this);
+        return new FlowTableList<>(this);
     }
 
     @Override

--- a/library/src/main/java/com/raizlabs/android/dbflow/sql/language/Select.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/sql/language/Select.java
@@ -42,7 +42,7 @@ public class Select implements Query {
      * The method name we wish to execute
      */
     private String mMethodName;
-g
+
     /**
      * The column name passed into the method name
      */

--- a/library/src/main/java/com/raizlabs/android/dbflow/sql/language/Select.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/sql/language/Select.java
@@ -42,7 +42,7 @@ public class Select implements Query {
      * The method name we wish to execute
      */
     private String mMethodName;
-
+g
     /**
      * The column name passed into the method name
      */

--- a/library/src/main/java/com/raizlabs/android/dbflow/sql/language/Select.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/sql/language/Select.java
@@ -1,15 +1,11 @@
 package com.raizlabs.android.dbflow.sql.language;
 
-import android.text.TextUtils;
-
 import com.raizlabs.android.dbflow.config.FlowManager;
 import com.raizlabs.android.dbflow.sql.Query;
+import com.raizlabs.android.dbflow.sql.QueryBuilder;
 import com.raizlabs.android.dbflow.sql.builder.Condition;
 import com.raizlabs.android.dbflow.sql.builder.ConditionQueryBuilder;
-import com.raizlabs.android.dbflow.sql.QueryBuilder;
 import com.raizlabs.android.dbflow.structure.Model;
-import com.raizlabs.android.dbflow.structure.cache.BaseCacheableModel;
-import com.raizlabs.android.dbflow.structure.cache.ModelCache;
 
 import java.util.List;
 
@@ -99,12 +95,13 @@ public class Select implements Query {
 
     /**
      * Retrieves the count of the {@link ModelClass} table based on the specified WHERE conditions.
-     * @param tableClass The table to select count from
-     * @param conditions The list of conditions to select the count of models from
+     *
+     * @param tableClass   The table to select count from
+     * @param conditions   The list of conditions to select the count of models from
      * @param <ModelClass> The class that implements {@link com.raizlabs.android.dbflow.structure.Model}
      * @return The count of how many rows exist within the table based on the conditions passed.
      */
-    public static <ModelClass extends Model> long count(Class<ModelClass> tableClass, Condition...conditions) {
+    public static <ModelClass extends Model> long count(Class<ModelClass> tableClass, Condition... conditions) {
         return new Select().count().from(tableClass).where(conditions).count();
     }
 
@@ -160,7 +157,7 @@ public class Select implements Query {
     }
 
     /**
-     * appends {@link #COUNT} to the query
+     * appends COUNT to the query
      *
      * @return
      */

--- a/library/src/main/java/com/raizlabs/android/dbflow/sql/language/Where.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/sql/language/Where.java
@@ -75,11 +75,12 @@ public class Where<ModelClass extends Model> implements Query, ModelQueriable<Mo
     }
 
     /**
-     * Constructs this class with a SELECT * on the manager and {@link com.raizlabs.android.dbflow.sql.builder.ConditionQueryBuilder}
      *
-     * @param conditionQueryBuilder
-     * @param <ModelClass>
-     * @return
+     * A helper method to construct this class with a SELECT(columns) with the specified WHERE {@link com.raizlabs.android.dbflow.sql.builder.ConditionQueryBuilder}
+     *
+     * @param conditionQueryBuilder The WHERE conditions for this statement
+     * @param <ModelClass>          The class that implements {@link Model}
+     * @return A WHERE with the specified conditions and columns
      */
     public static <ModelClass extends Model> Where<ModelClass> with(ConditionQueryBuilder<ModelClass> conditionQueryBuilder,
                                                                     String... columns) {

--- a/library/src/main/java/com/raizlabs/android/dbflow/sql/language/Where.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/sql/language/Where.java
@@ -24,7 +24,6 @@ import com.raizlabs.android.dbflow.structure.Model;
 import java.util.List;
 
 /**
- * Author: andrewgrosner
  * Description: Defines the SQL WHERE statement of the query.
  */
 public class Where<ModelClass extends Model> implements Query, ModelQueriable<ModelClass> {

--- a/library/src/main/java/com/raizlabs/android/dbflow/sql/migration/IndexMigration.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/sql/migration/IndexMigration.java
@@ -39,7 +39,7 @@ public class IndexMigration<ModelClass extends Model> extends BaseMigration {
 
     @Override
     public void migrate(SQLiteDatabase database) {
-        getIndex().enable();
+        database.execSQL(getIndex().getQuery());
     }
 
     @Override


### PR DESCRIPTION
1. Fixes #139 where an `IndexMigration` recursively called the database rather than use the method database.
2. Fixes #141 where non-unique columns with specified `uniqueGroups` did not create the groups
3. Fixes #144 where `Long` or `Integer` primary keys caused a `NullPointerException`