### PR TITLE
Support `Iterable` for `Confition.in`

### DIFF
--- a/library/src/androidTest/java/com/raizlabs/android/dbflow/test/sql/BuilderTest.java
+++ b/library/src/androidTest/java/com/raizlabs/android/dbflow/test/sql/BuilderTest.java
@@ -5,6 +5,8 @@ import com.raizlabs.android.dbflow.sql.builder.Condition;
 import com.raizlabs.android.dbflow.sql.builder.ConditionQueryBuilder;
 import com.raizlabs.android.dbflow.test.FlowTestCase;
 
+import java.util.Arrays;
+
 /**
  * Author: andrewgrosner
  * Description: Test our {@link com.raizlabs.android.dbflow.sql.builder.ConditionQueryBuilder} and
@@ -60,9 +62,40 @@ public class BuilderTest extends FlowTestCase {
         ConditionQueryBuilder<ConditionModel> conditionQueryBuilder = new ConditionQueryBuilder<>(ConditionModel.class, in);
         assertEquals("`name` IN ('Jason','Ryan','Michael')", conditionQueryBuilder.getQuery().trim());
 
+        in = Condition.column(ConditionModel$Table.NAME).in(Arrays.asList("Jason", "Ryan", "Michael"));
+        conditionQueryBuilder = new ConditionQueryBuilder<>(ConditionModel.class, in);
+        assertEquals("`name` IN ('Jason','Ryan','Michael')", conditionQueryBuilder.getQuery().trim());
+
+        in = Condition.column(ConditionModel$Table.NAME).in(Arrays.asList("Single"));
+        conditionQueryBuilder = new ConditionQueryBuilder<>(ConditionModel.class, in);
+        assertEquals("`name` IN ('Single')", conditionQueryBuilder.getQuery().trim());
+
         Condition.In notIn = Condition.column(ConditionModel$Table.NAME).notIn("Jason", "Ryan", "Michael");
         conditionQueryBuilder = new ConditionQueryBuilder<>(ConditionModel.class, notIn);
         assertEquals("`name` NOT IN ('Jason','Ryan','Michael')", conditionQueryBuilder.getQuery().trim());
+
+        notIn = Condition.column(ConditionModel$Table.NAME).notIn(Arrays.asList("Jason", "Ryan", "Michael"));
+        conditionQueryBuilder = new ConditionQueryBuilder<>(ConditionModel.class, notIn);
+        assertEquals("`name` NOT IN ('Jason','Ryan','Michael')", conditionQueryBuilder.getQuery().trim());
+
+        notIn = Condition.column(ConditionModel$Table.NAME).notIn(Arrays.asList("Single"));
+        conditionQueryBuilder = new ConditionQueryBuilder<>(ConditionModel.class, notIn);
+        assertEquals("`name` NOT IN ('Single')", conditionQueryBuilder.getQuery().trim());
+
+        try {
+            Condition.column(ConditionModel$Table.NAME).in(Arrays.asList());
+            fail("Condition.in with empty iterable should throw IllegalArgumentException");
+        } catch (IllegalArgumentException e) {
+            /**/
+        }
+
+        try {
+            Condition.column(ConditionModel$Table.NAME).notIn(Arrays.asList());
+            fail("Condition.notIn with empty iterable should throw IllegalArgumentException");
+        } catch (IllegalArgumentException e) {
+            /**/
+        }
+
     }
 
 }

--- a/library/src/main/java/com/raizlabs/android/dbflow/sql/builder/Condition.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/sql/builder/Condition.java
@@ -6,7 +6,11 @@ import com.raizlabs.android.dbflow.converter.TypeConverter;
 import com.raizlabs.android.dbflow.sql.QueryBuilder;
 import com.raizlabs.android.dbflow.structure.Model;
 
+import java.lang.IllegalArgumentException;
+import java.lang.Iterable;
+import java.lang.Object;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 
 /**
@@ -499,6 +503,26 @@ public class Condition {
     }
 
     /**
+     * Turns this condition into a SQL IN operation.
+     *
+     * @param values The values in the IN query. Required and size>0.
+     * @return In operator
+     */
+    public In in(Iterable<?> values) {
+        final Iterator<?> it = values.iterator();
+        if ( !it.hasNext() ) {
+            throw new IllegalArgumentException("At least on value is required");
+        } else {
+            final In in = new In(this, it.next(), true);
+            while ( it.hasNext() ) {
+                in.and(it.next());
+            }
+            return in;
+        }
+    }
+
+
+    /**
      * Turns this condition into a SQL NOT IN operation.
      *
      * @param firstArgument The first value in the NOT IN query as one is required.
@@ -507,6 +531,25 @@ public class Condition {
      */
     public In notIn(Object firstArgument, Object...arguments) {
         return new In(this, firstArgument, false, arguments);
+    }
+
+    /**
+     * Turns this condition into a SQL NOT IN operation.
+     *
+     * @param values values The values in the NOT IN query. Required and size>0
+     * @return Not In operator
+     */
+    public In notIn(Iterable<?> values) {
+        final Iterator<?> it = values.iterator();
+        if ( !it.hasNext() ) {
+            throw new IllegalArgumentException("At least on value is required");
+        } else {
+            final In in = new In(this, it.next(), false);
+            while ( it.hasNext() ) {
+                in.and(it.next());
+            }
+            return in;
+        }
     }
 
     /**


### PR DESCRIPTION
Building an `In` from a collection is really painful at this time. Supporting `Iterable` out of the box can avoid many headaches and duplication.