### PR TITLE
Version 1.7.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Android Weekly](http://img.shields.io/badge/Android%20Weekly-%23129-2CB3E5.svg?style=flat)](http://androidweekly.net/issues/issue-129)
 [![Android Arsenal](https://img.shields.io/badge/Android%20Arsenal-DBFlow-brightgreen.svg?style=flat)](https://android-arsenal.com/details/1/1134) 
-[![Raizlabs Repository](http://img.shields.io/badge/Raizlabs%20Repository-1.7.1-blue.svg?style=flat)](https://github.com/Raizlabs/maven-releases)
+[![Raizlabs Repository](http://img.shields.io/badge/Raizlabs%20Repository-1.7.2-blue.svg?style=flat)](https://github.com/Raizlabs/maven-releases)
 
 DBFlow
 ======
@@ -24,6 +24,10 @@ What sets this library apart:
   8. ```ContentProvider``` generation using annotations
 
 ## Changelog
+
+#### 1.7.2
+
+1. Removes internal `ContentObserver` for `FlowCursorList`. Call `refresh()` when data becomes stale. This does not break any backwards compatibility as once a single refresh was called, the observer never reregistered anyways.
 
 #### 1.7.1
 
@@ -107,8 +111,8 @@ Add the library to the project-level build.gradle, using the [apt plugin](https:
   apply plugin: 'com.raizlabs.griddle'
 
   dependencies {
-    apt 'com.raizlabs.android:DBFlow-Compiler:1.7.1'
-    mod "com.raizlabs.android:{DBFlow-Core, DBFlow}:1.7.1"
+    apt 'com.raizlabs.android:DBFlow-Compiler:1.7.2'
+    mod "com.raizlabs.android:{DBFlow-Core, DBFlow}:1.7.2"
   }
 
 ```
@@ -120,9 +124,9 @@ or by standard Gradle use (without linking sources support):
   apply plugin: 'com.neenbedankt.android-apt'
 
   dependencies {
-    apt 'com.raizlabs.android:DBFlow-Compiler:1.7.1'
-    compile "com.raizlabs.android:DBFlow-Core:1.7.1"
-    compile "com.raizlabs.android:DBFlow:1.7.1"
+    apt 'com.raizlabs.android:DBFlow-Compiler:1.7.2'
+    compile "com.raizlabs.android:DBFlow-Core:1.7.2"
+    compile "com.raizlabs.android:DBFlow:1.7.2"
   }
 
 ```

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=1.7.1
+VERSION_NAME=1.7.2
 VERSION_CODE=1
 GROUP=com.raizlabs.android
 

--- a/library/src/main/java/com/raizlabs/android/dbflow/list/FlowTableList.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/list/FlowTableList.java
@@ -54,7 +54,7 @@ public class FlowTableList<ModelClass extends Model> extends ContentObserver imp
     private TransactionListener<List<ModelClass>> mInternalTransactionListener = new TransactionListenerAdapter<List<ModelClass>>() {
         @Override
         public void onResultReceived(List<ModelClass> modelClasses) {
-            mCursorList.refresh();
+            refresh();
 
             if (mTransactionListener != null) {
                 mTransactionListener.onResultReceived(modelClasses);
@@ -172,6 +172,13 @@ public class FlowTableList<ModelClass extends Model> extends ContentObserver imp
      */
     public FlowCursorList<ModelClass> getCursorList() {
         return mCursorList;
+    }
+
+    /**
+     * Refreshes the content backing this list.
+     */
+    public void refresh() {
+        mCursorList.refresh();
     }
 
     /**


### PR DESCRIPTION
1. Removes internal `ContentObserver` for `FlowCursorList`. Call `refresh()` when data becomes stale. This does not break any backwards compatibility as once a single refresh was called, the observer never reregistered anyways. fixes #162 