### PR TITLE
Cursor Synchronization

### DIFF
--- a/library/src/main/java/com/raizlabs/android/dbflow/sql/SqlUtils.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/sql/SqlUtils.java
@@ -98,20 +98,23 @@ public class SqlUtils {
         final List<CacheableClass> entities = new ArrayList<>();
         ModelAdapter<CacheableClass> instanceAdapter = FlowManager.getModelAdapter(modelClass);
         if (instanceAdapter != null) {
-            if (cursor.moveToFirst()) {
-                do {
-                    long id = cursor.getLong(cursor.getColumnIndex(instanceAdapter.getCachingColumnName()));
+            synchronized (cursor) {
+                // Ensure that we aren't iterating over this cursor concurrently from different threads
+                if (cursor.moveToFirst()) {
+                    do {
+                        long id = cursor.getLong(cursor.getColumnIndex(instanceAdapter.getCachingColumnName()));
 
-                    // if it exists in cache no matter the query we will use that one
-                    CacheableClass cacheable = BaseCacheableModel.getCache(modelClass).get(id);
-                    if (cacheable != null) {
-                        entities.add(cacheable);
-                    } else {
-                        cacheable = instanceAdapter.newInstance();
-                        instanceAdapter.loadFromCursor(cursor, cacheable);
-                        entities.add(cacheable);
-                    }
-                } while (cursor.moveToNext());
+                        // if it exists in cache no matter the query we will use that one
+                        CacheableClass cacheable = BaseCacheableModel.getCache(modelClass).get(id);
+                        if (cacheable != null) {
+                            entities.add(cacheable);
+                        } else {
+                            cacheable = instanceAdapter.newInstance();
+                            instanceAdapter.loadFromCursor(cursor, cacheable);
+                            entities.add(cacheable);
+                        }
+                    } while (cursor.moveToNext());
+                }
             }
         }
         return entities;

--- a/library/src/main/java/com/raizlabs/android/dbflow/sql/SqlUtils.java
+++ b/library/src/main/java/com/raizlabs/android/dbflow/sql/SqlUtils.java
@@ -136,13 +136,16 @@ public class SqlUtils {
             }
         }
         if (modelAdapter != null) {
-            if (cursor.moveToFirst()) {
-                do {
-                    Model model = modelAdapter.newInstance();
-                    modelAdapter.loadFromCursor(cursor, model);
-                    entities.add((ModelClass) model);
+            // Ensure that we aren't iterating over this cursor concurrently from different threads
+            synchronized (cursor) {
+                if (cursor.moveToFirst()) {
+                    do {
+                        Model model = modelAdapter.newInstance();
+                        modelAdapter.loadFromCursor(cursor, model);
+                        entities.add((ModelClass) model);
+                    }
+                    while (cursor.moveToNext());
                 }
-                while (cursor.moveToNext());
             }
         }
 


### PR DESCRIPTION
FIxes an issue where when `SqlUtils.convertToList` may be called concurrently from different threads on the same cursor, causing the cursor's positioning to misbehave and cause the iteration to run off the ends.

Currently this is synchronizing on the cursor such that this method will never be moving the same cursor concurrently, but there may be other places where the cursor is moved that may still cause issues. E.g. we may need to synchronize in `convertToModel` as well.