### PR TITLE
Added throwing an error on invalid database name

### DIFF
--- a/compiler/src/main/java/com/raizlabs/android/dbflow/processor/utils/WriterUtils.java
+++ b/compiler/src/main/java/com/raizlabs/android/dbflow/processor/utils/WriterUtils.java
@@ -6,7 +6,10 @@ import com.raizlabs.android.dbflow.processor.writer.FlowWriter;
 import com.squareup.javawriter.JavaWriter;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 import javax.lang.model.element.Modifier;
 
@@ -71,4 +74,29 @@ public class WriterUtils {
         return success;
     }
 
+    /**
+     * Checks if className is valid Java class name. It will check for Java keywords like abstract, assert, boolean etc.
+     * and it will check if className matches regex pattern [A-Za-z_$]+[a-zA-Z0-9_$]*
+     *
+     * @param className class name to validate without package name.
+     * @return {@code true} if parameter is a valid Java class name, {@code false} otherwise.
+     */
+    public static boolean isValidJavaClassName(final String className) {
+        final List<String> javaKeywords = Arrays.asList(
+                "abstract", "assert", "boolean", "break", "byte",
+                "case", "catch", "char", "class", "const",
+                "continue", "default", "do", "double", "else",
+                "enum", "extends", "false", "final", "finally",
+                "float", "for", "goto", "if", "implements",
+                "import", "instanceof", "int", "interface", "long",
+                "native", "new", "null", "package", "private",
+                "protected", "public", "return", "short", "static",
+                "strictfp", "super", "switch", "synchronized", "this",
+                "throw", "throws", "transient", "true", "try",
+                "void", "volatile", "while");
+
+        final Pattern javaClassNamePattern = Pattern.compile("[A-Za-z_$]+[a-zA-Z0-9_$]*");
+
+        return !javaKeywords.contains(className) && javaClassNamePattern.matcher(className).matches();
+    }
 }

--- a/compiler/src/main/java/com/raizlabs/android/dbflow/processor/utils/WriterUtils.java
+++ b/compiler/src/main/java/com/raizlabs/android/dbflow/processor/utils/WriterUtils.java
@@ -5,9 +5,13 @@ import com.raizlabs.android.dbflow.processor.model.ProcessorManager;
 import com.raizlabs.android.dbflow.processor.writer.FlowWriter;
 import com.squareup.javawriter.JavaWriter;
 
-import javax.lang.model.element.Modifier;
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Set;
+import java.util.regex.Pattern;
+
+import javax.lang.model.element.Modifier;
 
 /**
  * Description: Provides some handy writing methods.

--- a/compiler/src/main/java/com/raizlabs/android/dbflow/processor/utils/WriterUtils.java
+++ b/compiler/src/main/java/com/raizlabs/android/dbflow/processor/utils/WriterUtils.java
@@ -5,13 +5,9 @@ import com.raizlabs.android.dbflow.processor.model.ProcessorManager;
 import com.raizlabs.android.dbflow.processor.writer.FlowWriter;
 import com.squareup.javawriter.JavaWriter;
 
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Set;
-import java.util.regex.Pattern;
-
 import javax.lang.model.element.Modifier;
+import java.io.IOException;
+import java.util.Set;
 
 /**
  * Description: Provides some handy writing methods.
@@ -72,31 +68,5 @@ public class WriterUtils {
             e.printStackTrace();
         }
         return success;
-    }
-
-    /**
-     * Checks if className is valid Java class name. It will check for Java keywords like abstract, assert, boolean etc.
-     * and it will check if className matches regex pattern [A-Za-z_$]+[a-zA-Z0-9_$]*
-     *
-     * @param className class name to validate without package name.
-     * @return {@code true} if parameter is a valid Java class name, {@code false} otherwise.
-     */
-    public static boolean isValidJavaClassName(final String className) {
-        final List<String> javaKeywords = Arrays.asList(
-                "abstract", "assert", "boolean", "break", "byte",
-                "case", "catch", "char", "class", "const",
-                "continue", "default", "do", "double", "else",
-                "enum", "extends", "false", "final", "finally",
-                "float", "for", "goto", "if", "implements",
-                "import", "instanceof", "int", "interface", "long",
-                "native", "new", "null", "package", "private",
-                "protected", "public", "return", "short", "static",
-                "strictfp", "super", "switch", "synchronized", "this",
-                "throw", "throws", "transient", "true", "try",
-                "void", "volatile", "while");
-
-        final Pattern javaClassNamePattern = Pattern.compile("[A-Za-z_$]+[a-zA-Z0-9_$]*");
-
-        return !javaKeywords.contains(className) && javaClassNamePattern.matcher(className).matches();
     }
 }

--- a/compiler/src/main/java/com/raizlabs/android/dbflow/processor/utils/WriterUtils.java
+++ b/compiler/src/main/java/com/raizlabs/android/dbflow/processor/utils/WriterUtils.java
@@ -6,10 +6,7 @@ import com.raizlabs.android.dbflow.processor.writer.FlowWriter;
 import com.squareup.javawriter.JavaWriter;
 
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.List;
 import java.util.Set;
-import java.util.regex.Pattern;
 
 import javax.lang.model.element.Modifier;
 
@@ -73,4 +70,5 @@ public class WriterUtils {
         }
         return success;
     }
+
 }

--- a/compiler/src/main/java/com/raizlabs/android/dbflow/processor/writer/DatabaseWriter.java
+++ b/compiler/src/main/java/com/raizlabs/android/dbflow/processor/writer/DatabaseWriter.java
@@ -5,15 +5,18 @@ import com.raizlabs.android.dbflow.annotation.ConflictAction;
 import com.raizlabs.android.dbflow.annotation.Database;
 import com.raizlabs.android.dbflow.processor.Classes;
 import com.raizlabs.android.dbflow.processor.ProcessorUtils;
-import com.raizlabs.android.dbflow.processor.definition.*;
+import com.raizlabs.android.dbflow.processor.definition.BaseDefinition;
+import com.raizlabs.android.dbflow.processor.definition.MigrationDefinition;
+import com.raizlabs.android.dbflow.processor.definition.ModelContainerDefinition;
+import com.raizlabs.android.dbflow.processor.definition.ModelViewDefinition;
+import com.raizlabs.android.dbflow.processor.definition.QueryModelDefinition;
+import com.raizlabs.android.dbflow.processor.definition.TableDefinition;
 import com.raizlabs.android.dbflow.processor.handler.DatabaseHandler;
 import com.raizlabs.android.dbflow.processor.model.ProcessorManager;
 import com.raizlabs.android.dbflow.processor.utils.ModelUtils;
 import com.raizlabs.android.dbflow.processor.utils.WriterUtils;
 import com.squareup.javawriter.JavaWriter;
 
-import javax.lang.model.element.Element;
-import javax.lang.model.element.Modifier;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -21,10 +24,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
 
+import javax.lang.model.element.Element;
+import javax.lang.model.element.Modifier;
+
+
 /**
- * Description: Writes {@link com.raizlabs.android.dbflow.annotation.Database} definitions,
- * which contain {@link com.raizlabs.android.dbflow.annotation.Table},
- * {@link com.raizlabs.android.dbflow.annotation.ModelView}, and {@link com.raizlabs.android.dbflow.annotation.Migration}
+ * Description: Writes {@link com.raizlabs.android.dbflow.annotation.Database} definitions, which contain {@link
+ * com.raizlabs.android.dbflow.annotation.Table}, {@link com.raizlabs.android.dbflow.annotation.ModelView}, and {@link
+ * com.raizlabs.android.dbflow.annotation.Migration}
  */
 public class DatabaseWriter extends BaseDefinition implements FlowWriter {
 
@@ -109,17 +116,17 @@ public class DatabaseWriter extends BaseDefinition implements FlowWriter {
 
         for (TableDefinition tableDefinition : manager.getTableDefinitions(databaseName)) {
             javaWriter.emitStatement("holder.putDatabaseForTable(%1s, this)",
-                                     ModelUtils.getFieldClass(tableDefinition.getQualifiedModelClassName()));
+                    ModelUtils.getFieldClass(tableDefinition.getQualifiedModelClassName()));
         }
 
         for (ModelViewDefinition modelViewDefinition : manager.getModelViewDefinitions(databaseName)) {
             javaWriter.emitStatement("holder.putDatabaseForTable(%1s, this)",
-                                     ModelUtils.getFieldClass(modelViewDefinition.getFullyQualifiedModelClassName()));
+                    ModelUtils.getFieldClass(modelViewDefinition.getFullyQualifiedModelClassName()));
         }
 
-        for(QueryModelDefinition queryModelDefinition: manager.getQueryModelDefinitions(databaseName)) {
+        for (QueryModelDefinition queryModelDefinition : manager.getQueryModelDefinitions(databaseName)) {
             javaWriter.emitStatement("holder.putDatabaseForTable(%1s, this)",
-                                     ModelUtils.getFieldClass(queryModelDefinition.getQualifiedModelClassName()));
+                    ModelUtils.getFieldClass(queryModelDefinition.getQualifiedModelClassName()));
         }
 
         javaWriter.emitEmptyLine();
@@ -132,10 +139,10 @@ public class DatabaseWriter extends BaseDefinition implements FlowWriter {
                 List<MigrationDefinition> migrationDefinitions = migrationDefinitionMap.get(version);
                 javaWriter.emitStatement("List<%1s> migrations%1s = new ArrayList<>()", Classes.MIGRATION, version);
                 javaWriter.emitStatement("%1s.put(%1s,%1s%1s)", DatabaseHandler.MIGRATION_FIELD_NAME, version,
-                                         "migrations", version);
+                        "migrations", version);
                 for (MigrationDefinition migrationDefinition : migrationDefinitions) {
                     javaWriter.emitStatement("%1s%1s.add(new %1s())", "migrations", version,
-                                             migrationDefinition.getSourceFileName());
+                            migrationDefinition.getSourceFileName());
                 }
             }
         }
@@ -144,33 +151,33 @@ public class DatabaseWriter extends BaseDefinition implements FlowWriter {
 
         for (TableDefinition tableDefinition : manager.getTableDefinitions(databaseName)) {
             javaWriter.emitStatement(DatabaseHandler.MODEL_FIELD_NAME + ".add(%1s)",
-                                     ModelUtils.getFieldClass(tableDefinition.getQualifiedModelClassName()));
+                    ModelUtils.getFieldClass(tableDefinition.getQualifiedModelClassName()));
             javaWriter.emitStatement(DatabaseHandler.MODEL_NAME_MAP + ".put(\"%1s\", %1s)", tableDefinition.tableName,
-                                     ModelUtils.getFieldClass(tableDefinition.getQualifiedModelClassName()));
+                    ModelUtils.getFieldClass(tableDefinition.getQualifiedModelClassName()));
             javaWriter.emitStatement(DatabaseHandler.MODEL_ADAPTER_MAP_FIELD_NAME + ".put(%1s, new %1s())",
-                                     ModelUtils.getFieldClass(tableDefinition.getQualifiedModelClassName()),
-                                     tableDefinition.getQualifiedAdapterClassName());
+                    ModelUtils.getFieldClass(tableDefinition.getQualifiedModelClassName()),
+                    tableDefinition.getQualifiedAdapterClassName());
         }
 
         for (ModelContainerDefinition modelContainerDefinition : manager.getModelContainers(databaseName)) {
             javaWriter.emitStatement(DatabaseHandler.MODEL_CONTAINER_ADAPTER_MAP_FIELD_NAME + ".put(%1s, new %1s())",
-                                     ModelUtils.getFieldClass(modelContainerDefinition.getModelClassQualifiedName()),
-                                     modelContainerDefinition.getSourceFileName());
+                    ModelUtils.getFieldClass(modelContainerDefinition.getModelClassQualifiedName()),
+                    modelContainerDefinition.getSourceFileName());
         }
 
         for (ModelViewDefinition modelViewDefinition : manager.getModelViewDefinitions(databaseName)) {
             javaWriter.emitStatement(DatabaseHandler.MODEL_VIEW_FIELD_NAME + ".add(%1s)",
-                                     ModelUtils.getFieldClass(modelViewDefinition.getFullyQualifiedModelClassName()));
+                    ModelUtils.getFieldClass(modelViewDefinition.getFullyQualifiedModelClassName()));
             javaWriter.emitStatement(DatabaseHandler.MODEL_VIEW_ADAPTER_MAP_FIELD_NAME + ".put(%1s, new %1s())",
-                                     ModelUtils.getFieldClass(modelViewDefinition.getFullyQualifiedModelClassName()),
-                                     modelViewDefinition.getSourceFileName());
+                    ModelUtils.getFieldClass(modelViewDefinition.getFullyQualifiedModelClassName()),
+                    modelViewDefinition.getSourceFileName());
         }
 
         javaWriter.emitSingleLineComment("Writing Query Models");
         for (QueryModelDefinition queryModelDefinition : manager.getQueryModelDefinitions(databaseName)) {
             javaWriter.emitStatement(DatabaseHandler.QUERY_MODEL_ADAPTER_MAP_FIELD_NAME + ".put(%1s, new %1s())",
-                                     ModelUtils.getFieldClass(queryModelDefinition.getQualifiedModelClassName()),
-                                     queryModelDefinition.getQualifiedAdapterName());
+                    ModelUtils.getFieldClass(queryModelDefinition.getQualifiedModelClassName()),
+                    queryModelDefinition.getQualifiedAdapterName());
         }
 
         javaWriter.endConstructor();
@@ -231,14 +238,9 @@ public class DatabaseWriter extends BaseDefinition implements FlowWriter {
     }
 
     /**
-     * <p>Checks if databaseName is valid. It will check if databaseName matches regex pattern [A-Za-z_$]+[a-zA-Z0-9_$]*</p>
-     * Examples:
-     * <ul>
-     *     <li>database - valid</li>
-     *     <li>DbFlow1 - valid</li>
-     *     <li>database.db - invalid (contains a dot)</li>
-     *     <li>1database - invalid (starts with a number)</li>
-     * </ul>
+     * <p>Checks if databaseName is valid. It will check if databaseName matches regex pattern
+     * [A-Za-z_$]+[a-zA-Z0-9_$]*</p> Examples: <ul> <li>database - valid</li> <li>DbFlow1 - valid</li> <li>database.db -
+     * invalid (contains a dot)</li> <li>1database - invalid (starts with a number)</li> </ul>
      *
      * @param databaseName database name to validate.
      * @return {@code true} if parameter is a valid database name, {@code false} otherwise.

--- a/compiler/src/main/java/com/raizlabs/android/dbflow/processor/writer/DatabaseWriter.java
+++ b/compiler/src/main/java/com/raizlabs/android/dbflow/processor/writer/DatabaseWriter.java
@@ -27,11 +27,10 @@ import java.util.regex.Pattern;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.Modifier;
 
-
 /**
- * Description: Writes {@link com.raizlabs.android.dbflow.annotation.Database} definitions, which contain {@link
- * com.raizlabs.android.dbflow.annotation.Table}, {@link com.raizlabs.android.dbflow.annotation.ModelView}, and {@link
- * com.raizlabs.android.dbflow.annotation.Migration}
+ * Description: Writes {@link com.raizlabs.android.dbflow.annotation.Database} definitions,
+ * which contain {@link com.raizlabs.android.dbflow.annotation.Table},
+ * {@link com.raizlabs.android.dbflow.annotation.ModelView}, and {@link com.raizlabs.android.dbflow.annotation.Migration}
  */
 public class DatabaseWriter extends BaseDefinition implements FlowWriter {
 
@@ -62,7 +61,7 @@ public class DatabaseWriter extends BaseDefinition implements FlowWriter {
         if (databaseName == null || databaseName.isEmpty()) {
             databaseName = element.getSimpleName().toString();
         }
-        if (!isValidDatabaseName(databaseName)) {
+        if (isValidDatabaseName(databaseName)) {
             throw new Error("Database name [ " + databaseName + " ] is not valid. It must pass [A-Za-z_$]+[a-zA-Z0-9_$]* " +
                     "regex so it can't start with a number or contain any special character except '$'. Especially a dot character is not allowed!");
         }
@@ -116,17 +115,17 @@ public class DatabaseWriter extends BaseDefinition implements FlowWriter {
 
         for (TableDefinition tableDefinition : manager.getTableDefinitions(databaseName)) {
             javaWriter.emitStatement("holder.putDatabaseForTable(%1s, this)",
-                    ModelUtils.getFieldClass(tableDefinition.getQualifiedModelClassName()));
+                                     ModelUtils.getFieldClass(tableDefinition.getQualifiedModelClassName()));
         }
 
         for (ModelViewDefinition modelViewDefinition : manager.getModelViewDefinitions(databaseName)) {
             javaWriter.emitStatement("holder.putDatabaseForTable(%1s, this)",
-                    ModelUtils.getFieldClass(modelViewDefinition.getFullyQualifiedModelClassName()));
+                                     ModelUtils.getFieldClass(modelViewDefinition.getFullyQualifiedModelClassName()));
         }
 
-        for (QueryModelDefinition queryModelDefinition : manager.getQueryModelDefinitions(databaseName)) {
+        for(QueryModelDefinition queryModelDefinition: manager.getQueryModelDefinitions(databaseName)) {
             javaWriter.emitStatement("holder.putDatabaseForTable(%1s, this)",
-                    ModelUtils.getFieldClass(queryModelDefinition.getQualifiedModelClassName()));
+                                     ModelUtils.getFieldClass(queryModelDefinition.getQualifiedModelClassName()));
         }
 
         javaWriter.emitEmptyLine();
@@ -139,10 +138,10 @@ public class DatabaseWriter extends BaseDefinition implements FlowWriter {
                 List<MigrationDefinition> migrationDefinitions = migrationDefinitionMap.get(version);
                 javaWriter.emitStatement("List<%1s> migrations%1s = new ArrayList<>()", Classes.MIGRATION, version);
                 javaWriter.emitStatement("%1s.put(%1s,%1s%1s)", DatabaseHandler.MIGRATION_FIELD_NAME, version,
-                        "migrations", version);
+                                         "migrations", version);
                 for (MigrationDefinition migrationDefinition : migrationDefinitions) {
                     javaWriter.emitStatement("%1s%1s.add(new %1s())", "migrations", version,
-                            migrationDefinition.getSourceFileName());
+                                             migrationDefinition.getSourceFileName());
                 }
             }
         }
@@ -151,33 +150,33 @@ public class DatabaseWriter extends BaseDefinition implements FlowWriter {
 
         for (TableDefinition tableDefinition : manager.getTableDefinitions(databaseName)) {
             javaWriter.emitStatement(DatabaseHandler.MODEL_FIELD_NAME + ".add(%1s)",
-                    ModelUtils.getFieldClass(tableDefinition.getQualifiedModelClassName()));
+                                     ModelUtils.getFieldClass(tableDefinition.getQualifiedModelClassName()));
             javaWriter.emitStatement(DatabaseHandler.MODEL_NAME_MAP + ".put(\"%1s\", %1s)", tableDefinition.tableName,
-                    ModelUtils.getFieldClass(tableDefinition.getQualifiedModelClassName()));
+                                     ModelUtils.getFieldClass(tableDefinition.getQualifiedModelClassName()));
             javaWriter.emitStatement(DatabaseHandler.MODEL_ADAPTER_MAP_FIELD_NAME + ".put(%1s, new %1s())",
-                    ModelUtils.getFieldClass(tableDefinition.getQualifiedModelClassName()),
-                    tableDefinition.getQualifiedAdapterClassName());
+                                     ModelUtils.getFieldClass(tableDefinition.getQualifiedModelClassName()),
+                                     tableDefinition.getQualifiedAdapterClassName());
         }
 
         for (ModelContainerDefinition modelContainerDefinition : manager.getModelContainers(databaseName)) {
             javaWriter.emitStatement(DatabaseHandler.MODEL_CONTAINER_ADAPTER_MAP_FIELD_NAME + ".put(%1s, new %1s())",
-                    ModelUtils.getFieldClass(modelContainerDefinition.getModelClassQualifiedName()),
-                    modelContainerDefinition.getSourceFileName());
+                                     ModelUtils.getFieldClass(modelContainerDefinition.getModelClassQualifiedName()),
+                                     modelContainerDefinition.getSourceFileName());
         }
 
         for (ModelViewDefinition modelViewDefinition : manager.getModelViewDefinitions(databaseName)) {
             javaWriter.emitStatement(DatabaseHandler.MODEL_VIEW_FIELD_NAME + ".add(%1s)",
-                    ModelUtils.getFieldClass(modelViewDefinition.getFullyQualifiedModelClassName()));
+                                     ModelUtils.getFieldClass(modelViewDefinition.getFullyQualifiedModelClassName()));
             javaWriter.emitStatement(DatabaseHandler.MODEL_VIEW_ADAPTER_MAP_FIELD_NAME + ".put(%1s, new %1s())",
-                    ModelUtils.getFieldClass(modelViewDefinition.getFullyQualifiedModelClassName()),
-                    modelViewDefinition.getSourceFileName());
+                                     ModelUtils.getFieldClass(modelViewDefinition.getFullyQualifiedModelClassName()),
+                                     modelViewDefinition.getSourceFileName());
         }
 
         javaWriter.emitSingleLineComment("Writing Query Models");
         for (QueryModelDefinition queryModelDefinition : manager.getQueryModelDefinitions(databaseName)) {
             javaWriter.emitStatement(DatabaseHandler.QUERY_MODEL_ADAPTER_MAP_FIELD_NAME + ".put(%1s, new %1s())",
-                    ModelUtils.getFieldClass(queryModelDefinition.getQualifiedModelClassName()),
-                    queryModelDefinition.getQualifiedAdapterName());
+                                     ModelUtils.getFieldClass(queryModelDefinition.getQualifiedModelClassName()),
+                                     queryModelDefinition.getQualifiedAdapterName());
         }
 
         javaWriter.endConstructor();

--- a/compiler/src/main/java/com/raizlabs/android/dbflow/processor/writer/DatabaseWriter.java
+++ b/compiler/src/main/java/com/raizlabs/android/dbflow/processor/writer/DatabaseWriter.java
@@ -60,6 +60,9 @@ public class DatabaseWriter extends BaseDefinition implements FlowWriter {
         if (databaseName == null || databaseName.isEmpty()) {
             databaseName = element.getSimpleName().toString();
         }
+        if (!WriterUtils.isValidJavaClassName(databaseName)) {
+            throw new Error("Database name [ " + databaseName + " ] is not valid. It must not be any of Java keywords and must pass [A-Za-z_$]+[a-zA-Z0-9_$]* regex.");
+        }
 
         sqliteOpenHelperClass = ProcessorUtils.getOpenHelperClass(database);
 


### PR DESCRIPTION
Right now there is no database name validation which leads to hard to understand exceptions during code generation when developer will use character in database name which not allowed in Java class name. You can check it by changing database name from "App" to "App.db" in sample application. I've added validation of database name and throwing an Error if validation doesn't pass which should be much easier to understand what exactly is wrong .