### PR TITLE
AUTOINCREMENT is only allowed on an INTEGER  PRIMARY KEY

### DIFF
--- a/DBFlow-Compiler/src/main/java/com/raizlabs/android/dbflow/processor/model/builder/TableCreationQueryBuilder.java
+++ b/DBFlow-Compiler/src/main/java/com/raizlabs/android/dbflow/processor/model/builder/TableCreationQueryBuilder.java
@@ -22,7 +22,7 @@ public class TableCreationQueryBuilder extends QueryBuilder<TableCreationQueryBu
      * @return
      */
     public QueryBuilder appendColumn(ColumnDefinition column) {
-        if (column.length> -1) {
+        if (column.length> -1 && !column.isPrimaryKeyAutoIncrement) {
             query.append("(");
             query.append(column.length);
             query.append(")");


### PR DESCRIPTION
Since the column length definition is always being added to the data type the following exception occurs when a table is created where the primary key is incremented automatically:

android.database.sqlite.SQLiteException: AUTOINCREMENT is only allowed on an INTEGER PRIMARY KEY

This little hack checks whether the column is of type primary auto increment if not the column length can be added without fearing an exception. If the column is auto incremented the column length is not added.
Tried it within my project and it fixes the exception that occurred previously. Maybe you should take into consideration that column lengths are ignored by SQLITE according to their documentation.

Cheers,

Peter