### PR TITLE
Version 2.2.1

### DIFF
--- a/DBFlow-Compiler/src/main/java/com/raizlabs/android/dbflow/processor/definition/ColumnDefinition.java
+++ b/DBFlow-Compiler/src/main/java/com/raizlabs/android/dbflow/processor/definition/ColumnDefinition.java
@@ -307,7 +307,7 @@ public class ColumnDefinition extends BaseDefinition implements FlowWriter {
                 javaWriter.emitStatement("ModelContainer %1s = %1s.getInstance(%1s.getValue(\"%1s\"), %1s.class)",
                                          modelDefinition,
                                          ModelUtils.getVariable(true), ModelUtils.getVariable(true),
-                                         columnFieldName,
+                                         containerKeyName,
                                          foreignKeyTableClassName);
             } else {
                 javaWriter.beginControlFlow("if (%1s != null)", modelDefinition);
@@ -458,11 +458,11 @@ public class ColumnDefinition extends BaseDefinition implements FlowWriter {
 
                 if (isModelContainerAdapter && isModel) {
                     javaWriter.emitStatement("%1s.put(\"%1s\",%1s.getData())", ModelUtils.getVariable(true),
-                                             columnFieldName, modelContainerName);
+                                             containerKeyName, modelContainerName);
                     javaWriter.nextControlFlow("else");
 
                     javaWriter.emitStatement("%1s.put(\"%1s\", null)", ModelUtils.getVariable(true),
-                                             columnFieldName);
+                                             containerKeyName);
                 }
 
                 javaWriter.endControlFlow();

--- a/DBFlow-Compiler/src/main/java/com/raizlabs/android/dbflow/processor/definition/ColumnDefinition.java
+++ b/DBFlow-Compiler/src/main/java/com/raizlabs/android/dbflow/processor/definition/ColumnDefinition.java
@@ -473,7 +473,7 @@ public class ColumnDefinition extends BaseDefinition implements FlowWriter {
         }
     }
 
-    public void writeToModelDefinition(JavaWriter javaWriter) throws IOException {
+    public void writeToModelDefinition(JavaWriter javaWriter, boolean isModelContainerAdapter) throws IOException {
 
         if (!isModel) {
             AdapterQueryBuilder adapterQueryBuilder = new AdapterQueryBuilder("Object value");
@@ -486,6 +486,8 @@ public class ColumnDefinition extends BaseDefinition implements FlowWriter {
             javaWriter.beginControlFlow("if (value%1s != null) ", columnFieldName);
         }
 
+
+        ColumnAccessModel columnAccessModel = new ColumnAccessModel(manager, this, isModelContainerAdapter);
 
         AdapterQueryBuilder queryBuilder = new AdapterQueryBuilder();
         queryBuilder.appendVariable(false)

--- a/DBFlow-Compiler/src/main/java/com/raizlabs/android/dbflow/processor/definition/ColumnDefinition.java
+++ b/DBFlow-Compiler/src/main/java/com/raizlabs/android/dbflow/processor/definition/ColumnDefinition.java
@@ -532,13 +532,13 @@ public class ColumnDefinition extends BaseDefinition implements FlowWriter {
                     .append(
                             ".toModel())");
         } else {
-            if (columnAccessModel.isRequiresTypeConverter() && !columnAccessModel.isEnum()) {
+            if (columnAccessModel.isRequiresTypeConverter() && !columnAccessModel.isEnum() && !columnAccessModel.isBoolean()) {
                 queryBuilder.appendTypeConverter(null, getType, true);
             }
             queryBuilder.append(String.format("value%1s)", columnFieldName));
         }
 
-        if (columnAccessModel.isRequiresTypeConverter() && !columnAccessModel.isEnum()) {
+        if (columnAccessModel.isRequiresTypeConverter() && !columnAccessModel.isEnum() && !columnAccessModel.isBoolean()) {
             queryBuilder.append(")");
         }
 

--- a/DBFlow-Compiler/src/main/java/com/raizlabs/android/dbflow/processor/definition/ColumnDefinition.java
+++ b/DBFlow-Compiler/src/main/java/com/raizlabs/android/dbflow/processor/definition/ColumnDefinition.java
@@ -383,6 +383,8 @@ public class ColumnDefinition extends BaseDefinition implements FlowWriter {
             // special case for model objects within class
             if (!fieldIsModelContainer && !isModelContainerAdapter && isModel) {
 
+                ColumnAccessModel columnAccessModel = new ColumnAccessModel(manager, this, isModelContainerAdapter);
+
                 for (ForeignKeyReference foreignKeyReference : foreignKeyReferences) {
                     javaWriter.emitStatement(ModelUtils.getColumnIndex(foreignKeyReference.columnName()));
                 }
@@ -397,9 +399,14 @@ public class ColumnDefinition extends BaseDefinition implements FlowWriter {
 
                 AdapterQueryBuilder adapterQueryBuilder = new AdapterQueryBuilder().appendVariable(false);
                 adapterQueryBuilder.append(".")
-                        .append(columnFieldName)
-                        .appendSpaceSeparated("=");
+                        .append(columnAccessModel.getSetterReferenceColumnFieldName());
+                if (!columnAccessModel.isPrivate()) {
+                    adapterQueryBuilder.appendSpaceSeparated("=");
+                }
                 adapterQueryBuilder.append(rawConditionStatement);
+                if (columnAccessModel.isPrivate()) {
+                    adapterQueryBuilder.append(")");
+                }
                 javaWriter.emitStatement(adapterQueryBuilder.getQuery());
 
                 javaWriter.endControlFlow();

--- a/DBFlow-Compiler/src/main/java/com/raizlabs/android/dbflow/processor/definition/ColumnDefinition.java
+++ b/DBFlow-Compiler/src/main/java/com/raizlabs/android/dbflow/processor/definition/ColumnDefinition.java
@@ -500,8 +500,11 @@ public class ColumnDefinition extends BaseDefinition implements FlowWriter {
         AdapterQueryBuilder queryBuilder = new AdapterQueryBuilder();
         queryBuilder.appendVariable(false)
                 .append(".")
-                .append(columnFieldName);
-        queryBuilder.appendSpaceSeparated("=");
+                .append(columnAccessModel.getSetterReferenceColumnFieldName());
+
+        if (!columnAccessModel.isPrivate()) {
+            queryBuilder.appendSpaceSeparated("=");
+        }
 
         String getType = columnFieldType;
         // Type converters can never be primitive except boolean
@@ -528,7 +531,18 @@ public class ColumnDefinition extends BaseDefinition implements FlowWriter {
                     .append(
                             ".toModel())");
         } else {
+            if (columnAccessModel.isRequiresTypeConverter() && !columnAccessModel.isEnum()) {
+                queryBuilder.appendTypeConverter(null, getType, true);
+            }
             queryBuilder.append(String.format("value%1s)", columnFieldName));
+        }
+
+        if (columnAccessModel.isRequiresTypeConverter() && !columnAccessModel.isEnum()) {
+            queryBuilder.append(")");
+        }
+
+        if (columnAccessModel.isPrivate()) {
+            queryBuilder.append(")");
         }
 
         javaWriter.emitStatement(queryBuilder.getQuery());

--- a/DBFlow-Compiler/src/main/java/com/raizlabs/android/dbflow/processor/definition/ColumnDefinition.java
+++ b/DBFlow-Compiler/src/main/java/com/raizlabs/android/dbflow/processor/definition/ColumnDefinition.java
@@ -300,8 +300,9 @@ public class ColumnDefinition extends BaseDefinition implements FlowWriter {
                 javaWriter.emitSingleLineComment("Model Container Definition");
             }
 
+            ColumnAccessModel accessModel = new ColumnAccessModel(manager, this, isModelContainerAdapter);
             String modelDefinition = isModelContainerAdapter ? (ModelUtils.getVariable(true) + columnFieldName)
-                    : ModelUtils.getModelStatement(columnFieldName);
+                    : ModelUtils.getModelStatement(accessModel.getReferencedColumnFieldName());
             if (isModelContainerAdapter) {
                 javaWriter.emitStatement("ModelContainer %1s = %1s.getInstance(%1s.getValue(\"%1s\"), %1s.class)",
                                          modelDefinition,

--- a/DBFlow-Compiler/src/main/java/com/raizlabs/android/dbflow/processor/definition/ColumnDefinition.java
+++ b/DBFlow-Compiler/src/main/java/com/raizlabs/android/dbflow/processor/definition/ColumnDefinition.java
@@ -456,7 +456,7 @@ public class ColumnDefinition extends BaseDefinition implements FlowWriter {
 
                 }
 
-                if (isModelContainerAdapter && isModel && fieldIsModelContainer) {
+                if (isModelContainerAdapter && isModel) {
                     javaWriter.emitStatement("%1s.put(\"%1s\",%1s.getData())", ModelUtils.getVariable(true),
                                              columnFieldName, modelContainerName);
                     javaWriter.nextControlFlow("else");
@@ -476,6 +476,7 @@ public class ColumnDefinition extends BaseDefinition implements FlowWriter {
             ColumnAccessModel columnAccessModel = new ColumnAccessModel(manager, this, isModelContainerAdapter);
             LoadFromCursorModel loadFromCursorModel = new LoadFromCursorModel(columnAccessModel);
             loadFromCursorModel.setModelContainerName(columnName);
+            loadFromCursorModel.setIsModelContainerAdapter(isModelContainerAdapter);
             loadFromCursorModel.setIsNullable(isNullable());
             loadFromCursorModel.writeSingleField(javaWriter);
         }

--- a/DBFlow-Compiler/src/main/java/com/raizlabs/android/dbflow/processor/model/writer/ColumnAccessModel.java
+++ b/DBFlow-Compiler/src/main/java/com/raizlabs/android/dbflow/processor/model/writer/ColumnAccessModel.java
@@ -66,8 +66,11 @@ public class ColumnAccessModel implements Query {
 
     String getterName;
 
+    ColumnDefinition parentColumnDefinition;
+
     public ColumnAccessModel(ProcessorManager manager, ColumnDefinition columnDefinition,
                              boolean isModelContainerAdapter) {
+        parentColumnDefinition = columnDefinition;
         this.fieldIsAModelContainer = columnDefinition.fieldIsModelContainer;
         columnName = columnDefinition.columnName;
         columnFieldName = columnDefinition.columnFieldName;
@@ -133,6 +136,7 @@ public class ColumnAccessModel implements Query {
     }
 
     public ColumnAccessModel(ColumnDefinition columnDefinition, ForeignKeyReference foreignKeyReference) {
+        parentColumnDefinition = columnDefinition;
         this.fieldIsAModelContainer = columnDefinition.fieldIsModelContainer;
         columnName = columnDefinition.columnName;
         setterName = columnDefinition.setterName;
@@ -186,10 +190,11 @@ public class ColumnAccessModel implements Query {
         } else if (fieldIsAModelContainer) {
             contentValue.append(columnName)
                     .append(".")
-                    .appendGetValue(referencedColumnFieldName);
+                    .appendGetValue(getReferencedColumnFieldName());
         } else {
             if (isForeignKeyField) {
-                contentValue.append(columnName)
+                ColumnAccessModel columnAccessModel = new ColumnAccessModel(parentColumnDefinition.getManager(), parentColumnDefinition, isModelContainerAdapter);
+                contentValue.append(columnAccessModel.getReferencedColumnFieldName())
                         .append(".");
             }
             contentValue.append(getReferencedColumnFieldName());

--- a/DBFlow-Compiler/src/main/java/com/raizlabs/android/dbflow/processor/model/writer/ColumnAccessModel.java
+++ b/DBFlow-Compiler/src/main/java/com/raizlabs/android/dbflow/processor/model/writer/ColumnAccessModel.java
@@ -60,6 +60,8 @@ public class ColumnAccessModel implements Query {
 
     boolean isPrivate;
 
+    boolean isBoolean;
+
     boolean isEnum;
 
     String setterName;
@@ -77,6 +79,7 @@ public class ColumnAccessModel implements Query {
         columnFieldType = columnDefinition.columnFieldType;
         columnFieldActualType = columnDefinition.columnFieldActualType;
         referencedColumnFieldName = columnDefinition.columnFieldName;
+        isBoolean = columnDefinition.isBoolean;
         foreignKeyLocalColumnName = columnName;
         containerKeyName = columnDefinition.containerKeyName;
         isPrivate = columnDefinition.isPrivate;
@@ -141,6 +144,7 @@ public class ColumnAccessModel implements Query {
         columnName = columnDefinition.columnName;
         setterName = columnDefinition.setterName;
         getterName = columnDefinition.getterName;
+        isBoolean = columnDefinition.isBoolean;
         columnFieldActualType = columnDefinition.columnFieldActualType;
         columnFieldName = columnDefinition.columnFieldName;
         columnFieldType = columnDefinition.columnFieldType;
@@ -166,6 +170,10 @@ public class ColumnAccessModel implements Query {
 
     public boolean isEnum() {
         return isEnum;
+    }
+
+    public boolean isBoolean() {
+        return isBoolean;
     }
 
     public boolean isRequiresTypeConverter() {

--- a/DBFlow-Compiler/src/main/java/com/raizlabs/android/dbflow/processor/model/writer/ColumnAccessModel.java
+++ b/DBFlow-Compiler/src/main/java/com/raizlabs/android/dbflow/processor/model/writer/ColumnAccessModel.java
@@ -156,6 +156,10 @@ public class ColumnAccessModel implements Query {
         columnFieldBoxedType = columnFieldActualType;
     }
 
+    public boolean isPrivate() {
+        return isPrivate;
+    }
+
     public String getQueryNoCast() {
         return getQuery(false);
     }

--- a/DBFlow-Compiler/src/main/java/com/raizlabs/android/dbflow/processor/model/writer/ColumnAccessModel.java
+++ b/DBFlow-Compiler/src/main/java/com/raizlabs/android/dbflow/processor/model/writer/ColumnAccessModel.java
@@ -190,7 +190,7 @@ public class ColumnAccessModel implements Query {
         } else if (fieldIsAModelContainer) {
             contentValue.append(columnName)
                     .append(".")
-                    .appendGetValue(getReferencedColumnFieldName());
+                    .appendGetValue(referencedColumnFieldName);
         } else {
             if (isForeignKeyField) {
                 ColumnAccessModel columnAccessModel = new ColumnAccessModel(parentColumnDefinition.getManager(), parentColumnDefinition, isModelContainerAdapter);

--- a/DBFlow-Compiler/src/main/java/com/raizlabs/android/dbflow/processor/model/writer/ColumnAccessModel.java
+++ b/DBFlow-Compiler/src/main/java/com/raizlabs/android/dbflow/processor/model/writer/ColumnAccessModel.java
@@ -164,6 +164,14 @@ public class ColumnAccessModel implements Query {
         return isPrivate;
     }
 
+    public boolean isEnum() {
+        return isEnum;
+    }
+
+    public boolean isRequiresTypeConverter() {
+        return requiresTypeConverter;
+    }
+
     public String getQueryNoCast() {
         return getQuery(false);
     }

--- a/DBFlow-Compiler/src/main/java/com/raizlabs/android/dbflow/processor/model/writer/ForeignKeyContainerModel.java
+++ b/DBFlow-Compiler/src/main/java/com/raizlabs/android/dbflow/processor/model/writer/ForeignKeyContainerModel.java
@@ -45,7 +45,7 @@ public class ForeignKeyContainerModel extends ContentValueModel {
                     .appendCast(accessModel.castedClass)
                     .append(modelContainerName)
                     .append(".")
-                    .appendGetValue(accessModel.getReferencedColumnFieldName())
+                    .appendGetValue(accessModel.referencedColumnFieldName)
                     .append("))");
             javaWriter.emitStatement(adapterQueryBuilder.getQuery());
 

--- a/DBFlow-Compiler/src/main/java/com/raizlabs/android/dbflow/processor/model/writer/ForeignKeyContainerModel.java
+++ b/DBFlow-Compiler/src/main/java/com/raizlabs/android/dbflow/processor/model/writer/ForeignKeyContainerModel.java
@@ -34,7 +34,7 @@ public class ForeignKeyContainerModel extends ContentValueModel {
             AdapterQueryBuilder adapterQueryBuilder = new AdapterQueryBuilder();
 
             AdapterQueryBuilder ifBuilder = new AdapterQueryBuilder()
-                    .append(modelContainerName).append(".").appendGetValue(accessModel.referencedColumnFieldName);
+                    .append(modelContainerName).append(".").appendGetValue(accessModel.getReferencedColumnFieldName());
             javaWriter.beginControlFlow("if (%1s != null) ", ifBuilder.getQuery());
             if (!isContentValues()) {
                 adapterQueryBuilder.appendBindSQLiteStatement(getIndex(), accessModel.castedClass);
@@ -45,7 +45,7 @@ public class ForeignKeyContainerModel extends ContentValueModel {
                     .appendCast(accessModel.castedClass)
                     .append(modelContainerName)
                     .append(".")
-                    .appendGetValue(accessModel.referencedColumnFieldName)
+                    .appendGetValue(accessModel.getReferencedColumnFieldName())
                     .append("))");
             javaWriter.emitStatement(adapterQueryBuilder.getQuery());
 

--- a/DBFlow-Compiler/src/main/java/com/raizlabs/android/dbflow/processor/model/writer/LoadFromCursorModel.java
+++ b/DBFlow-Compiler/src/main/java/com/raizlabs/android/dbflow/processor/model/writer/LoadFromCursorModel.java
@@ -56,39 +56,42 @@ public class LoadFromCursorModel implements FlowWriter {
 
     @Override
     public void write(JavaWriter javaWriter) throws IOException {
-        if (isModelContainerAdapter) {
-            AdapterQueryBuilder adapterQueryBuilder = new AdapterQueryBuilder();
-            adapterQueryBuilder.append(modelContainerName)
-                    .appendPut(accessModel.getReferencedColumnFieldName())
-                    .append(ModelUtils.getCursorStatement(
-                            accessModel.castedClass, accessModel.foreignKeyLocalColumnName))
-                    .append(")");
-            javaWriter.emitStatement(adapterQueryBuilder.getQuery());
-        } else {
-            String cursorStatementClass = accessModel.castedClass;
-            if (accessModel.isEnum) {
-                cursorStatementClass = String.class.getName();
-            }
-            String cursorStatment = ModelUtils.getCursorStatement(cursorStatementClass,
-                                                                  accessModel.foreignKeyLocalColumnName);
-            emitColumnAssignment(javaWriter, cursorStatment);
+        String cursorStatementClass = accessModel.castedClass;
+        if (accessModel.isEnum) {
+            cursorStatementClass = String.class.getName();
         }
+        String cursorStatment = ModelUtils.getCursorStatement(cursorStatementClass,
+                accessModel.foreignKeyLocalColumnName);
+        emitColumnAssignment(javaWriter, cursorStatment);
     }
 
     private void emitColumnAssignment(JavaWriter javaWriter,
                                       String valueStatement) throws IOException {
         boolean isContainerFieldDefinition = accessModel.isModelContainerAdapter;
-        boolean isWritingForContainers = accessModel.fieldIsAModelContainer;
-        AdapterQueryBuilder queryBuilder = new AdapterQueryBuilder().appendVariable(isContainerFieldDefinition);
-        if (isWritingForContainers) {
-            queryBuilder.append(".")
-                    .append(accessModel.columnName);
+        boolean fieldIsAModelContainer = accessModel.fieldIsAModelContainer;
+        boolean isNull = valueStatement.equals("null");
+        AdapterQueryBuilder queryBuilder = new AdapterQueryBuilder();
+
+        if (isModelContainerAdapter) {
+            if (accessModel.isForeignKeyField) {
+                queryBuilder.append(modelContainerName);
+            } else {
+                queryBuilder.append(ModelUtils.getVariable(true));
+            }
+        } else {
+            queryBuilder.appendVariable(isContainerFieldDefinition);
+        }
+        if (fieldIsAModelContainer && isModelContainerAdapter) {
+            queryBuilder.appendPut(accessModel.getReferencedColumnFieldName());
+        } else if (fieldIsAModelContainer) {
+            queryBuilder.append(".").append(accessModel.columnFieldName)
+                    .appendPut(accessModel.getReferencedColumnFieldName());
+        } else if (isModelContainerAdapter && accessModel.isForeignKeyField) {
+            queryBuilder.appendPut(accessModel.getReferencedColumnFieldName());
         }
         if (isContainerFieldDefinition) {
             queryBuilder.appendPut(accessModel.containerKeyName);
-        } else if (isWritingForContainers) {
-            queryBuilder.appendPut(accessModel.getReferencedColumnFieldName());
-        } else {
+        } else if (!fieldIsAModelContainer && !isModelContainerAdapter) {
             queryBuilder.append(".")
                     .append(accessModel.getSetterReferenceColumnFieldName());
             if (!accessModel.isPrivate) {
@@ -97,14 +100,14 @@ public class LoadFromCursorModel implements FlowWriter {
         }
         if (accessModel.isEnum) {
             // don't attempt to use valueOf on a null, will throw a NullPointerException
-            if (!valueStatement.equals("null")) {
+            if (!isNull) {
                 queryBuilder.append(accessModel.castedClass)
                         .append(".valueOf(");
             }
         } else {
-            if (accessModel.requiresTypeConverter && !isContainerFieldDefinition) {
+            if (accessModel.requiresTypeConverter && !isNull) {
                 queryBuilder.appendTypeConverter(accessModel.columnFieldBoxedType, accessModel.columnFieldBoxedType,
-                                                 true);
+                        true);
             } else if (accessModel.isABlob) {
                 queryBuilder.append(String.format("new %1s(", Blob.class.getName()));
             }
@@ -112,15 +115,20 @@ public class LoadFromCursorModel implements FlowWriter {
 
         queryBuilder.append(valueStatement);
 
-        if (accessModel.requiresTypeConverter && !isContainerFieldDefinition && !accessModel.isEnum ||
-            (accessModel.isEnum && isContainerFieldDefinition && !valueStatement.equals("null"))) {
+        if (accessModel.requiresTypeConverter && !isNull && !accessModel.isEnum ||
+                (accessModel.isEnum && isContainerFieldDefinition && !isNull)) {
             queryBuilder.append("))");
-        } else if (isContainerFieldDefinition || isWritingForContainers || accessModel.isABlob ||
-                   (accessModel.isEnum && !valueStatement.equals("null"))) {
+        } else if (isModelContainerAdapter || isContainerFieldDefinition || fieldIsAModelContainer || accessModel.isABlob ||
+                (accessModel.isEnum && !isNull)) {
             queryBuilder.append(")");
         }
 
         if (accessModel.isPrivate && !isContainerFieldDefinition) {
+            queryBuilder.append(")");
+        }
+
+        if (accessModel.requiresTypeConverter && !accessModel.isEnum()
+                && isModelContainerAdapter && !isNull) {
             queryBuilder.append(")");
         }
 

--- a/DBFlow-Compiler/src/main/java/com/raizlabs/android/dbflow/processor/model/writer/LoadFromCursorModel.java
+++ b/DBFlow-Compiler/src/main/java/com/raizlabs/android/dbflow/processor/model/writer/LoadFromCursorModel.java
@@ -120,7 +120,7 @@ public class LoadFromCursorModel implements FlowWriter {
             queryBuilder.append(")");
         }
 
-        if (accessModel.isPrivate) {
+        if (accessModel.isPrivate && !isContainerFieldDefinition) {
             queryBuilder.append(")");
         }
 

--- a/DBFlow-Compiler/src/main/java/com/raizlabs/android/dbflow/processor/writer/LoadCursorWriter.java
+++ b/DBFlow-Compiler/src/main/java/com/raizlabs/android/dbflow/processor/writer/LoadCursorWriter.java
@@ -69,7 +69,7 @@ public class LoadCursorWriter implements FlowWriter {
 
                 for (ColumnDefinition columnDefinition : baseTableDefinition.getColumnDefinitions()) {
                     columnDefinition.writeLoadFromCursorDefinition(baseTableDefinition, javaWriter,
-                                                                   isModelContainerDefinition);
+                            isModelContainerDefinition);
                 }
 
                 // don't use methods here as they result in undefined behavior.
@@ -80,8 +80,8 @@ public class LoadCursorWriter implements FlowWriter {
                 }
                 if (implementsLoadFromCursorListener && !isModelContainerDefinition) {
                     javaWriter.emitStatement("%1s.onLoadFromCursor(%1s)",
-                                             ModelUtils.getVariable(isModelContainerDefinition),
-                                             params[1]);
+                            ModelUtils.getVariable(isModelContainerDefinition),
+                            params[1]);
                 }
 
             }
@@ -135,27 +135,27 @@ public class LoadCursorWriter implements FlowWriter {
                             ColumnDefinition columnDefinition = tableDefinition.getPrimaryColumnDefinitions().get(0);
 
                             javaWriter.emitStatement("return %1s.%1s", tableDefinition.getTableSourceClassName(),
-                                                     columnDefinition.columnName.toUpperCase());
+                                    columnDefinition.columnName.toUpperCase());
                         }
                     }, "String", "getCachingColumnName", Sets.newHashSet(Modifier.PUBLIC));
 
                     ColumnAccessModel columnAccessModel = new ColumnAccessModel(tableDefinition.getManager(),
-                                                                                tableDefinition.getPrimaryColumnDefinitions().get(
-                                                                                        0), false);
+                            tableDefinition.getPrimaryColumnDefinitions().get(
+                                    0), false);
                     final String statement = ModelUtils
                             .getCursorStatement(columnAccessModel.getCastedClass(),
-                                                columnAccessModel.getReferencedColumnFieldName())
+                                    columnAccessModel.getReferencedColumnFieldName())
                             .replace("()", "");
                     WriterUtils.emitOverriddenMethod(javaWriter, new FlowWriter() {
-                                                         @Override
-                                                         public void write(JavaWriter javaWriter) throws IOException {
+                                @Override
+                                public void write(JavaWriter javaWriter) throws IOException {
 
-                                                             javaWriter.emitStatement("return %1s", statement);
+                                    javaWriter.emitStatement("return %1s", statement);
 
-                                                         }
-                                                     }, "Object", "getCachingIdFromCursorIndex",
-                                                     Sets.newHashSet(Modifier.PUBLIC), "Cursor", "cursor",
-                                                     "int", "index" + columnAccessModel.getReferencedColumnFieldName().replace("()", ""));
+                                }
+                            }, "Object", "getCachingIdFromCursorIndex",
+                            Sets.newHashSet(Modifier.PUBLIC), "Cursor", "cursor",
+                            "int", "index" + columnAccessModel.getReferencedColumnFieldName().replace("()", ""));
                 }
             } else if (tableDefinition.hasAutoIncrement) {
                 params[0] = ModelUtils.getParameter(isModelContainerDefinition, tableDefinition.getModelClassName());
@@ -170,10 +170,17 @@ public class LoadCursorWriter implements FlowWriter {
                                 .append(ModelUtils.getVariable(isModelContainerDefinition));
 
                         if (!isModelContainerDefinition) {
-                            queryBuilder.append(".").append(columnDefinition.columnFieldName)
-                                    .append(" = ")
-                                    .appendCast(columnDefinition.columnFieldType)
+                            ColumnAccessModel columnAccessModel = new ColumnAccessModel(baseTableDefinition.getManager(),
+                                    columnDefinition, isModelContainerDefinition);
+                            queryBuilder.append(".").append(columnAccessModel.getSetterReferenceColumnFieldName());
+                            if (!columnAccessModel.isPrivate()) {
+                                queryBuilder.appendSpaceSeparated("=");
+                            }
+                            queryBuilder.appendCast(columnDefinition.columnFieldType)
                                     .append(params[3]).append(")");
+                            if (columnAccessModel.isPrivate()) {
+                                queryBuilder.append(")");
+                            }
                         } else {
                             String containerKeyName = columnDefinition.columnFieldName;
                             if (columnDefinition.containerKeyName != null) {
@@ -200,7 +207,10 @@ public class LoadCursorWriter implements FlowWriter {
                                 .append(ModelUtils.getVariable(isModelContainerDefinition));
 
                         if (!isModelContainerDefinition) {
-                            queryBuilder.append(".").append(columnDefinition.columnFieldName);
+                            ColumnAccessModel columnAccessModel = new ColumnAccessModel(
+                                    baseTableDefinition.getManager(),
+                                    columnDefinition, isModelContainerDefinition);
+                            queryBuilder.append(".").append(columnAccessModel.getReferencedColumnFieldName());
                         } else {
                             String containerKeyName = columnDefinition.columnFieldName;
                             if (columnDefinition.containerKeyName != null) {
@@ -220,7 +230,7 @@ public class LoadCursorWriter implements FlowWriter {
                             ColumnDefinition columnDefinition = tableDefinition.autoIncrementDefinition;
 
                             javaWriter.emitStatement("return %1s.%1s", tableDefinition.getTableSourceClassName(),
-                                                     columnDefinition.columnName.toUpperCase());
+                                    columnDefinition.columnName.toUpperCase());
                         }
                     }, "String", "getAutoIncrementingColumnName", Sets.newHashSet(Modifier.PUBLIC));
                 }

--- a/DBFlow-Compiler/src/main/java/com/raizlabs/android/dbflow/processor/writer/ToModelWriter.java
+++ b/DBFlow-Compiler/src/main/java/com/raizlabs/android/dbflow/processor/writer/ToModelWriter.java
@@ -33,7 +33,7 @@ public class ToModelWriter implements FlowWriter {
                 javaWriter.emitStatement(tableDefinition.getModelClassName() + " " + ModelUtils.getVariable(false) +
                         " = new " + tableDefinition.getModelClassName() + "()");
                 for (ColumnDefinition columnDefinition : tableDefinition.getColumnDefinitions()) {
-                    columnDefinition.writeToModelDefinition(javaWriter);
+                    columnDefinition.writeToModelDefinition(javaWriter, isModelContainerDefinition);
                 }
                 javaWriter.emitStatement("return " + ModelUtils.getVariable(false));
             }

--- a/DBFlow/src/androidTest/java/com/raizlabs/android/dbflow/test/AQL.java
+++ b/DBFlow/src/androidTest/java/com/raizlabs/android/dbflow/test/AQL.java
@@ -1,10 +1,13 @@
 package com.raizlabs.android.dbflow.test;
 
 import com.raizlabs.android.dbflow.annotation.Column;
+import com.raizlabs.android.dbflow.annotation.ForeignKey;
+import com.raizlabs.android.dbflow.annotation.ForeignKeyReference;
 import com.raizlabs.android.dbflow.annotation.ModelContainer;
 import com.raizlabs.android.dbflow.annotation.PrimaryKey;
 import com.raizlabs.android.dbflow.annotation.Table;
 import com.raizlabs.android.dbflow.structure.BaseModel;
+import com.raizlabs.android.dbflow.test.sql.BoxedModel;
 
 import java.util.Date;
 
@@ -33,6 +36,11 @@ public class AQL extends BaseModel {
 
     @Column(name = Columns.AQL_TIMESTAMP)
     private Date timestamp;
+
+    @Column
+    @ForeignKey(references = {@ForeignKeyReference(columnName = "id1", columnType = long.class, foreignColumnName = "id"),
+    @ForeignKeyReference(columnName = "id2", columnType = String.class, foreignColumnName = "name")})
+    private BoxedModel boxedModel;
 
     public Long getAql_id() {
         return aql_id;
@@ -64,5 +72,13 @@ public class AQL extends BaseModel {
 
     public void setTimestamp(Date timestamp) {
         this.timestamp = timestamp;
+    }
+
+    public BoxedModel getBoxedModel() {
+        return boxedModel;
+    }
+
+    public void setBoxedModel(BoxedModel boxedModel) {
+        this.boxedModel = boxedModel;
     }
 }

--- a/DBFlow/src/androidTest/java/com/raizlabs/android/dbflow/test/AQL.java
+++ b/DBFlow/src/androidTest/java/com/raizlabs/android/dbflow/test/AQL.java
@@ -1,6 +1,7 @@
 package com.raizlabs.android.dbflow.test;
 
 import com.raizlabs.android.dbflow.annotation.Column;
+import com.raizlabs.android.dbflow.annotation.ContainerKey;
 import com.raizlabs.android.dbflow.annotation.ForeignKey;
 import com.raizlabs.android.dbflow.annotation.ForeignKeyReference;
 import com.raizlabs.android.dbflow.annotation.ModelContainer;
@@ -37,6 +38,7 @@ public class AQL extends BaseModel {
     @Column(name = Columns.AQL_TIMESTAMP)
     private Date timestamp;
 
+    @ContainerKey("boxedLodo")
     @Column
     @ForeignKey(references = {@ForeignKeyReference(columnName = "id1", columnType = long.class, foreignColumnName = "id"),
     @ForeignKeyReference(columnName = "id2", columnType = String.class, foreignColumnName = "name")})

--- a/DBFlow/src/androidTest/java/com/raizlabs/android/dbflow/test/AQL.java
+++ b/DBFlow/src/androidTest/java/com/raizlabs/android/dbflow/test/AQL.java
@@ -1,0 +1,68 @@
+package com.raizlabs.android.dbflow.test;
+
+import com.raizlabs.android.dbflow.annotation.Column;
+import com.raizlabs.android.dbflow.annotation.ModelContainer;
+import com.raizlabs.android.dbflow.annotation.PrimaryKey;
+import com.raizlabs.android.dbflow.annotation.Table;
+import com.raizlabs.android.dbflow.structure.BaseModel;
+
+import java.util.Date;
+
+@Table(databaseName = TestDatabase.NAME, tableName = AQL.ENDPOINT)
+@ModelContainer
+public class AQL extends BaseModel {
+
+    public static final String ENDPOINT = "AQL";
+
+    public interface Columns {
+        String AQL_ID = "aql_id";
+        String AQL_NAME = "aql_name";
+        String AQL_SERVER_ID = "aql_server_id";
+        String AQL_TIMESTAMP = "aql_timestamp";
+    }
+
+    @Column(name = Columns.AQL_ID)
+    @PrimaryKey(autoincrement = true)
+    private Long aql_id;
+
+    @Column(name = Columns.AQL_NAME)
+    private String aql_name;
+
+    @Column(name = Columns.AQL_SERVER_ID)
+    private Long server_id;
+
+    @Column(name = Columns.AQL_TIMESTAMP)
+    private Date timestamp;
+
+    public Long getAql_id() {
+        return aql_id;
+    }
+
+    public void setAql_id(Long aql_id) {
+        this.aql_id = aql_id;
+    }
+
+    public String getAql_name() {
+        return aql_name;
+    }
+
+    public void setAql_name(String aql_name) {
+        this.aql_name = aql_name;
+    }
+
+    public Long getServer_id() {
+        return server_id;
+    }
+
+    public void setServer_id(Long server_id) {
+        this.server_id = server_id;
+    }
+
+    public Date getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(Date timestamp) {
+        this.timestamp = timestamp;
+    }
+}

--- a/DBFlow/src/androidTest/java/com/raizlabs/android/dbflow/test/sql/BoxedModel.java
+++ b/DBFlow/src/androidTest/java/com/raizlabs/android/dbflow/test/sql/BoxedModel.java
@@ -16,7 +16,7 @@ public class BoxedModel extends TestModel1 {
     @Column
     @PrimaryKey
     @NotNull
-    Long id = 1L;
+    public Long id = 1L;
 
     @Column
     @NotNull

--- a/DBFlow/src/main/java/com/raizlabs/android/dbflow/sql/language/OrderBy.java
+++ b/DBFlow/src/main/java/com/raizlabs/android/dbflow/sql/language/OrderBy.java
@@ -106,7 +106,7 @@ public class OrderBy implements Query {
             }
             queryBuilder.appendSpace().append(ascending ? "ASC" : "DESC");
             if (orderByCollation != null) {
-                queryBuilder.appendSpace().appendSpaceSeparated(orderByCollation);
+                queryBuilder.appendSpace().append("COLLATE").appendSpaceSeparated(orderByCollation);
             }
         }
         return queryBuilder.getQuery();

--- a/README.md
+++ b/README.md
@@ -33,6 +33,11 @@ If you wish to have your application featured here, please file an [issue](https
 
 ## Changelog
 
+#### 2.2.1
+1. Fixed issue with `OrderBy` where the `COLLATE` keyword was not appended to the query.
+2. Fixed conversion and inconsistency issues within a `ModelContainer` adapter that have foreign keys and private fields.
+3. Private primary keys now work with getter and setters, private fields within `ModelContainer` adapters now generate compilable code.
+
 #### 2.2.0
 
 1. Fixed a bug where `new Select().from(myTable.class).byId(PrimaryKey)` was incorrectly double-quoting columns.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Image](https://github.com/agrosner/DBFlow/blob/develop/dbflow_banner.png?raw=true)
 
-[![JCenter](https://img.shields.io/badge/JCenter-2.2.0-red.svg?style=flat)](https://bintray.com/raizlabs/Libraries/DBFlow/view)
+[![JCenter](https://img.shields.io/badge/JCenter-2.2.1-red.svg?style=flat)](https://bintray.com/raizlabs/Libraries/DBFlow/view)
 [![Android Weekly](http://img.shields.io/badge/Android%20Weekly-%23129-2CB3E5.svg?style=flat)](http://androidweekly.net/issues/issue-129)
 [![Android Arsenal](https://img.shields.io/badge/Android%20Arsenal-DBFlow-brightgreen.svg?style=flat)](https://android-arsenal.com/details/1/1134)
 
@@ -119,9 +119,9 @@ Add the library to the project-level build.gradle, using the  to enable Annotati
   apply plugin: 'com.neenbedankt.android-apt'
 
   dependencies {
-    apt 'com.raizlabs.android:DBFlow-Compiler:2.1.0'
-    compile "com.raizlabs.android:DBFlow-Core:2.1.0"
-    compile "com.raizlabs.android:DBFlow:2.1.0"
+    apt 'com.raizlabs.android:DBFlow-Compiler:2.2.1'
+    compile "com.raizlabs.android:DBFlow-Core:2.2.1"
+    compile "com.raizlabs.android:DBFlow:2.2.1"
   }
 
 ```

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=2.2.0
+version=2.2.1
 version_code=1
 group=com.raizlabs.android
 


### PR DESCRIPTION
1. Fixed issue with `OrderBy` where the `COLLATE` keyword was not appended to the query.
2. Fixed conversion and inconsistency issues within a `ModelContainer` adapter that have foreign keys and private fields.
3. Private primary keys now work with getter and setters, private fields within `ModelContainer` adapters now generate compilable code.