### PR TITLE
Removed extra parentheses from ConditionQueryBuilder

### DIFF
--- a/DBFlow/src/main/java/com/raizlabs/android/dbflow/sql/builder/ConditionQueryBuilder.java
+++ b/DBFlow/src/main/java/com/raizlabs/android/dbflow/sql/builder/ConditionQueryBuilder.java
@@ -263,7 +263,7 @@ public class ConditionQueryBuilder<ModelClass extends Model> extends QueryBuilde
             stringVal = String.valueOf(value);
         } else {
             if (value instanceof Where) {
-                stringVal = String.format("(%1s)", ((Where) value).getQuery().trim());
+                stringVal = String.format("%1s", ((Where) value).getQuery().trim());
             } else if (value instanceof ColumnAlias) {
                 stringVal = ((ColumnAlias) value).getQuery();
             } else {


### PR DESCRIPTION
When using nested queries, for example with "select * from table1 where id not in (select id from table2)", DBFlow adds an extra set of parentheses around the select statement:
select * from table1 where id not in ((select id from table2))

With Sqlite, this extra set of parentheses is a problem as it is changed to a SCALAR SUBQUERY, causing the inner select to return one element instead of a list. The result is thus far from the intended one.

Please also see this link for further reference:
http://sqlite.1065341.n5.nabble.com/Unexpected-behaviour-when-use-quot-IN-quot-clause-and-double-parentheses-td81057.html