### PR TITLE
Fixed compilation error when using type converter dependent properties in a ModelView class

### DIFF
--- a/DBFlow-Compiler/src/main/java/com/raizlabs/android/dbflow/processor/definition/ModelViewDefinition.java
+++ b/DBFlow-Compiler/src/main/java/com/raizlabs/android/dbflow/processor/definition/ModelViewDefinition.java
@@ -4,12 +4,10 @@ import com.google.common.collect.Sets;
 import com.raizlabs.android.dbflow.annotation.Column;
 import com.raizlabs.android.dbflow.annotation.ModelView;
 import com.raizlabs.android.dbflow.processor.Classes;
-import com.raizlabs.android.dbflow.processor.DBFlowProcessor;
 import com.raizlabs.android.dbflow.processor.ProcessorUtils;
 import com.raizlabs.android.dbflow.processor.handler.DatabaseHandler;
 import com.raizlabs.android.dbflow.processor.model.ProcessorManager;
 import com.raizlabs.android.dbflow.processor.utils.WriterUtils;
-import com.raizlabs.android.dbflow.processor.writer.DatabaseWriter;
 import com.raizlabs.android.dbflow.processor.writer.ExistenceWriter;
 import com.raizlabs.android.dbflow.processor.writer.FlowWriter;
 import com.raizlabs.android.dbflow.processor.writer.LoadCursorWriter;
@@ -130,8 +128,11 @@ public class ModelViewDefinition extends BaseTableDefinition implements FlowWrit
     @Override
     protected String[] getImports() {
         return new String[]{
-                Classes.CURSOR, Classes.SELECT, Classes.CONDITION_QUERY_BUILDER,
-                Classes.CONDITION
+                Classes.CURSOR,
+                Classes.SELECT,
+                Classes.CONDITION_QUERY_BUILDER,
+                Classes.CONDITION,
+                Classes.FLOW_MANAGER
         };
     }
 

--- a/DBFlow/src/androidTest/java/com/raizlabs/android/dbflow/test/typeconverter/TestTypeView.java
+++ b/DBFlow/src/androidTest/java/com/raizlabs/android/dbflow/test/typeconverter/TestTypeView.java
@@ -1,0 +1,43 @@
+package com.raizlabs.android.dbflow.test.typeconverter;
+
+import android.location.Location;
+import com.raizlabs.android.dbflow.annotation.Column;
+import com.raizlabs.android.dbflow.annotation.ModelView;
+import com.raizlabs.android.dbflow.structure.BaseModelView;
+import com.raizlabs.android.dbflow.test.TestDatabase;
+
+import java.util.Calendar;
+import java.util.Date;
+
+import org.json.JSONObject;
+
+/**
+ * Author: kzsolti
+ */
+@ModelView(databaseName = TestDatabase.NAME, query = "SELECT * FROM TestType")
+public class TestTypeView extends BaseModelView<TestType> {
+
+	@Column
+	public String name;
+
+	@Column
+	boolean nativeBoolean;
+
+	@Column
+	Boolean aBoolean;
+
+	@Column
+	Calendar calendar;
+
+	@Column
+	Date date;
+
+	@Column
+	java.sql.Date sqlDate;
+
+	@Column
+	JSONObject json;
+
+	@Column
+	Location location;
+}

--- a/DBFlow/src/androidTest/java/com/raizlabs/android/dbflow/test/typeconverter/TypeConverterTest.java
+++ b/DBFlow/src/androidTest/java/com/raizlabs/android/dbflow/test/typeconverter/TypeConverterTest.java
@@ -81,6 +81,68 @@ public class TypeConverterTest extends FlowTestCase {
     }
 
     /**
+     * Test converters in a view class.
+     */
+    public void testViewConverters() {
+
+        Delete.table(TestType.class);
+
+        TestType testType = new TestType();
+        testType.name = "Name";
+
+        long testTime = System.currentTimeMillis();
+
+        // calendar
+        Calendar calendar = Calendar.getInstance();
+        calendar.setTimeInMillis(testTime);
+        testType.calendar = calendar;
+
+        Date date = new Date(testTime);
+        testType.date = date;
+
+        java.sql.Date date1 = new java.sql.Date(testTime);
+        testType.sqlDate = date1;
+
+        JSONObject jsonObject;
+        try {
+            jsonObject = new JSONObject("{ name: test, happy: true }");
+            testType.json = jsonObject;
+        } catch (JSONException e) {
+            throw new RuntimeException(e);
+        }
+
+        Location location = new Location("test");
+        location.setLatitude(40.5);
+        location.setLongitude(40.5);
+        testType.location = location;
+
+        testType.save();
+
+        TestTypeView retrievedView = new Select().from(TestTypeView.class)
+                .where(column(TestTypeView$ViewTable.NAME).is("Name"))
+                .querySingle();
+
+        assertNotNull(retrievedView);
+
+        assertNotNull(retrievedView.calendar);
+        assertTrue(retrievedView.calendar.equals(calendar));
+
+        assertNotNull(retrievedView.date);
+        assertTrue(retrievedView.date.equals(date));
+
+        assertNotNull(retrievedView.sqlDate);
+        assertTrue(retrievedView.sqlDate.equals(date1));
+
+        assertNotNull(retrievedView.json);
+        assertTrue(retrievedView.json.toString().equals(jsonObject.toString()));
+
+        assertNotNull(retrievedView.location);
+        assertTrue(retrievedView.location.getLongitude() == location.getLongitude());
+        assertTrue(retrievedView.location.getLatitude() == location.getLatitude());
+
+    }
+
+    /**
      * Nullable database columns need to be allowed to receive null values.
      */
     public void testConvertersNullValues() {


### PR DESCRIPTION
While integrating DBFlow into my app, I encountered a compilation error when creating a simple view class. If you include a property of a type that uses a type converter, like for example:

```java
@ModelView(databaseName = TestDatabase.NAME, query = "SELECT * FROM TestType")
public class TestTypeView extends BaseModelView<TestType> {

	@Column
	Date date;
}
```

Then the generated view adapter class will not compile:

```
/Users/zsolt/Work/GitRepositories/DBFlow/DBFlow/build/generated/source/apt/androidTest/debug/com/raizlabs/android/dbflow/test/typeconverter/TestTypeView$View.java
Error:(21, 49) Gradle: error: cannot find symbol variable FlowManager
```

This is because of a missing import statement for FlowManager. This pull request contains a test case for this error, and the fix for the missing import in the code generator.