### PR TITLE
Fix exception message for missing ModelContainer annotation

### DIFF
--- a/DBFlow/src/main/java/com/raizlabs/android/dbflow/structure/container/BaseModelContainer.java
+++ b/DBFlow/src/main/java/com/raizlabs/android/dbflow/structure/container/BaseModelContainer.java
@@ -31,8 +31,10 @@ public abstract class BaseModelContainer<ModelClass extends Model, DataClass> im
         modelAdapter = FlowManager.getModelAdapter(table);
         modelContainerAdapter = FlowManager.getContainerAdapter(table);
         if (modelContainerAdapter == null) {
-            throw new InvalidDBConfiguration("The table" + FlowManager.getTableName(table) + " did not specify the ContainerAdapter" +
-                    "annotation. Please add and rebuild");
+            throw new InvalidDBConfiguration("The table " + FlowManager.getTableName(table) + " did not specify the " +
+                    com.raizlabs.android.dbflow.annotation.ModelContainer.class.getSimpleName() + " annotation." +
+                    " Please decorate " + table.getName() +
+                    " with annotation @" + com.raizlabs.android.dbflow.annotation.ModelContainer.class.getSimpleName() + ".");
         }
     }
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2014 Andrew Grosner
+Copyright (c) 2014 Raizlabs
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
The old exception message was using outdated class names. It took me quite some time to figure out what was wrong. The new message should be safe for any future class name changes.