### PR TITLE
Added ability to have in-memory database.

### DIFF
--- a/dbflow-core/src/main/java/com/raizlabs/android/dbflow/annotation/Database.java
+++ b/dbflow-core/src/main/java/com/raizlabs/android/dbflow/annotation/Database.java
@@ -39,6 +39,13 @@ public @interface Database {
     boolean foreignKeysSupported() default false;
 
     /**
+     * In order to use an in-memory database, set this to true.
+     *
+     * @return if database is in-memory.
+     */
+    boolean inMemory() default false;
+
+    /**
      * @return Checks for consistency in the DB, if true it will recopy over the prepackage database.
      */
     boolean consistencyCheckEnabled() default false;

--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/writer/DatabaseWriter.java
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/writer/DatabaseWriter.java
@@ -41,6 +41,8 @@ public class DatabaseWriter extends BaseDefinition implements FlowWriter {
 
     boolean foreignKeysSupported;
 
+    boolean inMemory;
+
     boolean consistencyChecksEnabled;
 
     boolean backupEnabled;
@@ -78,6 +80,7 @@ public class DatabaseWriter extends BaseDefinition implements FlowWriter {
 
         databaseVersion = database.version();
         foreignKeysSupported = database.foreignKeysSupported();
+        inMemory = database.inMemory();
 
         insertConflict = database.insertConflict();
         updateConflict = database.updateConflict();
@@ -208,6 +211,14 @@ public class DatabaseWriter extends BaseDefinition implements FlowWriter {
                 javaWriter.emitStatement("return %1s", foreignKeysSupported);
             }
         }, "boolean", "isForeignKeysSupported", DatabaseHandler.METHOD_MODIFIERS);
+
+        // Get Model Container
+        WriterUtils.emitOverriddenMethod(javaWriter, new FlowWriter() {
+            @Override
+            public void write(JavaWriter javaWriter) throws IOException {
+                javaWriter.emitStatement("return %1s", inMemory);
+            }
+        }, "boolean", "isInMemory", DatabaseHandler.METHOD_MODIFIERS);
 
         // Get Model Container
         WriterUtils.emitOverriddenMethod(javaWriter, new FlowWriter() {

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/config/BaseDatabaseDefinition.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/config/BaseDatabaseDefinition.java
@@ -202,6 +202,11 @@ public abstract class BaseDatabaseDefinition {
     public abstract boolean isForeignKeysSupported();
 
     /**
+     * @return True if the {@link com.raizlabs.android.dbflow.annotation.Database#inMemory()} annotation is true.
+     */
+    public abstract boolean isInMemory();
+
+    /**
      * @return True if the {@link com.raizlabs.android.dbflow.annotation.Database#backupEnabled()} annotation is true.
      */
     public abstract boolean backupEnabled();


### PR DESCRIPTION
Added necessary fields to Database and BaseDatabaseDefinition to allow FlowSQLiteOpenHelper to send null as the name argument to the SQLiteOpenHelper constructor. This causes an in-memory database to be created.

This is for issue https://github.com/Raizlabs/DBFlow/issues/315