### PR TITLE
Changed the way Insert statement is used in documentation.

### DIFF
--- a/usage/TriggersIndexesAndMore.md
+++ b/usage/TriggersIndexesAndMore.md
@@ -11,7 +11,7 @@ This section contains more advance usage of SQLite. These features are very usef
 CompletedTrigger<Friend> trigger = Trigger.create("NameTrigger")
                                     .after().update(Friend.class, Friend$Table.NAME)
                                     .begin(
-                                        new Insert<FriendLog>(FriendLog.class)
+                                        Insert.into(FriendLog.class)
                                           .columns(FriendLog$Table.OLDNAME, FriendLog$Table.NEWNAME, FriendLog$Table.DATE)
                                           .values("old.Name", "new.Name", System.currentTimeMillis())
                                           };


### PR DESCRIPTION
It seems in older versions of DbFlow, constructor of Insert class was publicly accessible, so you could create an object by calling it. But now you have to call .into() which is static factory method and is the only way to instantiate an Insert object.