### PR TITLE
Check enums and blobs for null

### DIFF
--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/column/DefinitionUtils.java
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/column/DefinitionUtils.java
@@ -47,7 +47,11 @@ public class DefinitionUtils {
         }
 
         if (!elementTypeName.isPrimitive()) {
-            codeBuilder.beginControlFlow("if ($L != null)", finalAccessStatement);
+            if(columnAccess instanceof EnumColumnAccess || columnAccess instanceof BlobColumnAccess) {
+                codeBuilder.beginControlFlow("if (($L != null) && ($L != null))", variableNameString + "." + elementName, finalAccessStatement);
+            } else {
+                codeBuilder.beginControlFlow("if ($L != null)", finalAccessStatement);
+            }
         }
 
         codeBuilder.addStatement("$L.put($S, $L)",

--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/column/DefinitionUtils.java
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/column/DefinitionUtils.java
@@ -47,7 +47,7 @@ public class DefinitionUtils {
         }
 
         if (!elementTypeName.isPrimitive()) {
-            if(columnAccess instanceof EnumColumnAccess || columnAccess instanceof BlobColumnAccess) {
+            if(!isModelContainerAdapter && (columnAccess instanceof EnumColumnAccess || columnAccess instanceof BlobColumnAccess)) {
                 codeBuilder.beginControlFlow("if (($L != null) && ($L != null))", variableNameString + "." + elementName, finalAccessStatement);
             } else {
                 codeBuilder.beginControlFlow("if ($L != null)", finalAccessStatement);


### PR DESCRIPTION
There might be a slightly better way to do it by exposing `WrapperColumnAccess#getExistingColumnAccess()` in `EnumColumnAccess` so that `getColumnAccessString` of the underlying `SimpleColumnAccess` can be used, but we feel not yet experienced enough for such a refactoring.