### PR TITLE
Manage the onLoadFromCursor call

### DIFF
--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/column/ColumnDefinition.java
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/column/ColumnDefinition.java
@@ -267,7 +267,7 @@ public class ColumnDefinition extends BaseDefinition {
                 elementTypeName, isModelContainerAdapter, columnAccess, ModelUtils.getVariable(isModelContainerAdapter), isPrimaryKeyAutoIncrement).build();
     }
 
-    public CodeBlock getLoadFromCursorMethod(boolean isModelContainerAdapter, boolean putNullForContainerAdapter) {
+    public CodeBlock getLoadFromCursorMethod(boolean isModelContainerAdapter, boolean putNullForContainerAdapter, boolean implementsLoadFromCursorListener) {
         boolean putDefaultValue = putNullForContainerAdapter;
         if (putContainerDefaultValue != putDefaultValue && isModelContainerAdapter) {
             putDefaultValue = putContainerDefaultValue;
@@ -275,7 +275,7 @@ public class ColumnDefinition extends BaseDefinition {
             putDefaultValue = true;
         }
         return DefinitionUtils.getLoadFromCursorMethod(containerKeyName, elementName,
-                elementTypeName, columnName, isModelContainerAdapter, putDefaultValue, columnAccess).build();
+                elementTypeName, columnName, isModelContainerAdapter, putDefaultValue, columnAccess, implementsLoadFromCursorListener).build();
     }
 
     /**

--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/column/DefinitionUtils.java
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/column/DefinitionUtils.java
@@ -153,7 +153,7 @@ public class DefinitionUtils {
     public static CodeBlock.Builder getLoadFromCursorMethod(String elementName, String fullElementName,
                                                             TypeName elementTypeName, String columnName,
                                                             boolean isModelContainerAdapter, boolean putDefaultValue,
-                                                            BaseColumnAccess columnAccess) {
+                                                            BaseColumnAccess columnAccess, boolean implementsLoadFromCursorListener) {
         String method = getLoadFromCursorMethodString(elementTypeName, columnAccess);
 
         CodeBlock.Builder codeBuilder = CodeBlock.builder();
@@ -201,6 +201,10 @@ public class DefinitionUtils {
         }
 
         codeBuilder.endControlFlow();
+
+        if (implementsLoadFromCursorListener) {
+            codeBuilder.addStatement("((com.raizlabs.android.dbflow.structure.listener.LoadFromCursorListener) $L).onLoadFromCursor($L)", ModelUtils.getVariable(isModelContainerAdapter), LoadFromCursorMethod.PARAM_CURSOR);
+        }
 
         return codeBuilder;
     }

--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/column/ForeignKeyColumnDefinition.java
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/column/ForeignKeyColumnDefinition.java
@@ -249,9 +249,9 @@ public class ForeignKeyColumnDefinition extends ColumnDefinition {
     }
 
     @Override
-    public CodeBlock getLoadFromCursorMethod(boolean isModelContainerAdapter, boolean putNullForContainerAdapter) {
+    public CodeBlock getLoadFromCursorMethod(boolean isModelContainerAdapter, boolean putNullForContainerAdapter, boolean implementsLoadFromCursorListener) {
         if (nonModelColumn) {
-            return super.getLoadFromCursorMethod(isModelContainerAdapter, putNullForContainerAdapter);
+            return super.getLoadFromCursorMethod(isModelContainerAdapter, putNullForContainerAdapter, implementsLoadFromCursorListener);
         } else {
             checkNeedsReferences();
             CodeBlock.Builder builder = CodeBlock.builder()

--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/method/LoadFromCursorMethod.java
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/method/LoadFromCursorMethod.java
@@ -48,7 +48,7 @@ public class LoadFromCursorMethod implements MethodDefinition {
 
         List<ColumnDefinition> columnDefinitionList = baseTableDefinition.getColumnDefinitions();
         for (ColumnDefinition columnDefinition : columnDefinitionList) {
-            methodBuilder.addCode(columnDefinition.getLoadFromCursorMethod(isModelContainerAdapter, putNullForContainerAdapter));
+            methodBuilder.addCode(columnDefinition.getLoadFromCursorMethod(isModelContainerAdapter, putNullForContainerAdapter, implementsLoadFromCursorListener));
         }
 
         if (baseTableDefinition instanceof TableDefinition && !isModelContainerAdapter) {

--- a/dbflow/src/androidTest/java/com/raizlabs/android/dbflow/test/structure/ListenerModelTest.java
+++ b/dbflow/src/androidTest/java/com/raizlabs/android/dbflow/test/structure/ListenerModelTest.java
@@ -22,12 +22,12 @@ public class ListenerModelTest extends FlowTestCase {
 
         ListenerModel listenerModel = new ListenerModel();
         listenerModel.name = "This is a test";
-        final boolean[] called = new boolean[]{false, false, false};
+        final boolean[] called = new boolean[]{false, false, false, false, false};
         listenerModel.registerListeners(
                 new SQLiteStatementListener() {
                     @Override
                     public void onBindToStatement(SQLiteStatement sqLiteStatement) {
-                        called[1] = true;
+                        called[0] = true;
                     }
 
                     @Override
@@ -43,13 +43,13 @@ public class ListenerModelTest extends FlowTestCase {
 
                     @Override
                     public void onBindToInsertValues(ContentValues contentValues) {
-                        called[2] = true;
+                        called[3] = true;
                     }
                 });
         listenerModel.registerLoadFromCursorListener(new LoadFromCursorListener() {
             @Override
             public void onLoadFromCursor(Cursor cursor) {
-                called[0] = true;
+                called[4] = true;
             }
         });
         listenerModel.insert();


### PR DESCRIPTION
Add generation of the onLoadFromCursor call when the Model implements LoadFromCursorListener.
The test ListenerModelTest is not ok yet, there is still SQLiteStatementListener#onBindToStatement not plugged.

It's one of my first improvement on this project, I would continue to help, so don't worry if it's not mergeable, but if you can please comment and provide some guidance, and I'll fix my issues ;)