### PR TITLE
Implemented support for using DBFlow in shared libraries

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[*]
+indent_style = space
+indent_size  = 4

--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/FlowManagerHolderDefinition.java
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/FlowManagerHolderDefinition.java
@@ -16,37 +16,37 @@ import javax.lang.model.element.Modifier;
  * and {@link com.raizlabs.android.dbflow.annotation.TypeConverter}
  */
 public class FlowManagerHolderDefinition implements TypeDefinition {
-
     private final ProcessorManager processorManager;
 
-    private static final String OPTION_TARGET_MODULE_NAME = "targetModuleName";
-
     private String className = "";
+
+    private static final String OPTION_TARGET_MODULE_NAME = "targetModuleName";
 
     public FlowManagerHolderDefinition(ProcessorManager processorManager) {
         this.processorManager = processorManager;
 
-        Map <String, String> options = this.processorManager.getProcessingEnvironment ().getOptions ();
+        Map<String, String> options = this.processorManager.getProcessingEnvironment().getOptions();
 
-        if (options.containsKey (OPTION_TARGET_MODULE_NAME))
-            className = options.get (OPTION_TARGET_MODULE_NAME);
+        if (options.containsKey(OPTION_TARGET_MODULE_NAME)) {
+            className = options.get(OPTION_TARGET_MODULE_NAME);
+        }
 
         className += ClassNames.DATABASE_HOLDER_STATIC_CLASS_NAME;
     }
 
     @Override
-	public TypeSpec getTypeSpec() {
+    public TypeSpec getTypeSpec() {
         TypeSpec.Builder typeBuilder = TypeSpec.classBuilder(this.className)
-	    .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
-	    .superclass(ClassNames.DATABASE_HOLDER);
+            .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
+            .superclass(ClassNames.DATABASE_HOLDER);
 
         MethodSpec.Builder constructor = MethodSpec.constructorBuilder()
-	    .addModifiers(Modifier.PUBLIC);
+            .addModifiers(Modifier.PUBLIC);
 
         for (TypeConverterDefinition typeConverterDefinition : processorManager.getTypeConverters()) {
             constructor.addStatement("$L.put($T.class, new $T())", DatabaseHandler.TYPE_CONVERTER_MAP_FIELD_NAME,
-				     typeConverterDefinition.getModelTypeName(),
-				     typeConverterDefinition.getClassName());
+                typeConverterDefinition.getModelTypeName(),
+                typeConverterDefinition.getClassName());
         }
 
         for (DatabaseDefinition databaseDefinition : processorManager.getDatabaseDefinitionMap()) {

--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/FlowManagerHolderDefinition.java
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/FlowManagerHolderDefinition.java
@@ -7,6 +7,8 @@ import com.raizlabs.android.dbflow.processor.model.ProcessorManager;
 import com.squareup.javapoet.MethodSpec;
 import com.squareup.javapoet.TypeSpec;
 
+import java.util.Map;
+
 import javax.lang.model.element.Modifier;
 
 /**
@@ -17,23 +19,34 @@ public class FlowManagerHolderDefinition implements TypeDefinition {
 
     private final ProcessorManager processorManager;
 
+    private static final String OPTION_TARGET_MODULE_NAME = "targetModuleName";
+
+    private String className = "";
+
     public FlowManagerHolderDefinition(ProcessorManager processorManager) {
         this.processorManager = processorManager;
+
+        Map <String, String> options = this.processorManager.getProcessingEnvironment ().getOptions ();
+
+        if (options.containsKey (OPTION_TARGET_MODULE_NAME))
+            className = options.get (OPTION_TARGET_MODULE_NAME);
+
+        className += ClassNames.DATABASE_HOLDER_STATIC_CLASS_NAME;
     }
 
     @Override
-    public TypeSpec getTypeSpec() {
-        TypeSpec.Builder typeBuilder = TypeSpec.classBuilder(ClassNames.DATABASE_HOLDER_STATIC_CLASS_NAME)
-                .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
-                .superclass(ClassNames.DATABASE_HOLDER);
+	public TypeSpec getTypeSpec() {
+        TypeSpec.Builder typeBuilder = TypeSpec.classBuilder(this.className)
+	    .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
+	    .superclass(ClassNames.DATABASE_HOLDER);
 
         MethodSpec.Builder constructor = MethodSpec.constructorBuilder()
-                .addModifiers(Modifier.PUBLIC);
+	    .addModifiers(Modifier.PUBLIC);
 
         for (TypeConverterDefinition typeConverterDefinition : processorManager.getTypeConverters()) {
             constructor.addStatement("$L.put($T.class, new $T())", DatabaseHandler.TYPE_CONVERTER_MAP_FIELD_NAME,
-                    typeConverterDefinition.getModelTypeName(),
-                    typeConverterDefinition.getClassName());
+				     typeConverterDefinition.getModelTypeName(),
+				     typeConverterDefinition.getClassName());
         }
 
         for (DatabaseDefinition databaseDefinition : processorManager.getDatabaseDefinitionMap()) {

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/config/DatabaseHolder.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/config/DatabaseHolder.java
@@ -11,12 +11,11 @@ import java.util.Map;
  * between them.
  */
 public abstract class DatabaseHolder {
+    protected final Map<Class<? extends Model>, BaseDatabaseDefinition> managerMap = new HashMap<>();
 
-    static final Map<Class<? extends Model>, BaseDatabaseDefinition> managerMap = new HashMap<>();
+    protected final Map<String, BaseDatabaseDefinition> managerNameMap = new HashMap<>();
 
-    static final Map<String, BaseDatabaseDefinition> managerNameMap = new HashMap<>();
-
-    protected static final Map<Class<?>, TypeConverter> typeConverters = new HashMap<>();
+    protected final Map<Class<?>, TypeConverter> typeConverters = new HashMap<>();
 
     /**
      * @param clazz The model value class to get a {@link com.raizlabs.android.dbflow.converter.TypeConverter}

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/config/FlowManager.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/config/FlowManager.java
@@ -34,49 +34,42 @@ public class FlowManager {
      * Exception thrown when a database holder cannot load the database holder
      * for a module.
      */
-    public static class ModuleNotFoundException extends RuntimeException
-    {
-        public ModuleNotFoundException ()
-        {
+    public static class ModuleNotFoundException extends RuntimeException {
+        public ModuleNotFoundException() {
         }
 
-        public ModuleNotFoundException (String detailMessage)
-        {
-            super (detailMessage);
+        public ModuleNotFoundException(String detailMessage) {
+            super(detailMessage);
         }
 
-        public ModuleNotFoundException (String detailMessage, Throwable throwable)
-        {
-            super (detailMessage, throwable);
+        public ModuleNotFoundException(String detailMessage, Throwable throwable) {
+            super(detailMessage, throwable);
         }
 
-        public ModuleNotFoundException (Throwable throwable)
-        {
-            super (throwable);
+        public ModuleNotFoundException(Throwable throwable) {
+            super(throwable);
         }
     }
 
-    private static class GlobalDatabaseHolder extends DatabaseHolder
-    {
-        public void add (DatabaseHolder holder)
-        {
-            managerMap.putAll (holder.managerMap);
-            managerNameMap.putAll (holder.managerNameMap);
-            typeConverters.putAll (holder.typeConverters);
+    private static class GlobalDatabaseHolder extends DatabaseHolder {
+        public void add(DatabaseHolder holder) {
+            managerMap.putAll(holder.managerMap);
+            managerNameMap.putAll(holder.managerNameMap);
+            typeConverters.putAll(holder.typeConverters);
         }
     }
 
     private static Context context;
 
-    private static GlobalDatabaseHolder globalDatabaseHolder = new GlobalDatabaseHolder ();
+    private static GlobalDatabaseHolder globalDatabaseHolder = new GlobalDatabaseHolder();
 
-    private static HashSet<String> loadedModules = new HashSet<> ();
+    private static HashSet<String> loadedModules = new HashSet<>();
 
 
     private static final String DEFAULT_DATABASE_HOLDER_NAME = "GeneratedDatabaseHolder";
 
     private static final String DEFAULT_DATABASE_HOLDER_PACKAGE_NAME =
-        FlowManager.class.getPackage ().getName ();
+        FlowManager.class.getPackage().getName();
 
     private static final String DEFAULT_DATABASE_HOLDER_CLASSNAME =
         DEFAULT_DATABASE_HOLDER_PACKAGE_NAME + "." + DEFAULT_DATABASE_HOLDER_NAME;
@@ -88,12 +81,13 @@ public class FlowManager {
      * @return The table name, which can be different than the {@link Model} class name
      */
     @SuppressWarnings("unchecked")
-	public static String getTableName(Class<? extends Model> table) {
-        ModelAdapter modelAdapter = getModelAdapter (table);
+
+    public static String getTableName(Class<? extends Model> table) {
+        ModelAdapter modelAdapter = getModelAdapter(table);
         String tableName = null;
         if (modelAdapter == null) {
             ModelViewAdapter modelViewAdapter = getDatabaseForTable(table).getModelViewAdapterForTable(
-												       (Class<? extends BaseModelView>) table);
+                (Class<? extends BaseModelView>) table);
             if (modelViewAdapter != null) {
                 tableName = modelViewAdapter.getViewName();
             }
@@ -109,16 +103,16 @@ public class FlowManager {
      * @return The associated table class for the specified name.
      */
     public static Class<? extends Model> getTableClassForName(String databaseName, String tableName) {
-        BaseDatabaseDefinition databaseDefinition = getDatabase (databaseName);
+        BaseDatabaseDefinition databaseDefinition = getDatabase(databaseName);
         if (databaseDefinition == null) {
             throw new IllegalArgumentException(String.format("The specified database %1s was not found. " +
-							     "Did you forget to add the @Database?", databaseName));
+                "Did you forget to add the @Database?", databaseName));
         }
-        Class<? extends Model> modelClass = databaseDefinition.getModelClassForName (tableName);
+        Class<? extends Model> modelClass = databaseDefinition.getModelClassForName(tableName);
         if (modelClass == null) {
             throw new IllegalArgumentException(String.format("The specified table %1s was not found. " +
-							     "Did you forget to add the @Table annotation and point it to %1s?",
-							     tableName, databaseName));
+                    "Did you forget to add the @Table annotation and point it to %1s?",
+                tableName, databaseName));
         }
         return modelClass;
     }
@@ -128,10 +122,10 @@ public class FlowManager {
      * @return the corresponding {@link BaseDatabaseDefinition} for the specified model
      */
     public static BaseDatabaseDefinition getDatabaseForTable(Class<? extends Model> table) {
-        BaseDatabaseDefinition flowManager = globalDatabaseHolder.getDatabaseForTable (table);
+        BaseDatabaseDefinition flowManager = globalDatabaseHolder.getDatabaseForTable(table);
         if (flowManager == null) {
             throw new InvalidDBConfiguration("Table: " + table.getName() + " is not registered with a Database. " +
-					     "Did you forget the @Table annotation?");
+                "Did you forget the @Table annotation?");
         }
         return flowManager;
     }
@@ -141,34 +135,36 @@ public class FlowManager {
      * @return the {@link BaseDatabaseDefinition} for the specified database
      */
     public static BaseDatabaseDefinition getDatabase(String databaseName) {
-        BaseDatabaseDefinition database = globalDatabaseHolder.getDatabase (databaseName);
-        if (database != null)
+        BaseDatabaseDefinition database = globalDatabaseHolder.getDatabase(databaseName);
+
+        if (database != null) {
             return database;
+        }
 
         throw new InvalidDBConfiguration("The specified database" + databaseName + " was not found. " +
-					 "Did you forget the @Database annotation?");
+            "Did you forget the @Database annotation?");
     }
 
     /**
      * @return The database holder, creating if necessary using reflection.
      */
-    protected static void loadDatabaseHolder (String className) {
-        if (loadedModules.contains (className))
+    protected static void loadDatabaseHolder(String className) {
+        if (loadedModules.contains(className)) {
             return;
+        }
 
         try {
             // Load the database holder, and add it to the global collection.
             DatabaseHolder dbHolder = (DatabaseHolder) Class.forName(className).newInstance();
 
-            if (dbHolder != null)
-            {
-                globalDatabaseHolder.add (dbHolder);
+            if (dbHolder != null) {
+                globalDatabaseHolder.add(dbHolder);
 
                 // Cache the holder for future reference.
-                loadedModules.add (className);
+                loadedModules.add(className);
             }
         } catch (Throwable e) {
-            throw new ModuleNotFoundException ("Cannot load " + className, e);
+            throw new ModuleNotFoundException("Cannot load " + className, e);
         }
     }
 
@@ -192,12 +188,11 @@ public class FlowManager {
      */
     public static void init(Context context) {
         // Initialize the context, then load the default database holder.
-        initContext (context);
+        initContext(context);
 
         try {
-            loadDatabaseHolder (DEFAULT_DATABASE_HOLDER_CLASSNAME);
-        }
-        catch (ModuleNotFoundException e) {
+            loadDatabaseHolder(DEFAULT_DATABASE_HOLDER_CLASSNAME);
+        } catch (ModuleNotFoundException e) {
             // Ignore this exception since it means the application does not have its
             // own database. The initialization happens because the application is using
             // a module that has a database.
@@ -207,18 +202,16 @@ public class FlowManager {
     /**
      * Loading the module Database holder via reflection. This will trigger all creations,
      * updates, and instantiation for each database defined.
-     *
+     * <p>
      * It is assumed FlowManager.init() is called by the application that uses the
      * module database. This method should only be called if you need to load databases
      * that are part of a module.
      */
-    public static void initModule (String moduleName)
-    {
-        loadDatabaseHolder (DEFAULT_DATABASE_HOLDER_PACKAGE_NAME + "." + moduleName + DEFAULT_DATABASE_HOLDER_NAME);
+    public static void initModule(String moduleName) {
+        loadDatabaseHolder(DEFAULT_DATABASE_HOLDER_PACKAGE_NAME + "." + moduleName + DEFAULT_DATABASE_HOLDER_NAME);
     }
 
-    private static void initContext (Context context)
-    {
+    private static void initContext(Context context) {
         // QUESTION Should we throw an exception if context is not null? In other
         // words, should we allow the client to initialize the context more than once?!
         FlowManager.context = context;
@@ -252,8 +245,8 @@ public class FlowManager {
         context = null;
 
         // Reset the global database holder.
-        globalDatabaseHolder = new GlobalDatabaseHolder ();
-        loadedModules.clear ();
+        globalDatabaseHolder = new GlobalDatabaseHolder();
+        loadedModules.clear();
     }
 
     /**
@@ -262,15 +255,15 @@ public class FlowManager {
      * it checks both the {@link ModelViewAdapter} and {@link QueryModelAdapter}.
      */
     @SuppressWarnings("unchecked")
-	public static InstanceAdapter getInstanceAdapter(Class<? extends Model> modelClass) {
+    public static InstanceAdapter getInstanceAdapter(Class<? extends Model> modelClass) {
         InstanceAdapter internalAdapter = getModelAdapter(modelClass);
         if (internalAdapter == null) {
             if (BaseModelView.class.isAssignableFrom(modelClass)) {
                 internalAdapter = FlowManager.getModelViewAdapter(
-								  (Class<? extends BaseModelView<? extends Model>>) modelClass);
+                    (Class<? extends BaseModelView<? extends Model>>) modelClass);
             } else if (BaseQueryModel.class.isAssignableFrom(modelClass)) {
                 internalAdapter = FlowManager.getQueryModelAdapter(
-								   (Class<? extends BaseQueryModel>) modelClass);
+                    (Class<? extends BaseQueryModel>) modelClass);
             }
         }
 
@@ -285,7 +278,7 @@ public class FlowManager {
      * We strongly prefer you use the built-in methods associated with {@link Model} and {@link BaseModel}.
      */
     @SuppressWarnings("unchecked")
-	public static <ModelClass extends Model> ModelAdapter<ModelClass> getModelAdapter(Class<ModelClass> modelClass) {
+    public static <ModelClass extends Model> ModelAdapter<ModelClass> getModelAdapter(Class<ModelClass> modelClass) {
         return FlowManager.getDatabaseForTable(modelClass).getModelAdapterForTable(modelClass);
     }
 
@@ -296,8 +289,8 @@ public class FlowManager {
      * in your model class so it can be used for containers. These are not generated by default as a means to keep app size down.
      */
     @SuppressWarnings("unchecked")
-	public static <ModelClass extends Model> ModelContainerAdapter<ModelClass> getContainerAdapter(
-												       Class<ModelClass> modelClass) {
+    public static <ModelClass extends Model> ModelContainerAdapter<ModelClass> getContainerAdapter(
+        Class<ModelClass> modelClass) {
         return FlowManager.getDatabaseForTable(modelClass).getModelContainerAdapterForTable(modelClass);
     }
 
@@ -309,8 +302,8 @@ public class FlowManager {
      * @return The model view adapter for the specified model view.
      */
     @SuppressWarnings("unchecked")
-	public static <ModelViewClass extends BaseModelView<? extends Model>> ModelViewAdapter<? extends Model, ModelViewClass> getModelViewAdapter(
-																		    Class<ModelViewClass> modelViewClass) {
+    public static <ModelViewClass extends BaseModelView<? extends Model>> ModelViewAdapter<? extends Model, ModelViewClass> getModelViewAdapter(
+        Class<ModelViewClass> modelViewClass) {
         return FlowManager.getDatabaseForTable(modelViewClass).getModelViewAdapterForTable(modelViewClass);
     }
 
@@ -322,8 +315,8 @@ public class FlowManager {
      * @return The query model adapter for the specified model query.
      */
     @SuppressWarnings("unchecked")
-	public static <QueryModel extends BaseQueryModel> QueryModelAdapter<QueryModel> getQueryModelAdapter(
-													     Class<QueryModel> queryModel) {
+    public static <QueryModel extends BaseQueryModel> QueryModelAdapter<QueryModel> getQueryModelAdapter(
+        Class<QueryModel> queryModel) {
         return FlowManager.getDatabaseForTable(queryModel).getQueryModelAdapterForQueryClass(queryModel);
     }
 

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/runtime/BaseContentProvider.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/runtime/BaseContentProvider.java
@@ -23,96 +23,112 @@ import java.util.List;
  * extend when generated.
  */
 public abstract class BaseContentProvider extends ContentProvider {
+  protected String moduleName;
 
-    /**
-     * Converts the column into a {@link Property}. This exists since the propery method is static and cannot
-     * be referenced easily.
-     */
-    public interface PropertyConverter {
+  /**
+   * Converts the column into a {@link Property}. This exists since the property method is static and cannot
+   * be referenced easily.
+   */
+  public interface PropertyConverter {
+    IProperty fromName(String columnName);
+  }
 
-        IProperty fromName(String columnName);
+  protected BaseContentProvider ()
+  {
+
+  }
+
+  protected BaseContentProvider (String moduleName)
+  {
+    this.moduleName = moduleName;
+  }
+
+  /**
+   * Converts a projection of {@link String} column names into an array of properties. Any columns
+   * not found may throw an {@link IllegalArgumentException}. This helps to prevent SQL injection attacks by
+   * explicitly checking for correct columns.
+   *
+   * @param propertyConverter The converter to convert the name.
+   * @param projection        The projection to convert.
+   * @return An array of {@link IProperty}.
+   */
+  protected static IProperty[] toProperties(PropertyConverter propertyConverter, String... projection) {
+    IProperty[] properties = new IProperty[projection.length];
+    for (int i = 0; i < projection.length; i++) {
+      String columnName = projection[i];
+      properties[i] = propertyConverter.fromName(columnName);
     }
+    return properties;
+  }
 
-    /**
-     * Converts a projection of {@link String} column names into an array of properties. Any columns
-     * not found may throw an {@link IllegalArgumentException}. This helps to prevent SQL injection attacks by
-     * explicitly checking for correct columns.
-     *
-     * @param propertyConverter The converter to convert the name.
-     * @param projection        The projection to convert.
-     * @return An array of {@link IProperty}.
-     */
-    protected static IProperty[] toProperties(PropertyConverter propertyConverter, String... projection) {
-        IProperty[] properties = new IProperty[projection.length];
-        for (int i = 0; i < projection.length; i++) {
-            String columnName = projection[i];
-            properties[i] = propertyConverter.fromName(columnName);
+  protected static SQLCondition[] toConditions(String selection, String[] selectionArgs) {
+    List<SQLCondition> conditions = new ArrayList<>();
+    if (StringUtils.isNotNullOrEmpty(selection)) {
+      String[] stringConditions = selection.split(" AND ");
+      if (selectionArgs != null && selectionArgs.length > 0 && selectionArgs.length > stringConditions.length) {
+        throw new IllegalArgumentException("Too many bind arguments.  "
+                                               + selectionArgs.length + " arguments were provided but the selection query needs "
+                                               + stringConditions.length + " arguments.");
+      }
+      List<String> copySelectionArgs = selectionArgs != null ? new ArrayList<>(Arrays.asList(selectionArgs)) : new ArrayList<String>();
+      for (int i = 0; i < stringConditions.length; i++) {
+        String stringCondition = stringConditions[i];
+        if (stringCondition.endsWith("?")) {
+          stringConditions[i] = stringCondition.substring(0, stringCondition.length() - 1) + copySelectionArgs.remove(0);
         }
-        return properties;
-    }
 
-    protected static SQLCondition[] toConditions(String selection, String[] selectionArgs) {
-        List<SQLCondition> conditions = new ArrayList<>();
-        if (StringUtils.isNotNullOrEmpty(selection)) {
-            String[] stringConditions = selection.split(" AND ");
-            if (selectionArgs != null && selectionArgs.length > 0 && selectionArgs.length > stringConditions.length) {
-                throw new IllegalArgumentException("Too many bind arguments.  "
-                        + selectionArgs.length + " arguments were provided but the selection query needs "
-                        + stringConditions.length + " arguments.");
-            }
-            List<String> copySelectionArgs = selectionArgs != null ? new ArrayList<>(Arrays.asList(selectionArgs)) : new ArrayList<String>();
-            for (int i = 0; i < stringConditions.length; i++) {
-                String stringCondition = stringConditions[i];
-                if (stringCondition.endsWith("?")) {
-                    stringConditions[i] = stringCondition.substring(0, stringCondition.length() - 1) + copySelectionArgs.remove(0);
-                }
-
-                String[] params = stringCondition.split("=");
-                if (params.length == 0) {
-                    throw new IllegalArgumentException("Selection conditions must be of Operation Type.");
-                } else if (params.length == 2) {
-                    conditions.add(Condition.column(new NameAlias(params[0])).eq(params[1]));
-                } else {
-                    throw new IllegalStateException("Something went wrong. Condition could not be associated with equals");
-                }
-            }
+        String[] params = stringCondition.split("=");
+        if (params.length == 0) {
+          throw new IllegalArgumentException("Selection conditions must be of Operation Type.");
+        } else if (params.length == 2) {
+          conditions.add(Condition.column(new NameAlias(params[0])).eq(params[1]));
+        } else {
+          throw new IllegalStateException("Something went wrong. Condition could not be associated with equals");
         }
-
-        return conditions.toArray(new SQLCondition[conditions.size()]);
+      }
     }
 
-    protected BaseDatabaseDefinition database;
+    return conditions.toArray(new SQLCondition[conditions.size()]);
+  }
 
-    @Override
-    public boolean onCreate() {
-        return true;
-    }
+  protected BaseDatabaseDefinition database;
 
-    @Override
-    public int bulkInsert(@NonNull final Uri uri, @NonNull final ContentValues[] values) {
-        final int[] count = {0};
-        TransactionManager.transact(getDatabase().getWritableDatabase(), new Runnable() {
-            @Override
-            public void run() {
-                for (ContentValues contentValues : values) {
-                    count[0] += bulkInsert(uri, contentValues);
-                }
-            }
-        });
-        //noinspection ConstantConditions
-        getContext().getContentResolver().notifyChange(uri, null);
-        return count[0];
-    }
+  @Override
+  public boolean onCreate() {
+    // If this is a module, then we need to initialize the module as part
+    // of the creation process. We can assume the framework has been general
+    // framework has been initialized.
+    if (moduleName != null)
+      FlowManager.initModule (moduleName);
 
-    protected abstract String getDatabaseName();
+    return true;
+  }
 
-    protected abstract int bulkInsert(Uri uri, ContentValues contentValues);
-
-    protected BaseDatabaseDefinition getDatabase() {
-        if (database == null) {
-            database = FlowManager.getDatabase(getDatabaseName());
+  @Override
+  public int bulkInsert(@NonNull final Uri uri, @NonNull final ContentValues[] values) {
+    final int[] count = {0};
+    TransactionManager.transact(getDatabase().getWritableDatabase(), new Runnable() {
+      @Override
+      public void run() {
+        for (ContentValues contentValues : values) {
+          count[0] += bulkInsert(uri, contentValues);
         }
-        return database;
+      }
+    });
+    //noinspection ConstantConditions
+    getContext().getContentResolver().notifyChange(uri, null);
+    return count[0];
+  }
+
+  protected abstract String getDatabaseName();
+
+  protected abstract int bulkInsert(Uri uri, ContentValues contentValues);
+
+  protected BaseDatabaseDefinition getDatabase() {
+    if (database == null) {
+      database = FlowManager.getDatabase(getDatabaseName());
     }
+    return database;
+  }
 
 }

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/runtime/BaseContentProvider.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/runtime/BaseContentProvider.java
@@ -23,112 +23,111 @@ import java.util.List;
  * extend when generated.
  */
 public abstract class BaseContentProvider extends ContentProvider {
-  protected String moduleName;
+    protected String moduleName;
 
-  /**
-   * Converts the column into a {@link Property}. This exists since the property method is static and cannot
-   * be referenced easily.
-   */
-  public interface PropertyConverter {
-    IProperty fromName(String columnName);
-  }
-
-  protected BaseContentProvider ()
-  {
-
-  }
-
-  protected BaseContentProvider (String moduleName)
-  {
-    this.moduleName = moduleName;
-  }
-
-  /**
-   * Converts a projection of {@link String} column names into an array of properties. Any columns
-   * not found may throw an {@link IllegalArgumentException}. This helps to prevent SQL injection attacks by
-   * explicitly checking for correct columns.
-   *
-   * @param propertyConverter The converter to convert the name.
-   * @param projection        The projection to convert.
-   * @return An array of {@link IProperty}.
-   */
-  protected static IProperty[] toProperties(PropertyConverter propertyConverter, String... projection) {
-    IProperty[] properties = new IProperty[projection.length];
-    for (int i = 0; i < projection.length; i++) {
-      String columnName = projection[i];
-      properties[i] = propertyConverter.fromName(columnName);
-    }
-    return properties;
-  }
-
-  protected static SQLCondition[] toConditions(String selection, String[] selectionArgs) {
-    List<SQLCondition> conditions = new ArrayList<>();
-    if (StringUtils.isNotNullOrEmpty(selection)) {
-      String[] stringConditions = selection.split(" AND ");
-      if (selectionArgs != null && selectionArgs.length > 0 && selectionArgs.length > stringConditions.length) {
-        throw new IllegalArgumentException("Too many bind arguments.  "
-                                               + selectionArgs.length + " arguments were provided but the selection query needs "
-                                               + stringConditions.length + " arguments.");
-      }
-      List<String> copySelectionArgs = selectionArgs != null ? new ArrayList<>(Arrays.asList(selectionArgs)) : new ArrayList<String>();
-      for (int i = 0; i < stringConditions.length; i++) {
-        String stringCondition = stringConditions[i];
-        if (stringCondition.endsWith("?")) {
-          stringConditions[i] = stringCondition.substring(0, stringCondition.length() - 1) + copySelectionArgs.remove(0);
-        }
-
-        String[] params = stringCondition.split("=");
-        if (params.length == 0) {
-          throw new IllegalArgumentException("Selection conditions must be of Operation Type.");
-        } else if (params.length == 2) {
-          conditions.add(Condition.column(new NameAlias(params[0])).eq(params[1]));
-        } else {
-          throw new IllegalStateException("Something went wrong. Condition could not be associated with equals");
-        }
-      }
+    /**
+     * Converts the column into a {@link Property}. This exists since the property method is static and cannot
+     * be referenced easily.
+     */
+    public interface PropertyConverter {
+        IProperty fromName(String columnName);
     }
 
-    return conditions.toArray(new SQLCondition[conditions.size()]);
-  }
+    protected BaseContentProvider() {
 
-  protected BaseDatabaseDefinition database;
-
-  @Override
-  public boolean onCreate() {
-    // If this is a module, then we need to initialize the module as part
-    // of the creation process. We can assume the framework has been general
-    // framework has been initialized.
-    if (moduleName != null)
-      FlowManager.initModule (moduleName);
-
-    return true;
-  }
-
-  @Override
-  public int bulkInsert(@NonNull final Uri uri, @NonNull final ContentValues[] values) {
-    final int[] count = {0};
-    TransactionManager.transact(getDatabase().getWritableDatabase(), new Runnable() {
-      @Override
-      public void run() {
-        for (ContentValues contentValues : values) {
-          count[0] += bulkInsert(uri, contentValues);
-        }
-      }
-    });
-    //noinspection ConstantConditions
-    getContext().getContentResolver().notifyChange(uri, null);
-    return count[0];
-  }
-
-  protected abstract String getDatabaseName();
-
-  protected abstract int bulkInsert(Uri uri, ContentValues contentValues);
-
-  protected BaseDatabaseDefinition getDatabase() {
-    if (database == null) {
-      database = FlowManager.getDatabase(getDatabaseName());
     }
-    return database;
-  }
+
+    protected BaseContentProvider(String moduleName) {
+        this.moduleName = moduleName;
+    }
+
+    /**
+     * Converts a projection of {@link String} column names into an array of properties. Any columns
+     * not found may throw an {@link IllegalArgumentException}. This helps to prevent SQL injection attacks by
+     * explicitly checking for correct columns.
+     *
+     * @param propertyConverter The converter to convert the name.
+     * @param projection        The projection to convert.
+     * @return An array of {@link IProperty}.
+     */
+    protected static IProperty[] toProperties(PropertyConverter propertyConverter, String... projection) {
+        IProperty[] properties = new IProperty[projection.length];
+        for (int i = 0; i < projection.length; i++) {
+            String columnName = projection[i];
+            properties[i] = propertyConverter.fromName(columnName);
+        }
+        return properties;
+    }
+
+    protected static SQLCondition[] toConditions(String selection, String[] selectionArgs) {
+        List<SQLCondition> conditions = new ArrayList<>();
+        if (StringUtils.isNotNullOrEmpty(selection)) {
+            String[] stringConditions = selection.split(" AND ");
+            if (selectionArgs != null && selectionArgs.length > 0 && selectionArgs.length > stringConditions.length) {
+                throw new IllegalArgumentException("Too many bind arguments.  "
+                    + selectionArgs.length + " arguments were provided but the selection query needs "
+                    + stringConditions.length + " arguments.");
+            }
+            List<String> copySelectionArgs = selectionArgs != null ? new ArrayList<>(Arrays.asList(selectionArgs)) : new ArrayList<String>();
+            for (int i = 0; i < stringConditions.length; i++) {
+                String stringCondition = stringConditions[i];
+                if (stringCondition.endsWith("?")) {
+                    stringConditions[i] = stringCondition.substring(0, stringCondition.length() - 1) + copySelectionArgs.remove(0);
+                }
+
+                String[] params = stringCondition.split("=");
+                if (params.length == 0) {
+                    throw new IllegalArgumentException("Selection conditions must be of Operation Type.");
+                } else if (params.length == 2) {
+                    conditions.add(Condition.column(new NameAlias(params[0])).eq(params[1]));
+                } else {
+                    throw new IllegalStateException("Something went wrong. Condition could not be associated with equals");
+                }
+            }
+        }
+
+        return conditions.toArray(new SQLCondition[conditions.size()]);
+    }
+
+    protected BaseDatabaseDefinition database;
+
+    @Override
+    public boolean onCreate() {
+        // If this is a module, then we need to initialize the module as part
+        // of the creation process. We can assume the framework has been general
+        // framework has been initialized.
+        if (moduleName != null) {
+            FlowManager.initModule(moduleName);
+        }
+
+        return true;
+    }
+
+    @Override
+    public int bulkInsert(@NonNull final Uri uri, @NonNull final ContentValues[] values) {
+        final int[] count = {0};
+        TransactionManager.transact(getDatabase().getWritableDatabase(), new Runnable() {
+            @Override
+            public void run() {
+                for (ContentValues contentValues : values) {
+                    count[0] += bulkInsert(uri, contentValues);
+                }
+            }
+        });
+        //noinspection ConstantConditions
+        getContext().getContentResolver().notifyChange(uri, null);
+        return count[0];
+    }
+
+    protected abstract String getDatabaseName();
+
+    protected abstract int bulkInsert(Uri uri, ContentValues contentValues);
+
+    protected BaseDatabaseDefinition getDatabase() {
+        if (database == null) {
+            database = FlowManager.getDatabase(getDatabaseName());
+        }
+        return database;
+    }
 
 }

--- a/usage/DatabaseModules.md
+++ b/usage/DatabaseModules.md
@@ -1,0 +1,41 @@
+# Databases Modules
+
+When you use DBFlow as is, DBFlow assumes the application defines all the databases
+it needs. There, however, are scenarios where an application needs to load a module,
+or library, that uses DBFlow to manage its databases. This is an important scenario
+because it allows you to reuse a database across multiple applications.
+
+To add databases to a module, first update the ```build.config``` with the ```apt```
+section. In the example below, all databases will be in the ```Test``` module.
+
+```groovy
+apt {
+    arguments {
+        targetModuleName 'Test'
+    }
+}
+```
+
+Initialize DBFlow using the standard approach. For example, you can initialize
+DBFlow in the ```Application``` class:
+
+```java
+public class ExampleApplication extends Application {
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        FlowManager.init(this);
+    }
+}
+```
+
+Lastly, instruct DBFlow to load the module that contains the database.
+
+```java
+FlowManager.initModule("Test");
+```
+
+Ideally, the module containing the databases should execute the line of code above. This
+can easily be done by providing an initialization method for the module that the application
+must invoke before it can be used. Otherwise, the application must be aware that is needs
+to manually instruct DBFlow to load a database module.

--- a/usage/DatabaseModules.md
+++ b/usage/DatabaseModules.md
@@ -3,7 +3,12 @@
 When you use DBFlow as is, DBFlow assumes the application defines all the databases
 it needs. There, however, are scenarios where an application needs to load a module,
 or library, that uses DBFlow to manage its databases. This is an important scenario
-because it allows you to reuse a database across multiple applications.
+because it allows you to reuse a database across multiple applications. Unfortunately,
+if you try this with DBFlow, then there will be duplicate symbols in the application and
+the module and the application will not build.
+
+To get around this problem, you must enable database module support for the module
+intended to be loaded by an application. Fortunately, this is a very easy process.
 
 To add databases to a module, first update the ```build.config``` with the ```apt```
 section. In the example below, all databases will be in the ```Test``` module.

--- a/usage/DatabaseModules.md
+++ b/usage/DatabaseModules.md
@@ -1,4 +1,4 @@
-# Databases Modules
+# Database Modules
 
 When you use DBFlow as is, DBFlow assumes the application defines all the databases
 it needs. There, however, are scenarios where an application needs to load a module,

--- a/usage/DatabaseModules.md
+++ b/usage/DatabaseModules.md
@@ -56,4 +56,4 @@ public class Test {
 
 Otherwise, the application must be aware that is needs to manually instruct DBFlow to load
 a database module. Lastly, ```FlowManager.initModule(moduleName)``` can be invoked multiple
-times without causing any extra side-effects.
+times without causing any additional side-effects after the first invocation.

--- a/usage/DatabaseModules.md
+++ b/usage/DatabaseModules.md
@@ -42,5 +42,18 @@ FlowManager.initModule("Test");
 
 Ideally, the module containing the databases should execute the line of code above. This
 can easily be done by providing an initialization method for the module that the application
-must invoke before it can be used. Otherwise, the application must be aware that is needs
-to manually instruct DBFlow to load a database module.
+must invoke before it can be used. For example:
+
+```java
+class Test {
+    public static void initialize(Context context) {
+        FlowManager.initModule("Test");
+
+        // Perform other initialization steps
+    }
+}
+```
+
+Otherwise, the application must be aware that is needs to manually instruct DBFlow to load
+a database module. Lastly, ```FlowManager.initModule(moduleName)``` can be invoked multiple
+times without causing any extra side-effects.

--- a/usage/DatabaseModules.md
+++ b/usage/DatabaseModules.md
@@ -45,7 +45,7 @@ can easily be done by providing an initialization method for the module that the
 must invoke before it can be used. For example:
 
 ```java
-class Test {
+public class Test {
     public static void initialize(Context context) {
         FlowManager.initModule("Test");
 

--- a/usage/DatabaseModules.md
+++ b/usage/DatabaseModules.md
@@ -41,8 +41,8 @@ FlowManager.initModule("Test");
 ```
 
 Ideally, the module containing the databases should execute the line of code above. This
-can easily be done by providing an initialization method for the module that the application
-must invoke before it can be used. For example:
+can easily be done by exporting an initialization method from the module that the application
+must invoke before it can be used, similar to DBFlow. For example:
 
 ```java
 public class Test {


### PR DESCRIPTION
This PR contains the patch for using DBFlow in shared libraries. The approach implemented in this approach is very simple. 

1. We have a single global database holder that is used to hold all the information originally stored in the loaded ```DefaultDatabaseHolder``` class loaded in the ```FlowManager```.

1. We implement a ```FlowManager.initModule``` method that is used to load the database holder from a shared library. It is assumed the shared library will call this method upon initialization.

1. When the module holder is loaded, it its contents are added to the global database holder.

This approach, however, does not allow you to unload a module. Since it seems this is really not a concern with DBFlow before, this functionality was not taken into consideration. This also influenced the current design. Also, there should not any name clashes since the key is a class unless the database and tables are in the same package.

Another approach that was not implemented was to have a map of each loaded holder in the global holder. Then implement the necessary methods on the global holder that iterate over the list of maps until it finds what is it looking for. This approach will have the same runtime complexity as the current design, but it will actually not yield the same performance (in theory) for each item stored in the map. This is because the lookup will result in 2 operations, instead of a single operation. This, however, was not evaluated since the current approach was easier to implement.