### PR TITLE
Fix to run gradle install

### DIFF
--- a/DBFlow-Compiler/build.gradle
+++ b/DBFlow-Compiler/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'java'
-apply plugin: 'maven'
 
 project.ext.artifactId = bt_name
 

--- a/DBFlow-Core/build.gradle
+++ b/DBFlow-Core/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'java'
-apply plugin: 'maven'
 
 project.ext.artifactId = bt_name
 

--- a/DBFlow/build.gradle
+++ b/DBFlow/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'com.android.library'
 apply plugin: 'android-apt'
-apply plugin: 'com.github.dcendents.android-maven'
 
 project.ext.artifactId = bt_name
 


### PR DESCRIPTION
Hi!

The maven plugin was defined in a couple of places so remove the first definition. The other one is still in this file: 
https://raw.githubusercontent.com/Raizlabs/maven-releases/master/bintray_upload.gradle

With this change `./gradlew install` works and the project also builds nicely on JitPack!
This is the build log for our fork that includes this change:
https://jitpack.io/com/github/jitpack-io/DBFlow/064be1bdc7/build.log

Happy building!