### PR TITLE
JitPack development builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,16 +101,18 @@ Add the library to the project-level build.gradle, using the  to enable Annotati
   }
 ```
 
-or if you wish to grab the latest develop commit in your project, specify the first 10 digits of the long commit hash:
+If you wish to grab the latest develop branch in your project, use JitPack dependencies:
 
 ```groovy
 
   dependencies {
-    apt 'com.raizlabs.android:dbflow-processor:{commit_hash}'
-    compile "com.raizlabs.android:dbflow-core:{commit_hash}"
-    compile "com.raizlabs.android:dbflow:{commit_hash}"
+    apt 'com.github.Raizlabs.DBFlow:dbflow-processor:develop-SNAPSHOT'
+    compile "com.github.Raizlabs.DBFlow:dbflow-core:develop-SNAPSHOT"
+    compile "com.github.Raizlabs.DBFlow:dbflow:develop-SNAPSHOT"
   }
 ```
+
+You can also specify a commit hash instead of `develop-SNAPSHOT` to grab a specific commit.
 
 # Pull Requests
 I welcome and encourage all pull requests. It usually will take me within 24-48 hours to respond to any issue or request. Here are some basic rules to follow to ensure timely addition of your request:

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.5.0-beta1'
+        classpath 'com.android.tools.build:gradle:1.5.0'
         classpath 'com.neenbedankt.gradle.plugins:android-apt:1.7'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.1'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.3'


### PR DESCRIPTION
Hey, thanks for the great work with 3.0.

I’ve been trying it out with a project of mine, and I noticed that you started recommending JitPack with 61968c8.

This is good news, but currently it doesn’t build since the build tools beta releases expire after a while, and [1.5.0-beta1 is already past that point](https://jitpack.io/com/github/Raizlabs/DBFlow/21f0299/build.log).

I’ve updated the build tools to 1.5.0 and also changed the dependency specs in the README to match JitPack’s multi-module format.

[Now it builds on JitPack.](https://jitpack.io/com/github/lnikkila/DBFlow/develop-SNAPSHOT/build.log)

Cheers!