### PR TITLE
Model Loader Objects

### DIFF
--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/ClassNames.java
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/ClassNames.java
@@ -89,4 +89,8 @@ public class ClassNames {
     public static final ClassName BASE_MODEL = ClassName.get(STRUCTURE, "BaseModel");
     public static final ClassName MODEL_CACHE = ClassName.get(STRUCTURE + ".cache", "ModelCache");
     public static final ClassName MULTI_KEY_CACHE_CONVERTER = ClassName.get(STRUCTURE + ".cache", "IMultiKeyCacheConverter");
+    public static final ClassName CACHEABLE_MODEL_LOADER = ClassName.get(SQL + ".queriable", "CacheableModelLoader");
+    public static final ClassName SINGLE_MODEL_LOADER = ClassName.get(SQL + ".queriable", "SingleModelLoader");
+    public static final ClassName CACHEABLE_LIST_MODEL_LOADER = ClassName.get(SQL + ".queriable", "CacheableListModelLoader");
+    public static final ClassName LIST_MODEL_LOADER = ClassName.get(SQL + ".queriable", "ListModelLoader");
 }

--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/ModelViewDefinition.java
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/ModelViewDefinition.java
@@ -224,6 +224,8 @@ public class ModelViewDefinition extends BaseTableDefinition {
             }
         }
 
+        InternalAdapterHelper.writeGetModelClass(typeBuilder, elementClassName);
+
         typeBuilder.addMethod(MethodSpec.methodBuilder("getCreationQuery")
                 .addAnnotation(Override.class)
                 .addModifiers(DatabaseHandler.METHOD_MODIFIERS)

--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/QueryModelDefinition.java
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/QueryModelDefinition.java
@@ -154,6 +154,8 @@ public class QueryModelDefinition extends BaseTableDefinition {
 
         customTypeConverterPropertyMethod.addCode(constructorCode);
 
+        InternalAdapterHelper.writeGetModelClass(typeBuilder, elementClassName);
+
         typeBuilder.addMethod(MethodSpec.constructorBuilder()
                 .addParameter(ClassNames.DATABASE_HOLDER, "holder")
                 .addCode(constructorCode.build())

--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/TableDefinition.java
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/TableDefinition.java
@@ -454,6 +454,20 @@ public class TableDefinition extends BaseTableDefinition {
 
         if (cachingEnabled) {
 
+            // TODO: pass in model cache loaders.
+
+            typeBuilder.addMethod(MethodSpec.methodBuilder("createSingleModelLoader")
+                    .addAnnotation(Override.class)
+                    .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
+                    .addStatement("return new $T<>(getModelClass())", ClassNames.CACHEABLE_MODEL_LOADER)
+                    .returns(ClassNames.SINGLE_MODEL_LOADER).build());
+
+            typeBuilder.addMethod(MethodSpec.methodBuilder("createListModelLoader")
+                    .addAnnotation(Override.class)
+                    .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
+                    .addStatement("return new $T<>(getModelClass())", ClassNames.CACHEABLE_LIST_MODEL_LOADER)
+                    .returns(ClassNames.LIST_MODEL_LOADER).build());
+
             typeBuilder.addMethod(MethodSpec.methodBuilder("cachingEnabled")
                     .addAnnotation(Override.class)
                     .addModifiers(Modifier.PUBLIC, Modifier.FINAL)

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/SqlUtils.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/SqlUtils.java
@@ -52,6 +52,7 @@ public class SqlUtils {
      * @return a list of {@link ModelClass}
      */
     @SuppressWarnings("unchecked")
+    @Deprecated
     public static <ModelClass extends Model> List<ModelClass> queryList(Class<ModelClass> modelClass, String sql,
                                                                         String... args) {
         BaseDatabaseDefinition flowManager = FlowManager.getDatabaseForTable(modelClass);
@@ -81,6 +82,7 @@ public class SqlUtils {
      * @param <CacheableClass> The class that extends {@link Model} with {@link Table#cachingEnabled()}.
      * @return A {@link List} of {@link CacheableClass}.
      */
+    @Deprecated
     public static <CacheableClass extends Model> List<CacheableClass> convertToCacheableList(
             Class<CacheableClass> modelClass, Cursor cursor, ModelCache<CacheableClass, ?> modelCache) {
         final List<CacheableClass> entities = new ArrayList<>();
@@ -124,6 +126,7 @@ public class SqlUtils {
      * @param <CacheableClass> The class that extends {@link Model} with {@link Table#cachingEnabled()}.
      * @return A {@link List} of {@link CacheableClass}.
      */
+    @Deprecated
     public static <CacheableClass extends Model> List<CacheableClass> convertToCacheableList(
             Class<CacheableClass> modelClass, Cursor cursor) {
         return convertToCacheableList(modelClass, cursor, FlowManager.getModelAdapter(modelClass).getModelCache());
@@ -138,6 +141,7 @@ public class SqlUtils {
      * @return An non-null {@link List}
      */
     @SuppressWarnings("unchecked")
+    @Deprecated
     public static <ModelClass extends Model> List<ModelClass> convertToList(Class<ModelClass> table, Cursor cursor) {
         final List<ModelClass> entities = new ArrayList<>();
         InstanceAdapter modelAdapter = FlowManager.getInstanceAdapter(table);
@@ -168,6 +172,7 @@ public class SqlUtils {
      * @return A model transformed from the {@link Cursor}
      */
     @SuppressWarnings("unchecked")
+    @Deprecated
     public static <ModelClass extends Model> ModelClass convertToModel(boolean dontMoveToFirst, Class<ModelClass> table,
                                                                        Cursor cursor) {
         ModelClass model = null;
@@ -195,6 +200,7 @@ public class SqlUtils {
      * @return A model transformed from the {@link Cursor}
      */
     @SuppressWarnings("unchecked")
+    @Deprecated
     public static <ModelClass extends Model, ModelContainerClass extends ModelContainer<ModelClass, ?>>
     ModelContainerClass convertToModelContainer(boolean dontMoveToFirst, @NonNull Class<ModelClass> table,
                                                 @Nullable Cursor cursor, @NonNull ModelContainerClass modelContainer) {
@@ -224,6 +230,7 @@ public class SqlUtils {
      * @return A model transformed from the {@link Cursor}
      */
     @SuppressWarnings("unchecked")
+    @Deprecated
     public static <CacheableClass extends Model> CacheableClass convertToCacheableModel(
             boolean dontMoveToFirst, Class<CacheableClass> table, Cursor cursor) {
         CacheableClass model = null;
@@ -260,6 +267,7 @@ public class SqlUtils {
      * @return a single {@link ModelClass}
      */
     @SuppressWarnings("unchecked")
+    @Deprecated
     public static <ModelClass extends Model> ModelClass querySingle(Class<ModelClass> modelClass, String sql,
                                                                     String... args) {
         Cursor cursor = FlowManager.getDatabaseForTable(modelClass).getWritableDatabase().rawQuery(sql, args);

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/BaseModelQueriable.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/BaseModelQueriable.java
@@ -11,7 +11,9 @@ import com.raizlabs.android.dbflow.sql.SqlUtils;
 import com.raizlabs.android.dbflow.sql.queriable.AsyncQuery;
 import com.raizlabs.android.dbflow.sql.queriable.ModelQueriable;
 import com.raizlabs.android.dbflow.structure.BaseQueryModel;
+import com.raizlabs.android.dbflow.structure.InstanceAdapter;
 import com.raizlabs.android.dbflow.structure.Model;
+import com.raizlabs.android.dbflow.structure.RetrievalAdapter;
 import com.raizlabs.android.dbflow.structure.container.ModelContainer;
 
 import java.util.List;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/BaseModelQueriable.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/BaseModelQueriable.java
@@ -8,7 +8,6 @@ import com.raizlabs.android.dbflow.list.FlowCursorList;
 import com.raizlabs.android.dbflow.list.FlowQueryList;
 import com.raizlabs.android.dbflow.runtime.TransactionManager;
 import com.raizlabs.android.dbflow.sql.Query;
-import com.raizlabs.android.dbflow.sql.SqlUtils;
 import com.raizlabs.android.dbflow.sql.queriable.AsyncQuery;
 import com.raizlabs.android.dbflow.sql.queriable.ModelQueriable;
 import com.raizlabs.android.dbflow.structure.BaseQueryModel;
@@ -47,9 +46,10 @@ public abstract class BaseModelQueriable<ModelClass extends Model> implements Mo
         return retrievalAdapter.getSingleModelLoader().load(getQuery());
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public <ModelContainerClass extends ModelContainer<ModelClass, ?>> ModelContainerClass queryModelContainer(@NonNull ModelContainerClass instance) {
-        return SqlUtils.convertToModelContainer(false, table, query(), instance);
+        return (ModelContainerClass) FlowManager.getContainerAdapter(table).getModelContainerLoader().load(getQuery(), instance);
     }
 
     @Override

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/BaseModelQueriable.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/BaseModelQueriable.java
@@ -3,6 +3,7 @@ package com.raizlabs.android.dbflow.sql.language;
 import android.database.Cursor;
 import android.support.annotation.NonNull;
 
+import com.raizlabs.android.dbflow.config.FlowManager;
 import com.raizlabs.android.dbflow.list.FlowCursorList;
 import com.raizlabs.android.dbflow.list.FlowQueryList;
 import com.raizlabs.android.dbflow.runtime.TransactionManager;
@@ -13,7 +14,6 @@ import com.raizlabs.android.dbflow.sql.queriable.ModelQueriable;
 import com.raizlabs.android.dbflow.structure.BaseQueryModel;
 import com.raizlabs.android.dbflow.structure.InstanceAdapter;
 import com.raizlabs.android.dbflow.structure.Model;
-import com.raizlabs.android.dbflow.structure.RetrievalAdapter;
 import com.raizlabs.android.dbflow.structure.container.ModelContainer;
 
 import java.util.List;
@@ -24,6 +24,7 @@ import java.util.List;
 public abstract class BaseModelQueriable<ModelClass extends Model> implements ModelQueriable<ModelClass>, Query {
 
     private final Class<ModelClass> table;
+    private final InstanceAdapter<?, ModelClass> retrievalAdapter;
 
     /**
      * Constructs new instance of this class and is meant for subclasses only.
@@ -32,16 +33,18 @@ public abstract class BaseModelQueriable<ModelClass extends Model> implements Mo
      */
     protected BaseModelQueriable(Class<ModelClass> table) {
         this.table = table;
+        //noinspection unchecked
+        retrievalAdapter = FlowManager.getInstanceAdapter(table);
     }
 
     @Override
     public List<ModelClass> queryList() {
-        return SqlUtils.queryList(table, getQuery());
+        return retrievalAdapter.getListModelLoader().load(getQuery());
     }
 
     @Override
     public ModelClass querySingle() {
-        return SqlUtils.querySingle(table, getQuery());
+        return retrievalAdapter.getSingleModelLoader().load(getQuery());
     }
 
     @Override
@@ -71,12 +74,12 @@ public abstract class BaseModelQueriable<ModelClass extends Model> implements Mo
 
     @Override
     public <QueryClass extends BaseQueryModel> List<QueryClass> queryCustomList(Class<QueryClass> queryModelClass) {
-        return SqlUtils.queryList(queryModelClass, getQuery());
+        return FlowManager.getQueryModelAdapter(queryModelClass).getListModelLoader().load(getQuery());
     }
 
     @Override
     public <QueryClass extends BaseQueryModel> QueryClass queryCustomSingle(Class<QueryClass> queryModelClass) {
-        return SqlUtils.querySingle(queryModelClass, getQuery());
+        return FlowManager.getQueryModelAdapter(queryModelClass).getSingleModelLoader().load(getQuery());
     }
 
     @Override

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/queriable/CacheableListModelLoader.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/queriable/CacheableListModelLoader.java
@@ -1,0 +1,63 @@
+package com.raizlabs.android.dbflow.sql.queriable;
+
+import android.database.Cursor;
+import android.support.annotation.NonNull;
+
+import com.raizlabs.android.dbflow.annotation.Table;
+import com.raizlabs.android.dbflow.structure.Model;
+import com.raizlabs.android.dbflow.structure.ModelAdapter;
+import com.raizlabs.android.dbflow.structure.cache.ModelCache;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Description: Loads a {@link List} of {@link TModel} with {@link Table#cachingEnabled()} true.
+ */
+public class CacheableListModelLoader<TModel extends Model> extends ListModelLoader<TModel> {
+
+    private ModelAdapter<TModel> modelAdapter;
+    private ModelCache<TModel, ?> modelCache;
+
+    public CacheableListModelLoader(Class<TModel> modelClass) {
+        super(modelClass);
+
+        if (!(getInstanceAdapter() instanceof ModelAdapter)) {
+            throw new IllegalArgumentException("A non-Table type was used.");
+        }
+        //noinspection unchecked
+        modelAdapter = (ModelAdapter<TModel>) getInstanceAdapter();
+        modelCache = modelAdapter.getModelCache();
+
+        if (!modelAdapter.cachingEnabled()) {
+            throw new IllegalArgumentException("You cannot call this method for a table that has no caching id. Either" +
+                    "use one Primary Key or call convertToList()");
+        } else if (modelCache == null) {
+            throw new IllegalArgumentException("ModelCache specified in convertToCacheableList() must not be null.");
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    protected List<TModel> convertToData(@NonNull Cursor cursor) {
+        final List<TModel> modelList = new ArrayList<>();
+        Object[] cacheValues = new Object[modelAdapter.getCachingColumns().length];
+        // Ensure that we aren't iterating over this cursor concurrently from different threads
+        if (cursor.moveToFirst()) {
+            do {
+                Object[] values = modelAdapter.getCachingColumnValuesFromCursor(cacheValues, cursor);
+                TModel model = modelCache.get(modelAdapter.getCachingId(values));
+                if (model != null) {
+                    modelAdapter.reloadRelationships(model, cursor);
+                    modelList.add(model);
+                } else {
+                    model = modelAdapter.newInstance();
+                    modelAdapter.loadFromCursor(cursor, model);
+                    modelList.add(model);
+                }
+            } while (cursor.moveToNext());
+        }
+        return modelList;
+    }
+
+}

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/queriable/CacheableModelLoader.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/queriable/CacheableModelLoader.java
@@ -26,16 +26,27 @@ public class CacheableModelLoader<TModel extends Model> extends SingleModelLoade
         modelAdapter = (ModelAdapter<TModel>) getInstanceAdapter();
     }
 
+    /**
+     * Converts data by loading from cache based on its sequence of caching ids. Will reuse the passed
+     * {@link TModel} if it's not found in the cache and non-null.
+     *
+     * @return A model from cache.
+     */
     @Nullable
     @Override
-    protected TModel convertToData(@NonNull Cursor cursor) {
+    protected TModel convertToData(@NonNull Cursor cursor, @Nullable TModel data) {
         ModelCache<TModel, ?> modelCache = modelAdapter.getModelCache();
         Object[] values = modelAdapter.getCachingColumnValuesFromCursor(
                 new Object[modelAdapter.getCachingColumns().length], cursor);
         TModel model = modelCache.get(modelAdapter.getCachingId(values));
         if (model == null) {
-            model = modelAdapter.newInstance();
+            if (data == null) {
+                model = modelAdapter.newInstance();
+            } else {
+                model = data;
+            }
             modelAdapter.loadFromCursor(cursor, model);
+            modelCache.addModel(modelAdapter.getCachingId(values), model);
         } else {
             modelAdapter.reloadRelationships(model, cursor);
         }

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/queriable/CacheableModelLoader.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/queriable/CacheableModelLoader.java
@@ -35,21 +35,25 @@ public class CacheableModelLoader<TModel extends Model> extends SingleModelLoade
     @Nullable
     @Override
     protected TModel convertToData(@NonNull Cursor cursor, @Nullable TModel data) {
-        ModelCache<TModel, ?> modelCache = modelAdapter.getModelCache();
-        Object[] values = modelAdapter.getCachingColumnValuesFromCursor(
-                new Object[modelAdapter.getCachingColumns().length], cursor);
-        TModel model = modelCache.get(modelAdapter.getCachingId(values));
-        if (model == null) {
-            if (data == null) {
-                model = modelAdapter.newInstance();
+        if (cursor.moveToFirst()) {
+            ModelCache<TModel, ?> modelCache = modelAdapter.getModelCache();
+            Object[] values = modelAdapter.getCachingColumnValuesFromCursor(
+                    new Object[modelAdapter.getCachingColumns().length], cursor);
+            TModel model = modelCache.get(modelAdapter.getCachingId(values));
+            if (model == null) {
+                if (data == null) {
+                    model = modelAdapter.newInstance();
+                } else {
+                    model = data;
+                }
+                modelAdapter.loadFromCursor(cursor, model);
+                modelCache.addModel(modelAdapter.getCachingId(values), model);
             } else {
-                model = data;
+                modelAdapter.reloadRelationships(model, cursor);
             }
-            modelAdapter.loadFromCursor(cursor, model);
-            modelCache.addModel(modelAdapter.getCachingId(values), model);
+            return model;
         } else {
-            modelAdapter.reloadRelationships(model, cursor);
+            return null;
         }
-        return model;
     }
 }

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/queriable/CacheableModelLoader.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/queriable/CacheableModelLoader.java
@@ -1,0 +1,44 @@
+package com.raizlabs.android.dbflow.sql.queriable;
+
+import android.database.Cursor;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import com.raizlabs.android.dbflow.annotation.Table;
+import com.raizlabs.android.dbflow.structure.Model;
+import com.raizlabs.android.dbflow.structure.ModelAdapter;
+import com.raizlabs.android.dbflow.structure.cache.ModelCache;
+
+/**
+ * Description: Loads model data that is backed by a {@link ModelCache}. Used when {@link Table#cachingEnabled()}
+ * is true.
+ */
+public class CacheableModelLoader<TModel extends Model> extends SingleModelLoader<TModel> {
+
+    private ModelAdapter<TModel> modelAdapter;
+
+    public CacheableModelLoader(Class<TModel> modelClass) {
+        super(modelClass);
+        if (!(getInstanceAdapter() instanceof ModelAdapter)) {
+            throw new IllegalArgumentException("A non-Table type was used.");
+        }
+        //noinspection unchecked
+        modelAdapter = (ModelAdapter<TModel>) getInstanceAdapter();
+    }
+
+    @Nullable
+    @Override
+    protected TModel convertToData(@NonNull Cursor cursor) {
+        ModelCache<TModel, ?> modelCache = modelAdapter.getModelCache();
+        Object[] values = modelAdapter.getCachingColumnValuesFromCursor(
+                new Object[modelAdapter.getCachingColumns().length], cursor);
+        TModel model = modelCache.get(modelAdapter.getCachingId(values));
+        if (model == null) {
+            model = modelAdapter.newInstance();
+            modelAdapter.loadFromCursor(cursor, model);
+        } else {
+            modelAdapter.reloadRelationships(model, cursor);
+        }
+        return model;
+    }
+}

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/queriable/ListModelLoader.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/queriable/ListModelLoader.java
@@ -2,6 +2,7 @@ package com.raizlabs.android.dbflow.sql.queriable;
 
 import android.database.Cursor;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 
 import com.raizlabs.android.dbflow.structure.Model;
 
@@ -19,15 +20,20 @@ public class ListModelLoader<TModel extends Model> extends ModelLoader<TModel, L
 
     @SuppressWarnings("unchecked")
     @Override
-    protected List<TModel> convertToData(@NonNull Cursor cursor) {
-        final List<TModel> modelList = new ArrayList<>();
+    protected List<TModel> convertToData(@NonNull Cursor cursor, @Nullable List<TModel> data) {
+        if (data == null) {
+            data = new ArrayList<>();
+        } else {
+            data.clear();
+        }
+
         if (cursor.moveToFirst()) {
             do {
                 TModel model = (TModel) getInstanceAdapter().newInstance();
                 getInstanceAdapter().loadFromCursor(cursor, model);
-                modelList.add(model);
+                data.add(model);
             } while (cursor.moveToNext());
         }
-        return modelList;
+        return data;
     }
 }

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/queriable/ListModelLoader.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/queriable/ListModelLoader.java
@@ -1,0 +1,33 @@
+package com.raizlabs.android.dbflow.sql.queriable;
+
+import android.database.Cursor;
+import android.support.annotation.NonNull;
+
+import com.raizlabs.android.dbflow.structure.Model;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Description: Loads a {@link List} of {@link TModel}.
+ */
+public class ListModelLoader<TModel extends Model> extends ModelLoader<TModel, List<TModel>> {
+
+    public ListModelLoader(Class<TModel> modelClass) {
+        super(modelClass);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    protected List<TModel> convertToData(@NonNull Cursor cursor) {
+        final List<TModel> modelList = new ArrayList<>();
+        if (cursor.moveToFirst()) {
+            do {
+                TModel model = (TModel) getInstanceAdapter().newInstance();
+                getInstanceAdapter().loadFromCursor(cursor, model);
+                modelList.add(model);
+            } while (cursor.moveToNext());
+        }
+        return modelList;
+    }
+}

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/queriable/ModelContainerLoader.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/queriable/ModelContainerLoader.java
@@ -14,7 +14,7 @@ import com.raizlabs.android.dbflow.structure.container.ModelContainerAdapter;
  * Description: loads data into a {@link ModelContainer}. Only works when the passed {@link ModelContainer} is non-null,
  * since we don't know the type of object to create or return.
  */
-public class ModelContainerLoader<TModelContainer extends ModelContainer<TModel, ?>, TModel extends Model> extends ModelLoader<TModel, ModelContainer<TModel, ?>> {
+public class ModelContainerLoader<TModel extends Model> extends ModelLoader<TModel, ModelContainer<TModel, ?>> {
 
     private ModelContainerAdapter<TModel> modelContainerAdapter;
 

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/queriable/ModelContainerLoader.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/queriable/ModelContainerLoader.java
@@ -1,0 +1,40 @@
+
+package com.raizlabs.android.dbflow.sql.queriable;
+
+import android.database.Cursor;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import com.raizlabs.android.dbflow.config.FlowManager;
+import com.raizlabs.android.dbflow.structure.Model;
+import com.raizlabs.android.dbflow.structure.container.ModelContainer;
+import com.raizlabs.android.dbflow.structure.container.ModelContainerAdapter;
+
+/**
+ * Description: loads data into a {@link ModelContainer}. Only works when the passed {@link ModelContainer} is non-null,
+ * since we don't know the type of object to create or return.
+ */
+public class ModelContainerLoader<TModelContainer extends ModelContainer<TModel, ?>, TModel extends Model> extends ModelLoader<TModel, ModelContainer<TModel, ?>> {
+
+    private ModelContainerAdapter<TModel> modelContainerAdapter;
+
+    public ModelContainerLoader(Class<TModel> modelClass) {
+        super(modelClass);
+        modelContainerAdapter = FlowManager.getContainerAdapter(modelClass);
+    }
+
+    @Override
+    protected ModelContainer<TModel, ?> convertToData(@NonNull Cursor cursor, @Nullable ModelContainer<TModel, ?> data) {
+        if (data != null) {
+            if (cursor.moveToFirst()) {
+                modelContainerAdapter.loadFromCursor(cursor, data);
+            }
+            return data;
+        } else {
+            return null;
+        }
+
+    }
+
+
+}

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/queriable/ModelLoader.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/queriable/ModelLoader.java
@@ -34,11 +34,15 @@ public abstract class ModelLoader<TModel extends Model, TReturn> {
      */
     @Nullable
     public TReturn load(String query) {
+        return load(query, null);
+    }
+
+    @Nullable
+    public TReturn load(String query, @Nullable TReturn data) {
         final Cursor cursor = databaseDefinition.getWritableDatabase().rawQuery(query, null);
-        TReturn data = null;
         if (cursor != null) {
             try {
-                data = convertToData(cursor);
+                data = convertToData(cursor, data);
             } finally {
                 cursor.close();
             }
@@ -55,5 +59,9 @@ public abstract class ModelLoader<TModel extends Model, TReturn> {
         return instanceAdapter;
     }
 
-    protected abstract TReturn convertToData(@NonNull final Cursor cursor);
+    public BaseDatabaseDefinition getDatabaseDefinition() {
+        return databaseDefinition;
+    }
+
+    protected abstract TReturn convertToData(@NonNull final Cursor cursor, @Nullable TReturn data);
 }

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/queriable/ModelLoader.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/queriable/ModelLoader.java
@@ -63,5 +63,13 @@ public abstract class ModelLoader<TModel extends Model, TReturn> {
         return databaseDefinition;
     }
 
+    /**
+     * Specify how to convert the {@link Cursor} data into a {@link TReturn}. Can be null.
+     *
+     * @param cursor The cursor resulting from a query passed into {@link #load(String)}
+     * @param data   The data (if not null) that we can reuse without need to create new object.
+     * @return A new (or reused) instance that represents the {@link Cursor}.
+     */
+    @Nullable
     protected abstract TReturn convertToData(@NonNull final Cursor cursor, @Nullable TReturn data);
 }

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/queriable/ModelLoader.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/queriable/ModelLoader.java
@@ -1,0 +1,59 @@
+package com.raizlabs.android.dbflow.sql.queriable;
+
+import android.database.Cursor;
+import android.database.sqlite.SQLiteDatabase;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import com.raizlabs.android.dbflow.config.BaseDatabaseDefinition;
+import com.raizlabs.android.dbflow.config.FlowManager;
+import com.raizlabs.android.dbflow.structure.InstanceAdapter;
+import com.raizlabs.android.dbflow.structure.Model;
+
+/**
+ * Description: Represents how models load from DB. It will query a {@link SQLiteDatabase}
+ * and query for a {@link Cursor}. Then the cursor is used to convert itself into an object.
+ */
+public abstract class ModelLoader<TModel extends Model, TReturn> {
+
+    private final Class<TModel> modelClass;
+    private final BaseDatabaseDefinition databaseDefinition;
+    private InstanceAdapter instanceAdapter;
+
+    public ModelLoader(Class<TModel> modelClass) {
+        this.modelClass = modelClass;
+        databaseDefinition = FlowManager.getDatabaseForTable(modelClass);
+        instanceAdapter = FlowManager.getInstanceAdapter(modelClass);
+    }
+
+    /**
+     * Loads the data from a query and returns it as a {@link TReturn}.
+     *
+     * @param query The query to call.
+     * @return The data loaded from the database.
+     */
+    @Nullable
+    public TReturn load(String query) {
+        final Cursor cursor = databaseDefinition.getWritableDatabase().rawQuery(query, null);
+        TReturn data = null;
+        if (cursor != null) {
+            try {
+                data = convertToData(cursor);
+            } finally {
+                cursor.close();
+            }
+        }
+        return data;
+    }
+
+    public Class<TModel> getModelClass() {
+        return modelClass;
+    }
+
+    @NonNull
+    public InstanceAdapter getInstanceAdapter() {
+        return instanceAdapter;
+    }
+
+    protected abstract TReturn convertToData(@NonNull final Cursor cursor);
+}

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/queriable/SingleModelLoader.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/queriable/SingleModelLoader.java
@@ -18,12 +18,13 @@ public class SingleModelLoader<TModel extends Model> extends ModelLoader<TModel,
     @SuppressWarnings("unchecked")
     @Override
     @Nullable
-    protected TModel convertToData(@NonNull final Cursor cursor) {
-        TModel model = null;
+    protected TModel convertToData(@NonNull final Cursor cursor, @Nullable TModel data) {
         if (cursor.moveToFirst()) {
-            model = (TModel) getInstanceAdapter().newInstance();
-            getInstanceAdapter().loadFromCursor(cursor, model);
+            if (data == null) {
+                data = (TModel) getInstanceAdapter().newInstance();
+            }
+            getInstanceAdapter().loadFromCursor(cursor, data);
         }
-        return model;
+        return data;
     }
 }

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/queriable/SingleModelLoader.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/queriable/SingleModelLoader.java
@@ -1,0 +1,29 @@
+package com.raizlabs.android.dbflow.sql.queriable;
+
+import android.database.Cursor;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import com.raizlabs.android.dbflow.structure.Model;
+
+/**
+ * Description: Responsible for loading data into a single object.
+ */
+public class SingleModelLoader<TModel extends Model> extends ModelLoader<TModel, TModel> {
+
+    public SingleModelLoader(Class<TModel> modelClass) {
+        super(modelClass);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    @Nullable
+    protected TModel convertToData(@NonNull final Cursor cursor) {
+        TModel model = null;
+        if (cursor.moveToFirst()) {
+            model = (TModel) getInstanceAdapter().newInstance();
+            getInstanceAdapter().loadFromCursor(cursor, model);
+        }
+        return model;
+    }
+}

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/InstanceAdapter.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/InstanceAdapter.java
@@ -3,8 +3,8 @@ package com.raizlabs.android.dbflow.structure;
 /**
  * Description: Provides a {@link #newInstance()} method to a {@link RetrievalAdapter}
  */
-public abstract class InstanceAdapter<ModelClass extends Model>
-        extends RetrievalAdapter<ModelClass> {
+public abstract class InstanceAdapter<ModelClass extends Model, TableClass extends Model>
+        extends RetrievalAdapter<ModelClass, TableClass> {
 
     /**
      * @return A new model using its default constructor. This is why default is required so that

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/InstanceAdapter.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/InstanceAdapter.java
@@ -3,12 +3,12 @@ package com.raizlabs.android.dbflow.structure;
 /**
  * Description: Provides a {@link #newInstance()} method to a {@link RetrievalAdapter}
  */
-public interface InstanceAdapter<TableClass extends Model, ModelClass extends Model>
-        extends RetrievalAdapter<TableClass, ModelClass> {
+public abstract class InstanceAdapter<ModelClass extends Model>
+        extends RetrievalAdapter<ModelClass> {
 
     /**
      * @return A new model using its default constructor. This is why default is required so that
      * we don't use reflection to create objects = faster.
      */
-    ModelClass newInstance();
+    public abstract ModelClass newInstance();
 }

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/InternalAdapter.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/InternalAdapter.java
@@ -14,11 +14,6 @@ import com.raizlabs.android.dbflow.structure.container.ModelContainerAdapter;
 public interface InternalAdapter<TableClass extends Model, ModelClass extends Model> {
 
     /**
-     * @return the model class this adapter corresponds to
-     */
-    Class<TableClass> getModelClass();
-
-    /**
      * @return The table name of this adapter.
      */
     String getTableName();

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/ModelAdapter.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/ModelAdapter.java
@@ -18,7 +18,7 @@ import com.raizlabs.android.dbflow.structure.cache.SimpleMapCache;
  * Author: andrewgrosner
  * Description: Internal adapter that gets extended when a {@link Table} gets used.
  */
-public abstract class ModelAdapter<ModelClass extends Model> extends InstanceAdapter<ModelClass>
+public abstract class ModelAdapter<ModelClass extends Model> extends InstanceAdapter<ModelClass, ModelClass>
         implements InternalAdapter<ModelClass, ModelClass> {
 
     private SQLiteStatement mInsertStatement;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/ModelAdapter.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/ModelAdapter.java
@@ -18,8 +18,8 @@ import com.raizlabs.android.dbflow.structure.cache.SimpleMapCache;
  * Author: andrewgrosner
  * Description: Internal adapter that gets extended when a {@link Table} gets used.
  */
-public abstract class ModelAdapter<ModelClass extends Model>
-        implements InternalAdapter<ModelClass, ModelClass>, InstanceAdapter<ModelClass, ModelClass> {
+public abstract class ModelAdapter<ModelClass extends Model> extends InstanceAdapter<ModelClass>
+        implements InternalAdapter<ModelClass, ModelClass> {
 
     private SQLiteStatement mInsertStatement;
     private String[] cachingColumns;
@@ -222,6 +222,7 @@ public abstract class ModelAdapter<ModelClass extends Model>
     public ModelCache<ModelClass, ?> createModelCache() {
         return new SimpleMapCache<>(getCacheSize());
     }
+
 
     /**
      * @return The query used to create this table.

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/ModelViewAdapter.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/ModelViewAdapter.java
@@ -6,7 +6,7 @@ import android.database.Cursor;
  * Description: The base class for a {@link ModelViewClass} adapter that defines how it interacts with the DB.
  */
 public abstract class ModelViewAdapter<ModelClass extends Model, ModelViewClass extends BaseModelView<ModelClass>>
-        implements InstanceAdapter<ModelViewClass, ModelViewClass> {
+        extends InstanceAdapter<ModelViewClass> {
 
     /**
      * Creates a new {@link ModelViewClass} and loads the cursor into it.

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/ModelViewAdapter.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/ModelViewAdapter.java
@@ -6,7 +6,7 @@ import android.database.Cursor;
  * Description: The base class for a {@link ModelViewClass} adapter that defines how it interacts with the DB.
  */
 public abstract class ModelViewAdapter<ModelClass extends Model, ModelViewClass extends BaseModelView<ModelClass>>
-        extends InstanceAdapter<ModelViewClass> {
+        extends InstanceAdapter<ModelViewClass, ModelViewClass> {
 
     /**
      * Creates a new {@link ModelViewClass} and loads the cursor into it.

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/QueryModelAdapter.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/QueryModelAdapter.java
@@ -7,7 +7,7 @@ import com.raizlabs.android.dbflow.sql.language.ConditionGroup;
  * Description: The baseclass for adapters to {@link QueryModel} that defines how it interacts with the DB. The
  * where query is not defined here, rather its determined by the query used.
  */
-public abstract class QueryModelAdapter<ModelClass extends Model> implements InstanceAdapter<ModelClass, ModelClass> {
+public abstract class QueryModelAdapter<ModelClass extends Model> extends InstanceAdapter<ModelClass> {
 
     @Override
     public ConditionGroup getPrimaryConditionClause(ModelClass model) {

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/QueryModelAdapter.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/QueryModelAdapter.java
@@ -7,7 +7,7 @@ import com.raizlabs.android.dbflow.sql.language.ConditionGroup;
  * Description: The baseclass for adapters to {@link QueryModel} that defines how it interacts with the DB. The
  * where query is not defined here, rather its determined by the query used.
  */
-public abstract class QueryModelAdapter<ModelClass extends Model> extends InstanceAdapter<ModelClass> {
+public abstract class QueryModelAdapter<ModelClass extends Model> extends InstanceAdapter<ModelClass, ModelClass> {
 
     @Override
     public ConditionGroup getPrimaryConditionClause(ModelClass model) {

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/RetrievalAdapter.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/RetrievalAdapter.java
@@ -10,10 +10,10 @@ import com.raizlabs.android.dbflow.sql.queriable.SingleModelLoader;
  * Description: Provides a base retrieval class for all {@link Model} backed
  * adapters.
  */
-public abstract class RetrievalAdapter<ModelClass extends Model> {
+public abstract class RetrievalAdapter<ModelClass extends Model, TableClass extends Model> {
 
-    private SingleModelLoader<ModelClass> singleModelLoader;
-    private ListModelLoader<ModelClass> listModelLoader;
+    private SingleModelLoader<TableClass> singleModelLoader;
+    private ListModelLoader<TableClass> listModelLoader;
 
     /**
      * Assigns the {@link android.database.Cursor} data into the specified {@link ModelClass}
@@ -38,28 +38,28 @@ public abstract class RetrievalAdapter<ModelClass extends Model> {
     /**
      * @return the model class this adapter corresponds to
      */
-    public abstract Class<ModelClass> getModelClass();
+    public abstract Class<TableClass> getModelClass();
 
 
-    public ListModelLoader<ModelClass> getListModelLoader() {
+    public ListModelLoader<TableClass> getListModelLoader() {
         if (listModelLoader == null) {
             listModelLoader = createListModelLoader();
         }
         return listModelLoader;
     }
 
-    protected ListModelLoader<ModelClass> createListModelLoader() {
+    protected ListModelLoader<TableClass> createListModelLoader() {
         return new ListModelLoader<>(getModelClass());
     }
 
-    public SingleModelLoader<ModelClass> getSingleModelLoader() {
+    public SingleModelLoader<TableClass> getSingleModelLoader() {
         if (singleModelLoader == null) {
             singleModelLoader = createSingleModelLoader();
         }
         return singleModelLoader;
     }
 
-    protected SingleModelLoader<ModelClass> createSingleModelLoader() {
+    protected SingleModelLoader<TableClass> createSingleModelLoader() {
         return new SingleModelLoader<>(getModelClass());
     }
 }

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/RetrievalAdapter.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/RetrievalAdapter.java
@@ -1,6 +1,7 @@
 package com.raizlabs.android.dbflow.structure;
 
 import android.database.Cursor;
+import android.support.annotation.NonNull;
 
 import com.raizlabs.android.dbflow.sql.language.ConditionGroup;
 import com.raizlabs.android.dbflow.sql.queriable.ListModelLoader;
@@ -57,6 +58,26 @@ public abstract class RetrievalAdapter<ModelClass extends Model, TableClass exte
             singleModelLoader = createSingleModelLoader();
         }
         return singleModelLoader;
+    }
+
+    /**
+     * Overrides the default implementation and allows you to provide your own implementation. Defines
+     * how a single {@link TableClass} is loaded.
+     *
+     * @param singleModelLoader The loader to use.
+     */
+    public void setSingleModelLoader(@NonNull SingleModelLoader<TableClass> singleModelLoader) {
+        this.singleModelLoader = singleModelLoader;
+    }
+
+    /**
+     * Overrides the default implementation and allows you to provide your own implementation. Defines
+     * how a list of {@link TableClass} are loaded.
+     *
+     * @param listModelLoader The loader to use.
+     */
+    public void setListModelLoader(@NonNull ListModelLoader<TableClass> listModelLoader) {
+        this.listModelLoader = listModelLoader;
     }
 
     protected SingleModelLoader<TableClass> createSingleModelLoader() {

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/RetrievalAdapter.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/RetrievalAdapter.java
@@ -3,12 +3,17 @@ package com.raizlabs.android.dbflow.structure;
 import android.database.Cursor;
 
 import com.raizlabs.android.dbflow.sql.language.ConditionGroup;
+import com.raizlabs.android.dbflow.sql.queriable.ListModelLoader;
+import com.raizlabs.android.dbflow.sql.queriable.SingleModelLoader;
 
 /**
- * Description: Provides a base retrieval interface for all {@link Model} backed
+ * Description: Provides a base retrieval class for all {@link Model} backed
  * adapters.
  */
-public interface RetrievalAdapter<TableClass extends Model, ModelClass extends Model> {
+public abstract class RetrievalAdapter<ModelClass extends Model> {
+
+    private SingleModelLoader<ModelClass> singleModelLoader;
+    private ListModelLoader<ModelClass> listModelLoader;
 
     /**
      * Assigns the {@link android.database.Cursor} data into the specified {@link ModelClass}
@@ -16,18 +21,45 @@ public interface RetrievalAdapter<TableClass extends Model, ModelClass extends M
      * @param model  The model to assign cursor data to
      * @param cursor The cursor to load into the model
      */
-    void loadFromCursor(Cursor cursor, ModelClass model);
+    public abstract void loadFromCursor(Cursor cursor, ModelClass model);
 
     /**
      * @param model The model to query values from
      * @return True if it exists as VIEW row in the database table
      */
-    boolean exists(ModelClass model);
+    public abstract boolean exists(ModelClass model);
 
     /**
-     * @param model
+     * @param model The primary condition clause.
      * @return The clause that contains necessary
      */
-    ConditionGroup getPrimaryConditionClause(ModelClass model);
+    public abstract ConditionGroup getPrimaryConditionClause(ModelClass model);
 
+    /**
+     * @return the model class this adapter corresponds to
+     */
+    public abstract Class<ModelClass> getModelClass();
+
+
+    public ListModelLoader<ModelClass> getListModelLoader() {
+        if (listModelLoader == null) {
+            listModelLoader = createListModelLoader();
+        }
+        return listModelLoader;
+    }
+
+    protected ListModelLoader<ModelClass> createListModelLoader() {
+        return new ListModelLoader<>(getModelClass());
+    }
+
+    public SingleModelLoader<ModelClass> getSingleModelLoader() {
+        if (singleModelLoader == null) {
+            singleModelLoader = createSingleModelLoader();
+        }
+        return singleModelLoader;
+    }
+
+    protected SingleModelLoader<ModelClass> createSingleModelLoader() {
+        return new SingleModelLoader<>(getModelClass());
+    }
 }

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/container/ModelContainerAdapter.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/container/ModelContainerAdapter.java
@@ -19,7 +19,7 @@ import java.util.Map;
  */
 public abstract class ModelContainerAdapter<ModelClass extends Model> extends RetrievalAdapter<ModelContainer<ModelClass, ?>, ModelClass> implements InternalAdapter<ModelClass, ModelContainer<ModelClass, ?>> {
 
-    private ModelContainerLoader<ModelContainer<ModelClass, ?>, ModelClass> modelContainerLoader;
+    private ModelContainerLoader<ModelClass> modelContainerLoader;
 
     protected final Map<String, Class> columnMap = new HashMap<>();
 
@@ -125,14 +125,14 @@ public abstract class ModelContainerAdapter<ModelClass extends Model> extends Re
         return columnMap.get(columnName);
     }
 
-    public ModelContainerLoader<ModelContainer<ModelClass, ?>, ModelClass> getModelContainerLoader() {
+    public ModelContainerLoader<ModelClass> getModelContainerLoader() {
         if (modelContainerLoader == null) {
             modelContainerLoader = createModelContainerLoader();
         }
         return modelContainerLoader;
     }
 
-    protected ModelContainerLoader<ModelContainer<ModelClass, ?>, ModelClass> createModelContainerLoader() {
+    protected ModelContainerLoader<ModelClass> createModelContainerLoader() {
         return new ModelContainerLoader<>(getModelClass());
     }
 }

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/container/ModelContainerAdapter.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/container/ModelContainerAdapter.java
@@ -16,7 +16,7 @@ import java.util.Map;
  * Description: The base class that generated {@link ModelContainerAdapter} implement
  * to provide the necessary interactions.
  */
-public abstract class ModelContainerAdapter<ModelClass extends Model> extends RetrievalAdapter<ModelContainer<ModelClass, ?>> implements InternalAdapter<ModelClass, ModelContainer<ModelClass, ?>> {
+public abstract class ModelContainerAdapter<ModelClass extends Model> extends RetrievalAdapter<ModelContainer<ModelClass, ?>, ModelClass> implements InternalAdapter<ModelClass, ModelContainer<ModelClass, ?>> {
 
     protected final Map<String, Class> columnMap = new HashMap<>();
 

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/container/ModelContainerAdapter.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/container/ModelContainerAdapter.java
@@ -1,6 +1,5 @@
 package com.raizlabs.android.dbflow.structure.container;
 
-import android.database.Cursor;
 import android.database.sqlite.SQLiteStatement;
 import android.support.annotation.NonNull;
 
@@ -17,7 +16,7 @@ import java.util.Map;
  * Description: The base class that generated {@link ModelContainerAdapter} implement
  * to provide the necessary interactions.
  */
-public abstract class ModelContainerAdapter<ModelClass extends Model> implements InternalAdapter<ModelClass, ModelContainer<ModelClass, ?>>, RetrievalAdapter<ModelClass, ModelContainer<ModelClass, ?>> {
+public abstract class ModelContainerAdapter<ModelClass extends Model> extends RetrievalAdapter<ModelContainer<ModelClass, ?>> implements InternalAdapter<ModelClass, ModelContainer<ModelClass, ?>> {
 
     protected final Map<String, Class> columnMap = new HashMap<>();
 

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/container/ModelContainerAdapter.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/container/ModelContainerAdapter.java
@@ -1,5 +1,6 @@
 package com.raizlabs.android.dbflow.structure.container;
 
+import android.database.Cursor;
 import android.database.sqlite.SQLiteStatement;
 import android.support.annotation.NonNull;
 
@@ -134,5 +135,14 @@ public abstract class ModelContainerAdapter<ModelClass extends Model> extends Re
 
     protected ModelContainerLoader<ModelClass> createModelContainerLoader() {
         return new ModelContainerLoader<>(getModelClass());
+    }
+
+    /**
+     * Override the {@link ModelContainerLoader} with your own implementation (if necessary).
+     *
+     * @param modelContainerLoader The loader used to load {@link Cursor} data into a {@link ModelContainer}.
+     */
+    public void setModelContainerLoader(ModelContainerLoader<ModelClass> modelContainerLoader) {
+        this.modelContainerLoader = modelContainerLoader;
     }
 }

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/container/ModelContainerAdapter.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/container/ModelContainerAdapter.java
@@ -5,6 +5,7 @@ import android.support.annotation.NonNull;
 
 import com.raizlabs.android.dbflow.annotation.PrimaryKey;
 import com.raizlabs.android.dbflow.sql.SqlUtils;
+import com.raizlabs.android.dbflow.sql.queriable.ModelContainerLoader;
 import com.raizlabs.android.dbflow.structure.InternalAdapter;
 import com.raizlabs.android.dbflow.structure.Model;
 import com.raizlabs.android.dbflow.structure.RetrievalAdapter;
@@ -17,6 +18,8 @@ import java.util.Map;
  * to provide the necessary interactions.
  */
 public abstract class ModelContainerAdapter<ModelClass extends Model> extends RetrievalAdapter<ModelContainer<ModelClass, ?>, ModelClass> implements InternalAdapter<ModelClass, ModelContainer<ModelClass, ?>> {
+
+    private ModelContainerLoader<ModelContainer<ModelClass, ?>, ModelClass> modelContainerLoader;
 
     protected final Map<String, Class> columnMap = new HashMap<>();
 
@@ -122,4 +125,14 @@ public abstract class ModelContainerAdapter<ModelClass extends Model> extends Re
         return columnMap.get(columnName);
     }
 
+    public ModelContainerLoader<ModelContainer<ModelClass, ?>, ModelClass> getModelContainerLoader() {
+        if (modelContainerLoader == null) {
+            modelContainerLoader = createModelContainerLoader();
+        }
+        return modelContainerLoader;
+    }
+
+    protected ModelContainerLoader<ModelContainer<ModelClass, ?>, ModelClass> createModelContainerLoader() {
+        return new ModelContainerLoader<>(getModelClass());
+    }
 }


### PR DESCRIPTION
1. Allow you to override/specify custom `Model` loaders from the database. They run the specified query string and convert that into a `Model` representation.
2. Specify custom one via `FlowManager.getModelAdapter(table).setSingleModelLoader()` or `FlowManager.getModelAdapter(table).setListModelLoader()`
3. Deprecates the conversion methods in `SqlUtils`
4. Also overrides for cacheable loading, so no longer needs to check if `Model` has caching or not at runtime.
5. Also creates one for `ModelContainerLoader` so you can customize a way to load `ModelContainer` out of the database if needed.