### PR TITLE
Fix generated Provider getDatabaseName() 

### DIFF
--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/ContentProviderDefinition.java
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/ContentProviderDefinition.java
@@ -130,7 +130,7 @@ public class ContentProviderDefinition extends BaseDefinition {
         typeBuilder.addMethod(MethodSpec.methodBuilder("getDatabaseName")
                 .addAnnotation(Override.class)
                 .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
-                .addStatement("return $S", databaseName)
+                .addStatement("return $S", databaseNameString)
                 .returns(ClassName.get(String.class)).build());
 
         MethodSpec.Builder getTypeBuilder = MethodSpec.methodBuilder("getType")


### PR DESCRIPTION
When generating the Provider, the field containing the full class name is used instead of the one extracted from DatabaseDefinition. This is preventing ContentProviders to work, since they look for a database name that does not exist.