### PR TITLE
Fix generation of FK insert statements with related model with auto increment key

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.5.0-beta1'
+        classpath 'com.android.tools.build:gradle:1.5.0'
         classpath 'com.neenbedankt.gradle.plugins:android-apt:1.7'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.1'
     }

--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/column/ForeignKeyColumnDefinition.java
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/column/ForeignKeyColumnDefinition.java
@@ -227,6 +227,11 @@ public class ForeignKeyColumnDefinition extends ColumnDefinition {
                             ModelUtils.getVariable(isModelContainerAdapter), isModelContainerAdapter, true);
             String finalAccessStatement = getFinalAccessStatement(builder, isModelContainerAdapter, statement);
             builder.beginControlFlow("if ($L != null)", finalAccessStatement);
+
+            if (saveForeignKeyModel) {
+                builder.addStatement("$L.save()", finalAccessStatement);
+            }
+
             CodeBlock.Builder elseBuilder = CodeBlock.builder();
             for (int i = 0; i < foreignKeyReferenceDefinitionList.size(); i++) {
                 if (i > 0) {
@@ -235,10 +240,6 @@ public class ForeignKeyColumnDefinition extends ColumnDefinition {
                 ForeignKeyReferenceDefinition referenceDefinition = foreignKeyReferenceDefinitionList.get(i);
                 builder.add(referenceDefinition.getSQLiteStatementMethod(index, isModelContainerAdapter));
                 elseBuilder.addStatement("$L.bindNull($L)", BindToStatementMethod.PARAM_STATEMENT, index.intValue() + " + " + BindToStatementMethod.PARAM_START);
-            }
-
-            if (saveForeignKeyModel) {
-                builder.addStatement("$L.save()", finalAccessStatement);
             }
 
             builder.nextControlFlow("else")


### PR DESCRIPTION
During generation of the insert statement for a foreign key column, the related model should be saved before it's ID parameter is bound. This allows the ID to be the generated (in the case of inserting a related object with auto increment primary key) before it is used to the parameter list.  Fixes #557 fixes #377