### PR TITLE
Include android-maven plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,7 @@ buildscript {
         classpath 'com.android.tools.build:gradle:1.5.0-beta1'
         classpath 'com.neenbedankt.gradle.plugins:android-apt:1.7'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.1'
+        classpath 'com.github.dcendents:android-maven-gradle-plugin:1.3'
     }
 }
 

--- a/dbflow/build.gradle
+++ b/dbflow/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'com.android.library'
 apply plugin: 'android-apt'
+apply plugin: 'com.github.dcendents.android-maven'
 
 project.ext.artifactId = bt_name
 


### PR DESCRIPTION
I noticed while building jitpack on my fork that it compiled only the core and processor module. Turns out that jitpack now requires the android-maven plugin for android libraries, see https://jitpack.io/docs/ANDROID/. When I included this plugin, jitpack now compiles all 3 modules. This fixes #559