### PR TITLE
Expand int to integer in order to reference proper class

### DIFF
--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/method/provider/ProviderMethodUtils.java
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/method/provider/ProviderMethodUtils.java
@@ -39,6 +39,12 @@ public class ProviderMethodUtils {
                         if ("char".equals(name)) {
                             name = "character";
                         }
+
+                        // handle integer
+                        if ("int".equals(name)) {
+                            name = "integer";
+                        }
+
                         name = name.substring(0, 1).toUpperCase() + name.substring(1);
                         codeBuilder.add("$L.valueOf(uri.getPathSegments().get($L))", name, pathSegment.segment());
                     } else {


### PR DESCRIPTION
Otherwise it the provider does not compile. Perhaps do it for all unboxed types?