### PR TITLE
Fix generation of extra comma in insert if pk autoinc isnt first column

### DIFF
--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/method/InsertStatementQueryMethod.java
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/method/InsertStatementQueryMethod.java
@@ -37,11 +37,11 @@ public class InsertStatementQueryMethod implements MethodDefinition {
         int columnSize = tableDefinition.getColumnDefinitions().size();
         int columnCount = 0;
         for (ColumnDefinition column : tableDefinition.getColumnDefinitions()) {
-            if (columnCount > 0) {
-                codeBuilder.add(",");
-            }
-
             if (!column.isPrimaryKeyAutoIncrement || !isInsert) {
+                if (columnCount > 0) {
+                    codeBuilder.add(",");
+                }
+
                 codeBuilder.add(column.getInsertStatementColumnName());
                 columnCount++;
             }
@@ -53,12 +53,12 @@ public class InsertStatementQueryMethod implements MethodDefinition {
 
         columnCount = 0;
         for (int i = 0; i < columnSize; i++) {
-            if (columnCount > 0) {
-                codeBuilder.add(",");
-            }
-
             ColumnDefinition definition = tableDefinition.getColumnDefinitions().get(i);
             if (!definition.isPrimaryKeyAutoIncrement || !isInsert) {
+                if (columnCount > 0) {
+                    codeBuilder.add(",");
+                }
+
                 codeBuilder.add(definition.getInsertStatementValuesString());
                 columnCount++;
             }

--- a/dbflow-tests/src/androidTest/java/com/raizlabs/android/dbflow/test/sql/InsertTest.java
+++ b/dbflow-tests/src/androidTest/java/com/raizlabs/android/dbflow/test/sql/InsertTest.java
@@ -1,10 +1,14 @@
 package com.raizlabs.android.dbflow.test.sql;
 
+import com.raizlabs.android.dbflow.annotation.Column;
+import com.raizlabs.android.dbflow.annotation.PrimaryKey;
+import com.raizlabs.android.dbflow.annotation.Table;
 import com.raizlabs.android.dbflow.config.FlowManager;
 import com.raizlabs.android.dbflow.sql.language.Delete;
 import com.raizlabs.android.dbflow.sql.language.Insert;
 import com.raizlabs.android.dbflow.sql.language.SQLite;
 import com.raizlabs.android.dbflow.sql.language.Select;
+import com.raizlabs.android.dbflow.structure.BaseModel;
 import com.raizlabs.android.dbflow.test.FlowTestCase;
 import com.raizlabs.android.dbflow.test.TestDatabase;
 
@@ -40,5 +44,33 @@ public class InsertTest extends FlowTestCase {
         model = new Select().from(InsertModel.class)
                 .where(InsertModel_Table.name.is("Test3")).querySingle();
         assertNotNull(model);
+    }
+
+    public void testInsertAutoIncNotFirst() {
+        Delete.table(InsertModelAutoIncPrimaryKeyNotFirst.class);
+
+        InsertModelAutoIncPrimaryKeyNotFirst model = new InsertModelAutoIncPrimaryKeyNotFirst();
+        model.value1 = "test1";
+        model.value2 = "test2";
+
+        model.save();
+
+        model = new Select().from(InsertModelAutoIncPrimaryKeyNotFirst.class)
+            .where(InsertModelAutoIncPrimaryKeyNotFirst_Table.value1.is("test1")).querySingle();
+        assertNotNull(model);
+
+    }
+
+    @Table(database = TestDatabase.class)
+    public static class InsertModelAutoIncPrimaryKeyNotFirst extends BaseModel {
+        @Column
+        String value1;
+
+        @Column
+        @PrimaryKey(autoincrement =  true)
+        int id;
+
+        @Column
+        String value2;
     }
 }


### PR DESCRIPTION
Don't generate comma in insert statement if column name/value won't be generated. Fixes #563