### PR TITLE
Save related FK on update (as well as insert) before binding parameter

### DIFF
--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/column/ForeignKeyColumnDefinition.java
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/column/ForeignKeyColumnDefinition.java
@@ -198,14 +198,15 @@ public class ForeignKeyColumnDefinition extends ColumnDefinition {
                             ModelUtils.getVariable(isModelContainerAdapter), isModelContainerAdapter, false);
             String finalAccessStatement = getFinalAccessStatement(builder, isModelContainerAdapter, statement);
             builder.beginControlFlow("if ($L != null)", finalAccessStatement);
+
+            if (saveForeignKeyModel) {
+                builder.addStatement("$L.save()", finalAccessStatement);
+            }
+
             CodeBlock.Builder elseBuilder = CodeBlock.builder();
             for (ForeignKeyReferenceDefinition referenceDefinition : foreignKeyReferenceDefinitionList) {
                 builder.add(referenceDefinition.getContentValuesStatement(isModelContainerAdapter));
                 elseBuilder.addStatement("$L.putNull($S)", BindToContentValuesMethod.PARAM_CONTENT_VALUES, QueryBuilder.quote(referenceDefinition.columnName));
-            }
-
-            if (saveForeignKeyModel) {
-                builder.addStatement("$L.save()", finalAccessStatement);
             }
 
             builder.nextControlFlow("else")

--- a/dbflow-tests/src/androidTest/java/com/raizlabs/android/dbflow/test/sql/ForeignKeyModelTest.java
+++ b/dbflow-tests/src/androidTest/java/com/raizlabs/android/dbflow/test/sql/ForeignKeyModelTest.java
@@ -1,0 +1,59 @@
+package com.raizlabs.android.dbflow.test.sql;
+
+import com.raizlabs.android.dbflow.annotation.Column;
+import com.raizlabs.android.dbflow.annotation.ForeignKey;
+import com.raizlabs.android.dbflow.annotation.ForeignKeyAction;
+import com.raizlabs.android.dbflow.annotation.PrimaryKey;
+import com.raizlabs.android.dbflow.annotation.Table;
+import com.raizlabs.android.dbflow.config.FlowManager;
+import com.raizlabs.android.dbflow.sql.language.Delete;
+import com.raizlabs.android.dbflow.sql.language.Insert;
+import com.raizlabs.android.dbflow.sql.language.SQLite;
+import com.raizlabs.android.dbflow.sql.language.Select;
+import com.raizlabs.android.dbflow.structure.BaseModel;
+import com.raizlabs.android.dbflow.test.FlowTestCase;
+import com.raizlabs.android.dbflow.test.TestDatabase;
+import com.raizlabs.android.dbflow.test.structure.TestModel1;
+
+/**
+ * Description:
+ */
+public class ForeignKeyModelTest extends FlowTestCase {
+
+
+    public void testInsertAndUpdate() {
+
+        Delete.table(FkParent.class);
+        Delete.table(FkRelated.class);
+
+        // Test insert
+        FkParent parent = new FkParent();
+        parent.related = new FkRelated();
+        parent.save();
+
+        // Test update parent with new related
+        parent.related = new FkRelated();
+        parent.save();
+    }
+
+    @Table(database = TestDatabase.class)
+    public static class FkParent extends BaseModel {
+        @Column
+        @PrimaryKey(autoincrement = true)
+        int id;
+
+        @Column
+        @ForeignKey(onUpdate = ForeignKeyAction.CASCADE, onDelete = ForeignKeyAction.CASCADE, saveForeignKeyModel = true)
+        FkRelated related;
+    }
+
+    @Table(database = TestDatabase.class)
+    public static class FkRelated extends BaseModel {
+        @Column
+        @PrimaryKey(autoincrement = true)
+        int id;
+
+        @Column
+        String value;
+    }
+}


### PR DESCRIPTION
In my pull request from a couple days ago https://github.com/Raizlabs/DBFlow/pull/558 for issue #557 I handled the insert scenario but overlooked the scenario of updating a model with a new foreign key model. Also added test coverage for both scenarios.  