### PR TITLE
Added documentation to GettingStarted showing how to save the queen with ant

### DIFF
--- a/usage/GettingStarted.md
+++ b/usage/GettingStarted.md
@@ -192,3 +192,32 @@ public class Queen extends BaseModel {
 ```
 
 If you wish to lazy-load the relationship yourself, specify `OneToMany.Method.DELETE` and `SAVE` instead of `ALL`. If you wish not to save them whenever the `Queen`'s data changes, specify `DELETE` and `LOAD` only.
+
+### Creating the Colony
+
+Use this code to create and populate a colony:
+
+```java
+Queen queen = new Queen();
+queen.name = "Queenie";
+
+Colony colony = new Colony();
+colony.name = "USOfAnts";
+
+// Start a colony.
+colony.save();
+
+// Associate queen with colony
+queen.colony = colony;
+queen.save();
+
+// Add an ant
+Ant ant = new Ant();
+ant.isMale = true;
+ant.type = "Worker";
+ant.associateQueen(queen);
+ant.save();
+```
+
+Note that `associateQueen` must be called after the `Queen` has been saved.
+


### PR DESCRIPTION
I had trouble with #313 also and used the test code as a reference to get it working. I think the problem is that it is not clear that `associateQueen` only works properly if the queen has been saved first. I think that should not be a requirement actually, because if I use OneToMany option to cascade saves, I think dbflow should only require saving the queen once to save it and all its ants. But, after some digging around it looks like resolving that would take some pretty large effort so just added some doc for now.
