### PR TITLE
3.0.0-beta3

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,9 @@ Add the library to the project-level build.gradle, using the  to enable Annotati
     apt 'com.github.Raizlabs.DBFlow:dbflow-processor:${dbflow_version}'
     compile "com.github.Raizlabs.DBFlow:dbflow-core:${dbflow_version}"
     compile "com.github.Raizlabs.DBFlow:dbflow:${dbflow_version}"
+    
+    // sql-cipher database encyrption (optional)
+    compile "com.github.Raizlabs.DBFlow:dbflow-sqlcipher:${dbflow_version}"
   }
 ```
 

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ DBFlow was built with the intention of bringing the best of all features from ot
 - **Built On SQLite**: SQLite is the most widely used database engine in world and using it as your base, you are not tied to a limited set of platforms or libraries.
 
 # Changelog
-# 3.0-beta1
-Many large updates to the library. Probably the most significant changes since the library  was written. Most major changes are [here](https://github.com/Raizlabs/DBFlow/blob/master/usage/Migration3Guide.md)
+
+Going forward, changes between versions exist in the [releases tab](https://github.com/Raizlabs/DBFlow/releases)
 
 for older changes, from other xx.xx versions, check it out [here](https://github.com/Raizlabs/DBFlow/wiki)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Image](https://github.com/agrosner/DBFlow/blob/develop/dbflow_banner.png?raw=true)
 
-[![JitPack.io](https://img.shields.io/badge/JitPack.io-3.0.0beta2-red.svg?style=flat)](https://jitpack.io/#Raizlabs/DBFlow) [![Android Weekly](http://img.shields.io/badge/Android%20Weekly-%23129-2CB3E5.svg?style=flat)](http://androidweekly.net/issues/issue-129) [![Android Arsenal](https://img.shields.io/badge/Android%20Arsenal-DBFlow-brightgreen.svg?style=flat)](https://android-arsenal.com/details/1/1134)
+[![JitPack.io](https://img.shields.io/badge/JitPack.io-3.0.0beta3-red.svg?style=flat)](https://jitpack.io/#Raizlabs/DBFlow) [![Android Weekly](http://img.shields.io/badge/Android%20Weekly-%23129-2CB3E5.svg?style=flat)](http://androidweekly.net/issues/issue-129) [![Android Arsenal](https://img.shields.io/badge/Android%20Arsenal-DBFlow-brightgreen.svg?style=flat)](https://android-arsenal.com/details/1/1134)
 
 A robust, powerful, and very simple ORM android database library with **annotation processing**.
 
@@ -89,14 +89,15 @@ Add the library to the project-level build.gradle, using the  to enable Annotati
 
   apply plugin: 'com.neenbedankt.android-apt'
 
-  def dbflow_version = "3.0.0-beta2"
+  def dbflow_version = "3.0.0-beta3"
   // or dbflow_version = "develop-SNAPSHOT" for grabbing latest dependency in your project on the develop branch
+  // or 10-digit short-hash of a specific commit. (Useful for bugs fixed in develop, but not in a release yet)
 
   dependencies {
     apt "com.github.Raizlabs.DBFlow:dbflow-processor:${dbflow_version}"
     compile "com.github.Raizlabs.DBFlow:dbflow-core:${dbflow_version}"
     compile "com.github.Raizlabs.DBFlow:dbflow:${dbflow_version}"
-    
+
     // sql-cipher database encyrption (optional)
     compile "com.github.Raizlabs.DBFlow:dbflow-sqlcipher:${dbflow_version}"
   }

--- a/dbflow-core/src/main/java/com/raizlabs/android/dbflow/annotation/Column.java
+++ b/dbflow-core/src/main/java/com/raizlabs/android/dbflow/annotation/Column.java
@@ -30,7 +30,8 @@ public @interface Column {
     Collate collate() default Collate.NONE;
 
     /**
-     * @return Adds a default value for this column when saving
+     * @return Adds a default value for this column when saving. Note this will place it in when saving
+     * to the DB because we cannot know the intention of missing data from a query.
      */
     String defaultValue() default "";
 

--- a/dbflow-core/src/main/java/com/raizlabs/android/dbflow/annotation/ColumnIgnore.java
+++ b/dbflow-core/src/main/java/com/raizlabs/android/dbflow/annotation/ColumnIgnore.java
@@ -1,0 +1,14 @@
+package com.raizlabs.android.dbflow.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Description: An annotation used to ignore a column in the {@link Table#allFields()} instance.
+ */
+@Retention(RetentionPolicy.SOURCE)
+@Target(ElementType.FIELD)
+public @interface ColumnIgnore {
+}

--- a/dbflow-core/src/main/java/com/raizlabs/android/dbflow/annotation/ManyToMany.java
+++ b/dbflow-core/src/main/java/com/raizlabs/android/dbflow/annotation/ManyToMany.java
@@ -6,7 +6,7 @@ import java.lang.annotation.Target;
 /**
  * Description: Builds a many-to-many relationship with another {@link Table}. Only one table needs to specify
  * the annotation and its assumed that they use primary keys only. The generated
- * class will contain an auto-incrementing primary key.
+ * class will contain an auto-incrementing primary key by default.
  */
 @Target(ElementType.TYPE)
 public @interface ManyToMany {
@@ -15,4 +15,11 @@ public @interface ManyToMany {
      * @return The other table class by which this will get merged.
      */
     Class<?> referencedTable();
+
+    /**
+     * @return By default, we generate an auto-incrementing {@link Long} {@link PrimaryKey}.
+     * If false, all {@link PrimaryKey} of the corresponding tables will be placed as {@link ForeignKey} and {@link PrimaryKey}
+     * of the generated table instead of using an autoincrementing Long {@link PrimaryKey}.
+     */
+    boolean generateAutoIncrement() default true;
 }

--- a/dbflow-core/src/main/java/com/raizlabs/android/dbflow/annotation/ManyToMany.java
+++ b/dbflow-core/src/main/java/com/raizlabs/android/dbflow/annotation/ManyToMany.java
@@ -1,0 +1,18 @@
+package com.raizlabs.android.dbflow.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
+/**
+ * Description: Builds a many-to-many relationship with another {@link Table}. Only one table needs to specify
+ * the annotation and its assumed that they use primary keys only. The generated
+ * class will contain an auto-incrementing primary key.
+ */
+@Target(ElementType.TYPE)
+public @interface ManyToMany {
+
+    /**
+     * @return The other table class by which this will get merged.
+     */
+    Class<?> referencedTable();
+}

--- a/dbflow-core/src/main/java/com/raizlabs/android/dbflow/annotation/ModelView.java
+++ b/dbflow-core/src/main/java/com/raizlabs/android/dbflow/annotation/ModelView.java
@@ -25,4 +25,12 @@ public @interface ModelView {
      * @return The class of the database this corresponds to.
      */
     Class<?> database();
+
+
+    /**
+     * @return When true, all public, package-private , non-static, and non-final fields of the reference class are considered as {@link com.raizlabs.android.dbflow.annotation.Column} .
+     * The only required annotated field becomes The {@link PrimaryKey}
+     * or {@link PrimaryKey#autoincrement()}.
+     */
+    boolean allFields() default false;
 }

--- a/dbflow-core/src/main/java/com/raizlabs/android/dbflow/annotation/Table.java
+++ b/dbflow-core/src/main/java/com/raizlabs/android/dbflow/annotation/Table.java
@@ -39,7 +39,7 @@ public @interface Table {
 
     /**
      * @return When true, all public, package-private , non-static, and non-final fields of the reference class are considered as {@link com.raizlabs.android.dbflow.annotation.Column} .
-     * The only required annotated field becomes The {@link com.raizlabs.android.dbflow.annotation.PrimaryKey}
+     * The only required annotated field becomes The {@link PrimaryKey}
      * or {@link PrimaryKey#autoincrement()}.
      */
     boolean allFields() default false;

--- a/dbflow-core/src/main/java/com/raizlabs/android/dbflow/annotation/provider/ContentProvider.java
+++ b/dbflow-core/src/main/java/com/raizlabs/android/dbflow/annotation/provider/ContentProvider.java
@@ -27,5 +27,11 @@ public @interface ContentProvider {
      */
     String baseContentUri() default "";
 
-
+    /**
+     * @return Default true, it will enforce that any kind of query to the DB the selection, selection args,
+     * and sortOrder can be converted into Property classes. This is to prevent SQL injection or unintended behavior.
+     * This, however, is pretty basic and doesn't allow complex queries. Setting this to false means
+     * you acknowledge any kind of risk and need to it work for more complicated queries.
+     */
+    boolean useSafeQueryChecking() default true;
 }

--- a/dbflow-core/src/main/java/com/raizlabs/android/dbflow/annotation/provider/TableEndpoint.java
+++ b/dbflow-core/src/main/java/com/raizlabs/android/dbflow/annotation/provider/TableEndpoint.java
@@ -20,5 +20,5 @@ public @interface TableEndpoint {
     /**
      * @return When placed in a top-level class, this is required to connect it to a provider.
      */
-    String contentProviderName() default "";
+    Class<?> contentProvider();
 }

--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/ClassNames.java
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/ClassNames.java
@@ -99,4 +99,6 @@ public class ClassNames {
     public static final ClassName CACHEABLE_LIST_MODEL_LOADER = ClassName.get(QUERIABLE, "CacheableListModelLoader");
     public static final ClassName LIST_MODEL_LOADER = ClassName.get(QUERIABLE, "ListModelLoader");
 
+    public static final ClassName DATABASE_WRAPPER = ClassName.get(DATABASE, "DatabaseWrapper");
+
 }

--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/ClassNames.java
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/ClassNames.java
@@ -101,4 +101,8 @@ public class ClassNames {
 
     public static final ClassName DATABASE_WRAPPER = ClassName.get(DATABASE, "DatabaseWrapper");
 
+    public static final ClassName ORDER_BY = ClassName.get(LANGUAGE, "OrderBy");
+    public static final ClassName SQLITE = ClassName.get(LANGUAGE, "SQLite");
+
+    public static final ClassName UNSAFE_STRING_CONDITION = ClassName.get(LANGUAGE, "UnSafeStringCondition");
 }

--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/DBFlowProcessor.java
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/DBFlowProcessor.java
@@ -81,15 +81,15 @@ public class DBFlowProcessor extends AbstractProcessor {
         super.init(processingEnv);
         manager = new ProcessorManager(processingEnv);
         manager.addHandlers(
-                new MigrationHandler(),
-                new TypeConverterHandler(),
-                new DatabaseHandler(),
-                new TableHandler(),
-                new QueryModelHandler(),
-                new ModelContainerHandler(),
-                new ModelViewHandler(),
-                new ContentProviderHandler(),
-                new TableEndpointHandler());
+            new MigrationHandler(),
+            new TypeConverterHandler(),
+            new DatabaseHandler(),
+            new TableHandler(),
+            new QueryModelHandler(),
+            new ModelContainerHandler(),
+            new ModelViewHandler(),
+            new ContentProviderHandler(),
+            new TableEndpointHandler());
     }
 
     @Override

--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/DBFlowProcessor.java
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/DBFlowProcessor.java
@@ -2,6 +2,7 @@ package com.raizlabs.android.dbflow.processor;
 
 import com.google.auto.service.AutoService;
 import com.raizlabs.android.dbflow.annotation.Column;
+import com.raizlabs.android.dbflow.annotation.ColumnIgnore;
 import com.raizlabs.android.dbflow.annotation.Migration;
 import com.raizlabs.android.dbflow.annotation.ModelContainer;
 import com.raizlabs.android.dbflow.annotation.ModelView;
@@ -59,6 +60,7 @@ public class DBFlowProcessor extends AbstractProcessor {
         supportedTypes.add(Migration.class.getCanonicalName());
         supportedTypes.add(ContentProvider.class.getCanonicalName());
         supportedTypes.add(TableEndpoint.class.getCanonicalName());
+        supportedTypes.add(ColumnIgnore.class.getCanonicalName());
         supportedTypes.add(QueryModel.class.getCanonicalName());
         return supportedTypes;
     }
@@ -81,15 +83,15 @@ public class DBFlowProcessor extends AbstractProcessor {
         super.init(processingEnv);
         manager = new ProcessorManager(processingEnv);
         manager.addHandlers(
-            new MigrationHandler(),
-            new TypeConverterHandler(),
-            new DatabaseHandler(),
-            new TableHandler(),
-            new QueryModelHandler(),
-            new ModelContainerHandler(),
-            new ModelViewHandler(),
-            new ContentProviderHandler(),
-            new TableEndpointHandler());
+                new MigrationHandler(),
+                new TypeConverterHandler(),
+                new DatabaseHandler(),
+                new TableHandler(),
+                new QueryModelHandler(),
+                new ModelContainerHandler(),
+                new ModelViewHandler(),
+                new ContentProviderHandler(),
+                new TableEndpointHandler());
     }
 
     @Override

--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/BaseDefinition.java
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/BaseDefinition.java
@@ -75,6 +75,16 @@ public abstract class BaseDefinition implements TypeDefinition {
         }
     }
 
+    public BaseDefinition(ClassName element, ProcessorManager processorManager) {
+        this.manager = processorManager;
+        this.elementTypeName = element;
+        packageName = element.packageName();
+        elementName = element.simpleName();
+        if (!elementTypeName.isPrimitive()) {
+            elementClassName = element.topLevelClassName();
+        }
+    }
+
     public BaseDefinition(TypeElement element, ProcessorManager processorManager) {
         this.manager = processorManager;
         this.typeElement = element;

--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/BaseDefinition.java
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/BaseDefinition.java
@@ -75,16 +75,6 @@ public abstract class BaseDefinition implements TypeDefinition {
         }
     }
 
-    public BaseDefinition(ClassName element, ProcessorManager processorManager) {
-        this.manager = processorManager;
-        this.elementTypeName = element;
-        packageName = element.packageName();
-        elementName = element.simpleName();
-        if (!elementTypeName.isPrimitive()) {
-            elementClassName = element.topLevelClassName();
-        }
-    }
-
     public BaseDefinition(TypeElement element, ProcessorManager processorManager) {
         this.manager = processorManager;
         this.typeElement = element;

--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/BaseTableDefinition.java
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/BaseTableDefinition.java
@@ -35,6 +35,8 @@ public abstract class BaseTableDefinition extends BaseDefinition {
     protected Map<ClassName, List<ColumnDefinition>> globalTypeConverters = new HashMap<>();
     protected final List<ColumnDefinition> packagePrivateList = Lists.newArrayList();
 
+    public Map<String, Element> classElementLookUpMap = new HashMap<>();
+
     private String modelClassName;
     public DatabaseDefinition databaseDefinition;
 
@@ -56,7 +58,7 @@ public abstract class BaseTableDefinition extends BaseDefinition {
 
     public TypeName getParameterClassName(boolean isModelContainerAdapter) {
         return isModelContainerAdapter ? ModelUtils.getModelContainerType(manager, elementClassName)
-            : elementClassName;
+                : elementClassName;
     }
 
     public String addColumnForCustomTypeConverter(ColumnDefinition columnDefinition, ClassName typeConverterName) {
@@ -87,18 +89,18 @@ public abstract class BaseTableDefinition extends BaseDefinition {
 
         if (!packagePrivateList.isEmpty()) {
             TypeSpec.Builder typeBuilder = TypeSpec.classBuilder(elementClassName.simpleName() + databaseDefinition.classSeparator + "Helper")
-                .addModifiers(Modifier.PUBLIC, Modifier.FINAL);
+                    .addModifiers(Modifier.PUBLIC, Modifier.FINAL);
 
             for (ColumnDefinition columnDefinition : packagePrivateList) {
                 String helperClassName = manager.getElements().getPackageOf(columnDefinition.element).toString() + "." + ClassName.get((TypeElement) columnDefinition.element.getEnclosingElement()).simpleName()
-                    + databaseDefinition.classSeparator + "Helper";
+                        + databaseDefinition.classSeparator + "Helper";
                 ClassName className = ClassName.bestGuess(helperClassName);
                 if (PackagePrivateAccess.containsColumn(className, columnDefinition.columnName)) {
 
                     MethodSpec.Builder method = MethodSpec.methodBuilder("get" + StringUtils.capitalize(columnDefinition.columnName))
-                        .addModifiers(Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL)
-                        .addParameter(elementTypeName, ModelUtils.getVariable(false))
-                        .returns(columnDefinition.elementTypeName);
+                            .addModifiers(Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL)
+                            .addParameter(elementTypeName, ModelUtils.getVariable(false))
+                            .returns(columnDefinition.elementTypeName);
                     boolean samePackage = ElementUtility.isInSamePackage(manager, columnDefinition.element, this.element);
 
                     if (samePackage) {
@@ -110,9 +112,9 @@ public abstract class BaseTableDefinition extends BaseDefinition {
                     typeBuilder.addMethod(method.build());
 
                     method = MethodSpec.methodBuilder("set" + StringUtils.capitalize(columnDefinition.columnName))
-                        .addModifiers(Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL)
-                        .addParameter(elementTypeName, ModelUtils.getVariable(false))
-                        .addParameter(columnDefinition.elementTypeName, "var");
+                            .addModifiers(Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL)
+                            .addParameter(elementTypeName, ModelUtils.getVariable(false))
+                            .addParameter(columnDefinition.elementTypeName, "var");
 
                     if (samePackage) {
                         method.addStatement("$L.$L = $L", ModelUtils.getVariable(false), columnDefinition.elementName, "var");

--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/BaseTableDefinition.java
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/BaseTableDefinition.java
@@ -44,6 +44,12 @@ public abstract class BaseTableDefinition extends BaseDefinition {
         columnDefinitions = new ArrayList<>();
     }
 
+    public BaseTableDefinition(ClassName typeElement, ProcessorManager processorManager) {
+        super(typeElement, processorManager);
+        this.modelClassName = typeElement.toString();
+        columnDefinitions = new ArrayList<>();
+    }
+
     protected abstract void createColumnDefinitions(TypeElement typeElement);
 
     public List<ColumnDefinition> getColumnDefinitions() {
@@ -56,7 +62,7 @@ public abstract class BaseTableDefinition extends BaseDefinition {
 
     public TypeName getParameterClassName(boolean isModelContainerAdapter) {
         return isModelContainerAdapter ? ModelUtils.getModelContainerType(manager, elementClassName)
-                : elementClassName;
+            : elementClassName;
     }
 
     public String addColumnForCustomTypeConverter(ColumnDefinition columnDefinition, ClassName typeConverterName) {
@@ -87,18 +93,18 @@ public abstract class BaseTableDefinition extends BaseDefinition {
 
         if (!packagePrivateList.isEmpty()) {
             TypeSpec.Builder typeBuilder = TypeSpec.classBuilder(elementClassName.simpleName() + databaseDefinition.classSeparator + "Helper")
-                    .addModifiers(Modifier.PUBLIC, Modifier.FINAL);
+                .addModifiers(Modifier.PUBLIC, Modifier.FINAL);
 
             for (ColumnDefinition columnDefinition : packagePrivateList) {
                 String helperClassName = manager.getElements().getPackageOf(columnDefinition.element).toString() + "." + ClassName.get((TypeElement) columnDefinition.element.getEnclosingElement()).simpleName()
-                        + databaseDefinition.classSeparator + "Helper";
+                    + databaseDefinition.classSeparator + "Helper";
                 ClassName className = ClassName.bestGuess(helperClassName);
                 if (PackagePrivateAccess.containsColumn(className, columnDefinition.columnName)) {
 
                     MethodSpec.Builder method = MethodSpec.methodBuilder("get" + StringUtils.capitalize(columnDefinition.columnName))
-                            .addModifiers(Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL)
-                            .addParameter(elementTypeName, ModelUtils.getVariable(false))
-                            .returns(columnDefinition.elementTypeName);
+                        .addModifiers(Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL)
+                        .addParameter(elementTypeName, ModelUtils.getVariable(false))
+                        .returns(columnDefinition.elementTypeName);
                     boolean samePackage = ElementUtility.isInSamePackage(manager, columnDefinition.element, this.element);
 
                     if (samePackage) {
@@ -110,9 +116,9 @@ public abstract class BaseTableDefinition extends BaseDefinition {
                     typeBuilder.addMethod(method.build());
 
                     method = MethodSpec.methodBuilder("set" + StringUtils.capitalize(columnDefinition.columnName))
-                            .addModifiers(Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL)
-                            .addParameter(elementTypeName, ModelUtils.getVariable(false))
-                            .addParameter(columnDefinition.elementTypeName, "var");
+                        .addModifiers(Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL)
+                        .addParameter(elementTypeName, ModelUtils.getVariable(false))
+                        .addParameter(columnDefinition.elementTypeName, "var");
 
                     if (samePackage) {
                         method.addStatement("$L.$L = $L", ModelUtils.getVariable(false), columnDefinition.elementName, "var");

--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/BaseTableDefinition.java
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/BaseTableDefinition.java
@@ -44,12 +44,6 @@ public abstract class BaseTableDefinition extends BaseDefinition {
         columnDefinitions = new ArrayList<>();
     }
 
-    public BaseTableDefinition(ClassName typeElement, ProcessorManager processorManager) {
-        super(typeElement, processorManager);
-        this.modelClassName = typeElement.toString();
-        columnDefinitions = new ArrayList<>();
-    }
-
     protected abstract void createColumnDefinitions(TypeElement typeElement);
 
     public List<ColumnDefinition> getColumnDefinitions() {

--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/ContentProviderDefinition.java
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/ContentProviderDefinition.java
@@ -41,6 +41,7 @@ public class ContentProviderDefinition extends BaseDefinition {
 
     public TypeName databaseName;
     public String databaseNameString;
+    public boolean useSafeQueryChecking;
 
     public String authority;
 
@@ -58,6 +59,7 @@ public class ContentProviderDefinition extends BaseDefinition {
             } catch (MirroredTypeException mte) {
                 databaseName = TypeName.get(mte.getTypeMirror());
             }
+            useSafeQueryChecking = provider.useSafeQueryChecking();
             DatabaseDefinition databaseDefinition = manager.getDatabaseWriter(databaseName);
             databaseNameString = databaseDefinition.databaseName;
             setOutputClassName(databaseDefinition.classSeparator + DEFINITION_NAME);

--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/ManyToManyDefinition.java
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/ManyToManyDefinition.java
@@ -1,0 +1,53 @@
+package com.raizlabs.android.dbflow.processor.definition;
+
+import com.raizlabs.android.dbflow.annotation.ManyToMany;
+import com.raizlabs.android.dbflow.annotation.Table;
+import com.raizlabs.android.dbflow.processor.ClassNames;
+import com.raizlabs.android.dbflow.processor.definition.method.DatabaseDefinition;
+import com.raizlabs.android.dbflow.processor.model.ProcessorManager;
+import com.raizlabs.android.dbflow.processor.utils.ModelUtils;
+import com.squareup.javapoet.TypeName;
+import com.squareup.javapoet.TypeSpec;
+
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.MirroredTypeException;
+
+/**
+ * Description: Generates the Model class that is used in a many to many.
+ */
+public class ManyToManyDefinition extends BaseDefinition {
+
+    TypeName referencedTable;
+
+    public ManyToManyDefinition(TypeElement element, ProcessorManager processorManager) {
+        super(element, processorManager);
+
+        ManyToMany manyToMany = element.getAnnotation(ManyToMany.class);
+        referencedTable = TypeName.get(ModelUtils.getReferencedClassFromAnnotation(manyToMany));
+
+        TypeName databaseTypeName = null;
+        Table table = element.getAnnotation(Table.class);
+        try {
+            table.database();
+        } catch (MirroredTypeException mte) {
+            databaseTypeName = TypeName.get(mte.getTypeMirror());
+        }
+
+        DatabaseDefinition databaseDefinition = manager.getDatabaseWriter(databaseTypeName);
+        if (databaseDefinition == null) {
+            manager.logError("DatabaseDefinition was null for : " + elementName);
+        } else {
+            setOutputClassName(databaseDefinition.classSeparator + referencedTable);
+        }
+    }
+
+    @Override
+    public void onWriteDefinition(TypeSpec.Builder typeBuilder) {
+
+    }
+
+    @Override
+    protected TypeName getExtendsClass() {
+        return ClassNames.BASE_MODEL;
+    }
+}

--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/ManyToManyDefinition.java
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/ManyToManyDefinition.java
@@ -1,14 +1,25 @@
 package com.raizlabs.android.dbflow.processor.definition;
 
+import com.raizlabs.android.dbflow.annotation.Column;
 import com.raizlabs.android.dbflow.annotation.ManyToMany;
+import com.raizlabs.android.dbflow.annotation.PrimaryKey;
 import com.raizlabs.android.dbflow.annotation.Table;
 import com.raizlabs.android.dbflow.processor.ClassNames;
+import com.raizlabs.android.dbflow.processor.definition.column.ColumnDefinition;
 import com.raizlabs.android.dbflow.processor.definition.method.DatabaseDefinition;
 import com.raizlabs.android.dbflow.processor.model.ProcessorManager;
 import com.raizlabs.android.dbflow.processor.utils.ModelUtils;
+import com.raizlabs.android.dbflow.processor.utils.StringUtils;
+import com.squareup.javapoet.AnnotationSpec;
+import com.squareup.javapoet.ClassName;
+import com.squareup.javapoet.FieldSpec;
+import com.squareup.javapoet.MethodSpec;
 import com.squareup.javapoet.TypeName;
 import com.squareup.javapoet.TypeSpec;
 
+import java.util.List;
+
+import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.MirroredTypeException;
 
@@ -18,6 +29,7 @@ import javax.lang.model.type.MirroredTypeException;
 public class ManyToManyDefinition extends BaseDefinition {
 
     TypeName referencedTable;
+    public TypeName databaseTypeName;
 
     public ManyToManyDefinition(TypeElement element, ProcessorManager processorManager) {
         super(element, processorManager);
@@ -25,7 +37,6 @@ public class ManyToManyDefinition extends BaseDefinition {
         ManyToMany manyToMany = element.getAnnotation(ManyToMany.class);
         referencedTable = TypeName.get(ModelUtils.getReferencedClassFromAnnotation(manyToMany));
 
-        TypeName databaseTypeName = null;
         Table table = element.getAnnotation(Table.class);
         try {
             table.database();
@@ -37,17 +48,53 @@ public class ManyToManyDefinition extends BaseDefinition {
         if (databaseDefinition == null) {
             manager.logError("DatabaseDefinition was null for : " + elementName);
         } else {
-            setOutputClassName(databaseDefinition.classSeparator + referencedTable);
+            ClassName referencedOutput = getElementClassName(manager.getElements().getTypeElement(referencedTable.toString()));
+            setOutputClassName(databaseDefinition.classSeparator + referencedOutput.simpleName());
         }
     }
 
     @Override
     public void onWriteDefinition(TypeSpec.Builder typeBuilder) {
+        typeBuilder.addAnnotation(AnnotationSpec.builder(Table.class).addMember("database", "$T.class", databaseTypeName).build());
 
+        TableDefinition referencedDefinition = manager.getTableDefinition(databaseTypeName, referencedTable);
+        TableDefinition selfDefinition = manager.getTableDefinition(databaseTypeName, elementTypeName);
+
+        typeBuilder.addField(FieldSpec.builder(TypeName.LONG, "_id")
+            .addAnnotation(AnnotationSpec.builder(PrimaryKey.class).addMember("autoincrement", "true").build())
+            .build());
+        typeBuilder.addMethod(MethodSpec.methodBuilder("getId")
+            .returns(TypeName.LONG)
+            .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
+            .addStatement("return $L", "_id")
+            .build());
+
+        List<ColumnDefinition> primaryKeys = referencedDefinition.getPrimaryColumnDefinitions();
+        appendColumnDefinitions(typeBuilder, primaryKeys, referencedDefinition);
+        primaryKeys = selfDefinition.getPrimaryColumnDefinitions();
+        appendColumnDefinitions(typeBuilder, primaryKeys, selfDefinition);
     }
 
     @Override
     protected TypeName getExtendsClass() {
         return ClassNames.BASE_MODEL;
+    }
+
+    private void appendColumnDefinitions(TypeSpec.Builder typeBuilder, List<ColumnDefinition> primaryKeys, TableDefinition referencedDefinition) {
+        for (ColumnDefinition primary : primaryKeys) {
+            String fieldName = primary.elementName + "_" + referencedDefinition.elementName;
+            typeBuilder.addField(FieldSpec.builder(primary.elementTypeName, fieldName)
+                .addAnnotation(AnnotationSpec.builder(Column.class).build()).build()).build();
+            typeBuilder.addMethod(MethodSpec.methodBuilder("get" + StringUtils.capitalize(fieldName))
+                .returns(primary.elementTypeName)
+                .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
+                .addStatement("return $L", fieldName)
+                .build());
+            typeBuilder.addMethod(MethodSpec.methodBuilder("set" + StringUtils.capitalize(fieldName))
+                .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
+                .addParameter(primary.elementTypeName, "param")
+                .addStatement("$L = param", fieldName)
+                .build());
+        }
     }
 }

--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/ModelViewDefinition.java
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/ModelViewDefinition.java
@@ -60,6 +60,8 @@ public class ModelViewDefinition extends BaseTableDefinition {
 
     public String viewTableName;
 
+    public boolean allFields;
+
     public ModelViewDefinition(ProcessorManager manager, Element element) {
         super(element, manager);
 
@@ -73,6 +75,7 @@ public class ModelViewDefinition extends BaseTableDefinition {
             } catch (MirroredTypeException mte) {
                 this.databaseName = TypeName.get(mte.getTypeMirror());
             }
+            allFields = modelView.allFields();
 
             databaseDefinition = manager.getDatabaseWriter(databaseName);
             this.viewTableName = getModelClassName() + databaseDefinition.classSeparator + TABLE_VIEW_TAG;
@@ -124,9 +127,18 @@ public class ModelViewDefinition extends BaseTableDefinition {
     @Override
     protected void createColumnDefinitions(TypeElement typeElement) {
         List<? extends Element> variableElements = ElementUtility.getAllElements(typeElement, manager);
+
+        for (Element element : variableElements) {
+            classElementLookUpMap.put(element.getSimpleName().toString(), element);
+        }
+
         ColumnValidator columnValidator = new ColumnValidator();
         for (Element variableElement : variableElements) {
-            if (variableElement.getAnnotation(Column.class) != null) {
+
+            boolean isValidAllFields = ElementUtility.isValidAllFields(allFields, element);
+
+            if (variableElement.getAnnotation(Column.class) != null || isValidAllFields) {
+
                 // package private, will generate helper
                 boolean isPackagePrivate = ElementUtility.isPackagePrivate(element);
                 boolean isPackagePrivateNotInSamePackage = isPackagePrivate && !ElementUtility.isInSamePackage(manager, element, this.element);

--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/QueryModelDefinition.java
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/QueryModelDefinition.java
@@ -99,14 +99,16 @@ public class QueryModelDefinition extends BaseTableDefinition {
     @Override
     protected void createColumnDefinitions(TypeElement typeElement) {
         List<? extends Element> variableElements = ElementUtility.getAllElements(typeElement, manager);
+
+        for (Element element : variableElements) {
+            classElementLookUpMap.put(element.getSimpleName().toString(), element);
+        }
+
         ColumnValidator columnValidator = new ColumnValidator();
         for (Element variableElement : variableElements) {
 
             // no private static or final fields
-            boolean isValidColumn = allFields && (variableElement.getKind().isField() &&
-                    !variableElement.getModifiers().contains(Modifier.STATIC) &&
-                    !variableElement.getModifiers().contains(Modifier.PRIVATE) &&
-                    !variableElement.getModifiers().contains(Modifier.FINAL));
+            boolean isValidColumn = ElementUtility.isValidAllFields(allFields, element);
 
             if (variableElement.getAnnotation(Column.class) != null || isValidColumn) {
 

--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/TableDefinition.java
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/TableDefinition.java
@@ -3,6 +3,7 @@ package com.raizlabs.android.dbflow.processor.definition;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.raizlabs.android.dbflow.annotation.Column;
+import com.raizlabs.android.dbflow.annotation.ColumnIgnore;
 import com.raizlabs.android.dbflow.annotation.ConflictAction;
 import com.raizlabs.android.dbflow.annotation.ContainerKey;
 import com.raizlabs.android.dbflow.annotation.ForeignKey;
@@ -278,7 +279,8 @@ public class TableDefinition extends BaseTableDefinition {
             boolean isValidColumn = (allFields && (element.getKind().isField() &&
                     !element.getModifiers().contains(Modifier.STATIC) &&
                     !element.getModifiers().contains(Modifier.FINAL))) &&
-                    !element.asType().toString().equals(ClassNames.MODEL_ADAPTER.toString()); // ignore model adapter fields.
+                    element.getAnnotation(ColumnIgnore.class) == null &&
+                    !element.asType().toString().equals(ClassNames.MODEL_ADAPTER.toString());
 
             // package private, will generate helper
             boolean isPackagePrivate = ElementUtility.isPackagePrivate(element);
@@ -290,7 +292,6 @@ public class TableDefinition extends BaseTableDefinition {
             boolean isInheritedPrimaryKey = inheritedPrimaryKeyMap.containsKey(element.getSimpleName().toString());
             if (element.getAnnotation(Column.class) != null || isForeign || isPrimary
                     || isValidColumn || isInherited || isInheritedPrimaryKey) {
-
 
                 ColumnDefinition columnDefinition;
                 if (isInheritedPrimaryKey) {

--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/TableDefinition.java
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/TableDefinition.java
@@ -271,16 +271,16 @@ public class TableDefinition extends BaseTableDefinition {
     protected void createColumnDefinitions(TypeElement typeElement) {
         List<? extends Element> elements = ElementUtility.getAllElements(typeElement, manager);
 
+        for (Element element : elements) {
+            classElementLookUpMap.put(element.getSimpleName().toString(), element);
+        }
+
         ColumnValidator columnValidator = new ColumnValidator();
         OneToManyValidator oneToManyValidator = new OneToManyValidator();
         for (Element element : elements) {
 
             // no private static or final fields for all columns, or any inherited columns here.
-            boolean isValidColumn = (allFields && (element.getKind().isField() &&
-                    !element.getModifiers().contains(Modifier.STATIC) &&
-                    !element.getModifiers().contains(Modifier.FINAL))) &&
-                    element.getAnnotation(ColumnIgnore.class) == null &&
-                    !element.asType().toString().equals(ClassNames.MODEL_ADAPTER.toString());
+            boolean isAllFields = ElementUtility.isValidAllFields(allFields, element);
 
             // package private, will generate helper
             boolean isPackagePrivate = ElementUtility.isPackagePrivate(element);
@@ -291,7 +291,7 @@ public class TableDefinition extends BaseTableDefinition {
             boolean isInherited = inheritedColumnMap.containsKey(element.getSimpleName().toString());
             boolean isInheritedPrimaryKey = inheritedPrimaryKeyMap.containsKey(element.getSimpleName().toString());
             if (element.getAnnotation(Column.class) != null || isForeign || isPrimary
-                    || isValidColumn || isInherited || isInheritedPrimaryKey) {
+                    || isAllFields || isInherited || isInheritedPrimaryKey) {
 
                 ColumnDefinition columnDefinition;
                 if (isInheritedPrimaryKey) {

--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/TableDefinition.java
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/TableDefinition.java
@@ -97,7 +97,7 @@ public class TableDefinition extends BaseTableDefinition {
 
     public boolean implementsLoadFromCursorListener = false;
 
-    private final MethodDefinition[] methods;
+    private MethodDefinition[] methods;
 
     public boolean cachingEnabled = false;
     public int cacheSize;
@@ -120,13 +120,22 @@ public class TableDefinition extends BaseTableDefinition {
 
     public TableDefinition(ProcessorManager manager, TypeElement element) {
         super(element, manager);
+        init(element, manager);
+    }
 
+    public TableDefinition(ProcessorManager manager, ClassName className) {
+        super(className, manager);
+        init(null, manager);
+    }
+
+    private void init(TypeElement element, ProcessorManager manager) {
         primaryColumnDefinitions = new ArrayList<>();
         foreignKeyDefinitions = new ArrayList<>();
         uniqueGroupsDefinitions = new ArrayList<>();
         indexGroupsDefinitions = new ArrayList<>();
 
-        Table table = element.getAnnotation(Table.class);
+        boolean nullElement = element == null;
+        Table table = !nullElement ? element.getAnnotation(Table.class) : null;
         if (table != null) {
             this.tableName = table.name();
             try {
@@ -139,7 +148,7 @@ public class TableDefinition extends BaseTableDefinition {
             cacheSize = table.cacheSize();
             databaseDefinition = manager.getDatabaseWriter(databaseTypeName);
             if (databaseDefinition == null) {
-                manager.logError("Databasewriter was null for : " + tableName);
+                manager.logError("DatabaseDefinition was null for : " + tableName);
             }
 
             setOutputClassName(databaseDefinition.classSeparator + DBFLOW_TABLE_TAG);
@@ -158,9 +167,9 @@ public class TableDefinition extends BaseTableDefinition {
             }
 
             insertConflictActionName = insertConflict.equals(ConflictAction.NONE) ? ""
-                    : insertConflict.name();
+                : insertConflict.name();
             updateConflictActionName = updateConflict.equals(ConflictAction.NONE) ? ""
-                    : updateConflict.name();
+                : updateConflict.name();
 
             allFields = table.allFields();
             useIsForPrivateBooleans = table.useIsForPrivateBooleans();
@@ -224,36 +233,33 @@ public class TableDefinition extends BaseTableDefinition {
             }
 
             implementsLoadFromCursorListener = ProcessorUtils.implementsClass(manager.getProcessingEnvironment(),
-                    ClassNames.LOAD_FROM_CURSOR_LISTENER.toString(), element);
+                ClassNames.LOAD_FROM_CURSOR_LISTENER.toString(), element);
 
             implementsContentValuesListener = ProcessorUtils.implementsClass(manager.getProcessingEnvironment(),
-                    ClassNames.CONTENT_VALUES_LISTENER.toString(), element);
+                ClassNames.CONTENT_VALUES_LISTENER.toString(), element);
 
             implementsSqlStatementListener = ProcessorUtils.implementsClass(manager.getProcessingEnvironment(),
-                    ClassNames.SQLITE_STATEMENT_LISTENER.toString(), element);
+                ClassNames.SQLITE_STATEMENT_LISTENER.toString(), element);
         }
 
         methods = new MethodDefinition[]
 
-                {
-                        new BindToContentValuesMethod(this, true, false, implementsContentValuesListener),
-                        new BindToContentValuesMethod(this, false, false, implementsContentValuesListener),
-                        new BindToStatementMethod(this, true, false),
-                        new BindToStatementMethod(this, false, false),
-                        new InsertStatementQueryMethod(this, true),
-                        new InsertStatementQueryMethod(this, false),
-                        new CreationQueryMethod(this),
-                        new LoadFromCursorMethod(this, false, implementsLoadFromCursorListener, false),
-                        new ExistenceMethod(this, false),
-                        new PrimaryConditionMethod(this, false),
-                        new OneToManyDeleteMethod(this, false),
-                        new OneToManySaveMethod(this, false, OneToManySaveMethod.METHOD_SAVE),
-                        new OneToManySaveMethod(this, false, OneToManySaveMethod.METHOD_INSERT),
-                        new OneToManySaveMethod(this, false, OneToManySaveMethod.METHOD_UPDATE)
-                }
-
-        ;
-
+            {
+                new BindToContentValuesMethod(this, true, false, implementsContentValuesListener),
+                new BindToContentValuesMethod(this, false, false, implementsContentValuesListener),
+                new BindToStatementMethod(this, true, false),
+                new BindToStatementMethod(this, false, false),
+                new InsertStatementQueryMethod(this, true),
+                new InsertStatementQueryMethod(this, false),
+                new CreationQueryMethod(this),
+                new LoadFromCursorMethod(this, false, implementsLoadFromCursorListener, false),
+                new ExistenceMethod(this, false),
+                new PrimaryConditionMethod(this, false),
+                new OneToManyDeleteMethod(this, false),
+                new OneToManySaveMethod(this, false, OneToManySaveMethod.METHOD_SAVE),
+                new OneToManySaveMethod(this, false, OneToManySaveMethod.METHOD_INSERT),
+                new OneToManySaveMethod(this, false, OneToManySaveMethod.METHOD_UPDATE)
+            };
     }
 
     @Override
@@ -276,9 +282,9 @@ public class TableDefinition extends BaseTableDefinition {
 
             // no private static or final fields for all columns, or any inherited columns here.
             boolean isValidColumn = (allFields && (element.getKind().isField() &&
-                    !element.getModifiers().contains(Modifier.STATIC) &&
-                    !element.getModifiers().contains(Modifier.PRIVATE) &&
-                    !element.getModifiers().contains(Modifier.FINAL)));
+                !element.getModifiers().contains(Modifier.STATIC) &&
+                !element.getModifiers().contains(Modifier.PRIVATE) &&
+                !element.getModifiers().contains(Modifier.FINAL)));
 
             // package private, will generate helper
             boolean isPackagePrivate = ElementUtility.isPackagePrivate(element);
@@ -289,18 +295,18 @@ public class TableDefinition extends BaseTableDefinition {
             boolean isInherited = inheritedColumnMap.containsKey(element.getSimpleName().toString());
             boolean isInheritedPrimaryKey = inheritedPrimaryKeyMap.containsKey(element.getSimpleName().toString());
             if (element.getAnnotation(Column.class) != null || isForeign || isPrimary
-                    || isValidColumn || isInherited || isInheritedPrimaryKey) {
+                || isValidColumn || isInherited || isInheritedPrimaryKey) {
 
 
                 ColumnDefinition columnDefinition;
                 if (isInheritedPrimaryKey) {
                     InheritedPrimaryKey inherited = inheritedPrimaryKeyMap.get(element.getSimpleName().toString());
                     columnDefinition = new ColumnDefinition(manager, element, this, isPackagePrivateNotInSamePackage,
-                            inherited.column(), inherited.primaryKey());
+                        inherited.column(), inherited.primaryKey());
                 } else if (isInherited) {
                     InheritedColumn inherited = inheritedColumnMap.get(element.getSimpleName().toString());
                     columnDefinition = new ColumnDefinition(manager, element, this, isPackagePrivateNotInSamePackage,
-                            inherited.column(), null);
+                        inherited.column(), null);
                 } else if (isForeign) {
                     columnDefinition = new ForeignKeyColumnDefinition(manager, this, element, isPackagePrivateNotInSamePackage);
                 } else {
@@ -401,9 +407,9 @@ public class TableDefinition extends BaseTableDefinition {
     @Override
     public void onWriteDefinition(TypeSpec.Builder typeBuilder) {
         MethodSpec.Builder getPropertyForNameMethod = MethodSpec.methodBuilder("getProperty")
-                .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
-                .addParameter(String.class, "columnName")
-                .returns(ClassNames.BASE_PROPERTY);
+            .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+            .addParameter(String.class, "columnName")
+            .returns(ClassNames.BASE_PROPERTY);
 
         getPropertyForNameMethod.addStatement("columnName = $T.quoteIfNeeded(columnName)", ClassName.get(QueryBuilder.class));
 
@@ -414,7 +420,7 @@ public class TableDefinition extends BaseTableDefinition {
         }
         getPropertyForNameMethod.beginControlFlow("default: ");
         getPropertyForNameMethod.addStatement("throw new $T($S)", IllegalArgumentException.class,
-                "Invalid column name passed. Ensure you are calling the correct table's column");
+            "Invalid column name passed. Ensure you are calling the correct table's column");
         getPropertyForNameMethod.endControlFlow();
         getPropertyForNameMethod.endControlFlow();
 
@@ -429,27 +435,27 @@ public class TableDefinition extends BaseTableDefinition {
     public void writeAdapter(ProcessingEnvironment processingEnvironment) throws IOException {
 
         TypeSpec.Builder typeBuilder = TypeSpec.classBuilder(adapterName)
-                .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
-                .superclass(ParameterizedTypeName.get(ClassNames.MODEL_ADAPTER, elementClassName));
+            .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
+            .superclass(ParameterizedTypeName.get(ClassNames.MODEL_ADAPTER, elementClassName));
         InternalAdapterHelper.writeGetModelClass(typeBuilder, elementClassName);
         InternalAdapterHelper.writeGetTableName(typeBuilder, tableName);
 
         if (hasAutoIncrement) {
             InternalAdapterHelper.writeUpdateAutoIncrement(typeBuilder, elementClassName,
-                    autoIncrementDefinition, false);
+                autoIncrementDefinition, false);
 
             typeBuilder.addMethod(MethodSpec.methodBuilder("getAutoIncrementingId")
-                    .addAnnotation(Override.class)
-                    .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
-                    .addParameter(elementClassName, ModelUtils.getVariable(false))
-                    .addStatement("return $L", autoIncrementDefinition.getColumnAccessString(false, false))
-                    .returns(ClassName.get(Number.class)).build());
+                .addAnnotation(Override.class)
+                .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
+                .addParameter(elementClassName, ModelUtils.getVariable(false))
+                .addStatement("return $L", autoIncrementDefinition.getColumnAccessString(false, false))
+                .returns(ClassName.get(Number.class)).build());
 
             typeBuilder.addMethod(MethodSpec.methodBuilder("getAutoIncrementingColumnName")
-                    .addAnnotation(Override.class)
-                    .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
-                    .addStatement("return $S", QueryBuilder.stripQuotes(autoIncrementDefinition.columnName))
-                    .returns(ClassName.get(String.class)).build());
+                .addAnnotation(Override.class)
+                .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
+                .addStatement("return $S", QueryBuilder.stripQuotes(autoIncrementDefinition.columnName))
+                .returns(ClassName.get(String.class)).build());
         }
 
         if (cachingEnabled) {
@@ -457,22 +463,22 @@ public class TableDefinition extends BaseTableDefinition {
             // TODO: pass in model cache loaders.
 
             typeBuilder.addMethod(MethodSpec.methodBuilder("createSingleModelLoader")
-                    .addAnnotation(Override.class)
-                    .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
-                    .addStatement("return new $T<>(getModelClass())", ClassNames.CACHEABLE_MODEL_LOADER)
-                    .returns(ClassNames.SINGLE_MODEL_LOADER).build());
+                .addAnnotation(Override.class)
+                .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
+                .addStatement("return new $T<>(getModelClass())", ClassNames.CACHEABLE_MODEL_LOADER)
+                .returns(ClassNames.SINGLE_MODEL_LOADER).build());
 
             typeBuilder.addMethod(MethodSpec.methodBuilder("createListModelLoader")
-                    .addAnnotation(Override.class)
-                    .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
-                    .addStatement("return new $T<>(getModelClass())", ClassNames.CACHEABLE_LIST_MODEL_LOADER)
-                    .returns(ClassNames.LIST_MODEL_LOADER).build());
+                .addAnnotation(Override.class)
+                .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
+                .addStatement("return new $T<>(getModelClass())", ClassNames.CACHEABLE_LIST_MODEL_LOADER)
+                .returns(ClassNames.LIST_MODEL_LOADER).build());
 
             typeBuilder.addMethod(MethodSpec.methodBuilder("cachingEnabled")
-                    .addAnnotation(Override.class)
-                    .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
-                    .addStatement("return $L", true)
-                    .returns(TypeName.BOOLEAN).build());
+                .addAnnotation(Override.class)
+                .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
+                .addStatement("return $L", true)
+                .returns(TypeName.BOOLEAN).build());
 
             List<ColumnDefinition> primaries = primaryColumnDefinitions;
             if (primaries == null || primaries.isEmpty()) {
@@ -481,8 +487,8 @@ public class TableDefinition extends BaseTableDefinition {
             InternalAdapterHelper.writeGetCachingId(typeBuilder, elementClassName, primaries, false);
 
             MethodSpec.Builder cachingbuilder = MethodSpec.methodBuilder("createCachingColumns")
-                    .addAnnotation(Override.class)
-                    .addModifiers(Modifier.PUBLIC, Modifier.FINAL);
+                .addAnnotation(Override.class)
+                .addModifiers(Modifier.PUBLIC, Modifier.FINAL);
             String columns = "return new String[]{";
             for (int i = 0; i < primaries.size(); i++) {
                 ColumnDefinition column = primaries.get(i);
@@ -494,43 +500,43 @@ public class TableDefinition extends BaseTableDefinition {
             columns += "}";
 
             cachingbuilder.addStatement(columns)
-                    .returns(ArrayTypeName.of(ClassName.get(String.class)));
+                .returns(ArrayTypeName.of(ClassName.get(String.class)));
 
             typeBuilder.addMethod(cachingbuilder.build());
 
             if (cacheSize != Table.DEFAULT_CACHE_SIZE) {
                 typeBuilder.addMethod(MethodSpec.methodBuilder("getCacheSize")
-                        .addAnnotation(Override.class)
-                        .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
-                        .addStatement("return $L", cacheSize)
-                        .returns(TypeName.INT).build());
+                    .addAnnotation(Override.class)
+                    .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
+                    .addStatement("return $L", cacheSize)
+                    .returns(TypeName.INT).build());
             }
 
             if (!StringUtils.isNullOrEmpty(customCacheFieldName)) {
                 typeBuilder.addMethod(MethodSpec.methodBuilder("createModelCache")
-                        .addAnnotation(Override.class)
-                        .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
-                        .addStatement("return $T.$L", elementClassName, customCacheFieldName)
-                        .returns(ParameterizedTypeName.get(ClassNames.MODEL_CACHE, elementClassName, WildcardTypeName.subtypeOf(Object.class))).build());
+                    .addAnnotation(Override.class)
+                    .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
+                    .addStatement("return $T.$L", elementClassName, customCacheFieldName)
+                    .returns(ParameterizedTypeName.get(ClassNames.MODEL_CACHE, elementClassName, WildcardTypeName.subtypeOf(Object.class))).build());
             }
 
             if (!StringUtils.isNullOrEmpty(customMultiCacheFieldName)) {
                 typeBuilder.addMethod(MethodSpec.methodBuilder("getCacheConverter")
-                        .addAnnotation(Override.class)
-                        .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
-                        .addStatement("return $T.$L", elementClassName, customMultiCacheFieldName)
-                        .returns(ParameterizedTypeName.get(ClassNames.MULTI_KEY_CACHE_CONVERTER, WildcardTypeName.subtypeOf(Object.class))).build());
+                    .addAnnotation(Override.class)
+                    .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
+                    .addStatement("return $T.$L", elementClassName, customMultiCacheFieldName)
+                    .returns(ParameterizedTypeName.get(ClassNames.MULTI_KEY_CACHE_CONVERTER, WildcardTypeName.subtypeOf(Object.class))).build());
             }
 
             MethodSpec.Builder reloadMethod = MethodSpec.methodBuilder("reloadRelationships")
-                    .addAnnotation(Override.class)
-                    .addParameter(elementClassName, ModelUtils.getVariable(false))
-                    .addParameter(ClassNames.CURSOR, LoadFromCursorMethod.PARAM_CURSOR)
-                    .addModifiers(Modifier.PUBLIC, Modifier.FINAL);
+                .addAnnotation(Override.class)
+                .addParameter(elementClassName, ModelUtils.getVariable(false))
+                .addParameter(ClassNames.CURSOR, LoadFromCursorMethod.PARAM_CURSOR)
+                .addModifiers(Modifier.PUBLIC, Modifier.FINAL);
             CodeBlock.Builder loadStatements = CodeBlock.builder();
             for (ColumnDefinition foreignColumn : foreignKeyDefinitions) {
                 CodeBlock.Builder codeBuilder = foreignColumn.getLoadFromCursorMethod(false, false,
-                        false).toBuilder();
+                    false).toBuilder();
                 if (!foreignColumn.elementTypeName.isPrimitive()) {
                     codeBuilder.nextControlFlow("else");
                     codeBuilder.addStatement(foreignColumn.setColumnAccessString(CodeBlock.builder().add("null").build(), false));
@@ -550,9 +556,9 @@ public class TableDefinition extends BaseTableDefinition {
         customTypeConverterPropertyMethod.addCode(constructorCode);
 
         typeBuilder.addMethod(MethodSpec.constructorBuilder()
-                .addParameter(ClassNames.DATABASE_HOLDER, "holder")
-                .addCode(constructorCode.build())
-                .addModifiers(Modifier.PUBLIC).build());
+            .addParameter(ClassNames.DATABASE_HOLDER, "holder")
+            .addCode(constructorCode.build())
+            .addModifiers(Modifier.PUBLIC).build());
 
         for (MethodDefinition methodDefinition : methods) {
             MethodSpec spec = methodDefinition.getMethodSpec();
@@ -562,35 +568,35 @@ public class TableDefinition extends BaseTableDefinition {
         }
 
         typeBuilder.addMethod(MethodSpec.methodBuilder("newInstance")
-                .addAnnotation(Override.class)
-                .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
-                .addStatement("return new $T()", elementClassName)
-                .returns(elementClassName)
-                .build());
+            .addAnnotation(Override.class)
+            .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
+            .addStatement("return new $T()", elementClassName)
+            .returns(elementClassName)
+            .build());
 
         typeBuilder.addMethod(MethodSpec.methodBuilder("getProperty")
-                .addAnnotation(Override.class)
-                .addParameter(ClassName.get(String.class), "name")
-                .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
-                .addStatement("return $T.getProperty($L)", outputClassName, "name")
-                .returns(ClassNames.BASE_PROPERTY)
-                .build());
+            .addAnnotation(Override.class)
+            .addParameter(ClassName.get(String.class), "name")
+            .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
+            .addStatement("return $T.getProperty($L)", outputClassName, "name")
+            .returns(ClassNames.BASE_PROPERTY)
+            .build());
 
         if (!updateConflictActionName.isEmpty()) {
             typeBuilder.addMethod(MethodSpec.methodBuilder("getUpdateOnConflictAction")
-                    .addAnnotation(Override.class)
-                    .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
-                    .addStatement("return $T.$L", ClassNames.CONFLICT_ACTION, updateConflictActionName)
-                    .returns(ClassNames.CONFLICT_ACTION)
-                    .build());
+                .addAnnotation(Override.class)
+                .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
+                .addStatement("return $T.$L", ClassNames.CONFLICT_ACTION, updateConflictActionName)
+                .returns(ClassNames.CONFLICT_ACTION)
+                .build());
         }
 
         if (!insertConflictActionName.isEmpty()) {
             typeBuilder.addMethod(MethodSpec.methodBuilder("getInsertOnConflictAction")
-                    .addAnnotation(Override.class)
-                    .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
-                    .addStatement("return $T.$L", ClassNames.CONFLICT_ACTION, insertConflictActionName)
-                    .returns(ClassNames.CONFLICT_ACTION).build());
+                .addAnnotation(Override.class)
+                .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
+                .addStatement("return $T.$L", ClassNames.CONFLICT_ACTION, insertConflictActionName)
+                .returns(ClassNames.CONFLICT_ACTION).build());
         }
 
 

--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/TableDefinition.java
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/TableDefinition.java
@@ -277,8 +277,8 @@ public class TableDefinition extends BaseTableDefinition {
             // no private static or final fields for all columns, or any inherited columns here.
             boolean isValidColumn = (allFields && (element.getKind().isField() &&
                     !element.getModifiers().contains(Modifier.STATIC) &&
-                    !element.getModifiers().contains(Modifier.PRIVATE) &&
-                    !element.getModifiers().contains(Modifier.FINAL)));
+                    !element.getModifiers().contains(Modifier.FINAL))) &&
+                    !element.asType().toString().equals(ClassNames.MODEL_ADAPTER.toString()); // ignore model adapter fields.
 
             // package private, will generate helper
             boolean isPackagePrivate = ElementUtility.isPackagePrivate(element);

--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/TableDefinition.java
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/TableDefinition.java
@@ -97,7 +97,7 @@ public class TableDefinition extends BaseTableDefinition {
 
     public boolean implementsLoadFromCursorListener = false;
 
-    private MethodDefinition[] methods;
+    private final MethodDefinition[] methods;
 
     public boolean cachingEnabled = false;
     public int cacheSize;
@@ -120,22 +120,13 @@ public class TableDefinition extends BaseTableDefinition {
 
     public TableDefinition(ProcessorManager manager, TypeElement element) {
         super(element, manager);
-        init(element, manager);
-    }
 
-    public TableDefinition(ProcessorManager manager, ClassName className) {
-        super(className, manager);
-        init(null, manager);
-    }
-
-    private void init(TypeElement element, ProcessorManager manager) {
         primaryColumnDefinitions = new ArrayList<>();
         foreignKeyDefinitions = new ArrayList<>();
         uniqueGroupsDefinitions = new ArrayList<>();
         indexGroupsDefinitions = new ArrayList<>();
 
-        boolean nullElement = element == null;
-        Table table = !nullElement ? element.getAnnotation(Table.class) : null;
+        Table table = element.getAnnotation(Table.class);
         if (table != null) {
             this.tableName = table.name();
             try {
@@ -167,9 +158,9 @@ public class TableDefinition extends BaseTableDefinition {
             }
 
             insertConflictActionName = insertConflict.equals(ConflictAction.NONE) ? ""
-                : insertConflict.name();
+                    : insertConflict.name();
             updateConflictActionName = updateConflict.equals(ConflictAction.NONE) ? ""
-                : updateConflict.name();
+                    : updateConflict.name();
 
             allFields = table.allFields();
             useIsForPrivateBooleans = table.useIsForPrivateBooleans();
@@ -233,33 +224,36 @@ public class TableDefinition extends BaseTableDefinition {
             }
 
             implementsLoadFromCursorListener = ProcessorUtils.implementsClass(manager.getProcessingEnvironment(),
-                ClassNames.LOAD_FROM_CURSOR_LISTENER.toString(), element);
+                    ClassNames.LOAD_FROM_CURSOR_LISTENER.toString(), element);
 
             implementsContentValuesListener = ProcessorUtils.implementsClass(manager.getProcessingEnvironment(),
-                ClassNames.CONTENT_VALUES_LISTENER.toString(), element);
+                    ClassNames.CONTENT_VALUES_LISTENER.toString(), element);
 
             implementsSqlStatementListener = ProcessorUtils.implementsClass(manager.getProcessingEnvironment(),
-                ClassNames.SQLITE_STATEMENT_LISTENER.toString(), element);
+                    ClassNames.SQLITE_STATEMENT_LISTENER.toString(), element);
         }
 
         methods = new MethodDefinition[]
 
-            {
-                new BindToContentValuesMethod(this, true, false, implementsContentValuesListener),
-                new BindToContentValuesMethod(this, false, false, implementsContentValuesListener),
-                new BindToStatementMethod(this, true, false),
-                new BindToStatementMethod(this, false, false),
-                new InsertStatementQueryMethod(this, true),
-                new InsertStatementQueryMethod(this, false),
-                new CreationQueryMethod(this),
-                new LoadFromCursorMethod(this, false, implementsLoadFromCursorListener, false),
-                new ExistenceMethod(this, false),
-                new PrimaryConditionMethod(this, false),
-                new OneToManyDeleteMethod(this, false),
-                new OneToManySaveMethod(this, false, OneToManySaveMethod.METHOD_SAVE),
-                new OneToManySaveMethod(this, false, OneToManySaveMethod.METHOD_INSERT),
-                new OneToManySaveMethod(this, false, OneToManySaveMethod.METHOD_UPDATE)
-            };
+                {
+                        new BindToContentValuesMethod(this, true, false, implementsContentValuesListener),
+                        new BindToContentValuesMethod(this, false, false, implementsContentValuesListener),
+                        new BindToStatementMethod(this, true, false),
+                        new BindToStatementMethod(this, false, false),
+                        new InsertStatementQueryMethod(this, true),
+                        new InsertStatementQueryMethod(this, false),
+                        new CreationQueryMethod(this),
+                        new LoadFromCursorMethod(this, false, implementsLoadFromCursorListener, false),
+                        new ExistenceMethod(this, false),
+                        new PrimaryConditionMethod(this, false),
+                        new OneToManyDeleteMethod(this, false),
+                        new OneToManySaveMethod(this, false, OneToManySaveMethod.METHOD_SAVE),
+                        new OneToManySaveMethod(this, false, OneToManySaveMethod.METHOD_INSERT),
+                        new OneToManySaveMethod(this, false, OneToManySaveMethod.METHOD_UPDATE)
+                }
+
+        ;
+
     }
 
     @Override
@@ -282,9 +276,9 @@ public class TableDefinition extends BaseTableDefinition {
 
             // no private static or final fields for all columns, or any inherited columns here.
             boolean isValidColumn = (allFields && (element.getKind().isField() &&
-                !element.getModifiers().contains(Modifier.STATIC) &&
-                !element.getModifiers().contains(Modifier.PRIVATE) &&
-                !element.getModifiers().contains(Modifier.FINAL)));
+                    !element.getModifiers().contains(Modifier.STATIC) &&
+                    !element.getModifiers().contains(Modifier.PRIVATE) &&
+                    !element.getModifiers().contains(Modifier.FINAL)));
 
             // package private, will generate helper
             boolean isPackagePrivate = ElementUtility.isPackagePrivate(element);
@@ -295,18 +289,18 @@ public class TableDefinition extends BaseTableDefinition {
             boolean isInherited = inheritedColumnMap.containsKey(element.getSimpleName().toString());
             boolean isInheritedPrimaryKey = inheritedPrimaryKeyMap.containsKey(element.getSimpleName().toString());
             if (element.getAnnotation(Column.class) != null || isForeign || isPrimary
-                || isValidColumn || isInherited || isInheritedPrimaryKey) {
+                    || isValidColumn || isInherited || isInheritedPrimaryKey) {
 
 
                 ColumnDefinition columnDefinition;
                 if (isInheritedPrimaryKey) {
                     InheritedPrimaryKey inherited = inheritedPrimaryKeyMap.get(element.getSimpleName().toString());
                     columnDefinition = new ColumnDefinition(manager, element, this, isPackagePrivateNotInSamePackage,
-                        inherited.column(), inherited.primaryKey());
+                            inherited.column(), inherited.primaryKey());
                 } else if (isInherited) {
                     InheritedColumn inherited = inheritedColumnMap.get(element.getSimpleName().toString());
                     columnDefinition = new ColumnDefinition(manager, element, this, isPackagePrivateNotInSamePackage,
-                        inherited.column(), null);
+                            inherited.column(), null);
                 } else if (isForeign) {
                     columnDefinition = new ForeignKeyColumnDefinition(manager, this, element, isPackagePrivateNotInSamePackage);
                 } else {
@@ -407,9 +401,9 @@ public class TableDefinition extends BaseTableDefinition {
     @Override
     public void onWriteDefinition(TypeSpec.Builder typeBuilder) {
         MethodSpec.Builder getPropertyForNameMethod = MethodSpec.methodBuilder("getProperty")
-            .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
-            .addParameter(String.class, "columnName")
-            .returns(ClassNames.BASE_PROPERTY);
+                .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+                .addParameter(String.class, "columnName")
+                .returns(ClassNames.BASE_PROPERTY);
 
         getPropertyForNameMethod.addStatement("columnName = $T.quoteIfNeeded(columnName)", ClassName.get(QueryBuilder.class));
 
@@ -420,7 +414,7 @@ public class TableDefinition extends BaseTableDefinition {
         }
         getPropertyForNameMethod.beginControlFlow("default: ");
         getPropertyForNameMethod.addStatement("throw new $T($S)", IllegalArgumentException.class,
-            "Invalid column name passed. Ensure you are calling the correct table's column");
+                "Invalid column name passed. Ensure you are calling the correct table's column");
         getPropertyForNameMethod.endControlFlow();
         getPropertyForNameMethod.endControlFlow();
 
@@ -435,27 +429,27 @@ public class TableDefinition extends BaseTableDefinition {
     public void writeAdapter(ProcessingEnvironment processingEnvironment) throws IOException {
 
         TypeSpec.Builder typeBuilder = TypeSpec.classBuilder(adapterName)
-            .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
-            .superclass(ParameterizedTypeName.get(ClassNames.MODEL_ADAPTER, elementClassName));
+                .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
+                .superclass(ParameterizedTypeName.get(ClassNames.MODEL_ADAPTER, elementClassName));
         InternalAdapterHelper.writeGetModelClass(typeBuilder, elementClassName);
         InternalAdapterHelper.writeGetTableName(typeBuilder, tableName);
 
         if (hasAutoIncrement) {
             InternalAdapterHelper.writeUpdateAutoIncrement(typeBuilder, elementClassName,
-                autoIncrementDefinition, false);
+                    autoIncrementDefinition, false);
 
             typeBuilder.addMethod(MethodSpec.methodBuilder("getAutoIncrementingId")
-                .addAnnotation(Override.class)
-                .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
-                .addParameter(elementClassName, ModelUtils.getVariable(false))
-                .addStatement("return $L", autoIncrementDefinition.getColumnAccessString(false, false))
-                .returns(ClassName.get(Number.class)).build());
+                    .addAnnotation(Override.class)
+                    .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
+                    .addParameter(elementClassName, ModelUtils.getVariable(false))
+                    .addStatement("return $L", autoIncrementDefinition.getColumnAccessString(false, false))
+                    .returns(ClassName.get(Number.class)).build());
 
             typeBuilder.addMethod(MethodSpec.methodBuilder("getAutoIncrementingColumnName")
-                .addAnnotation(Override.class)
-                .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
-                .addStatement("return $S", QueryBuilder.stripQuotes(autoIncrementDefinition.columnName))
-                .returns(ClassName.get(String.class)).build());
+                    .addAnnotation(Override.class)
+                    .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
+                    .addStatement("return $S", QueryBuilder.stripQuotes(autoIncrementDefinition.columnName))
+                    .returns(ClassName.get(String.class)).build());
         }
 
         if (cachingEnabled) {
@@ -463,22 +457,22 @@ public class TableDefinition extends BaseTableDefinition {
             // TODO: pass in model cache loaders.
 
             typeBuilder.addMethod(MethodSpec.methodBuilder("createSingleModelLoader")
-                .addAnnotation(Override.class)
-                .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
-                .addStatement("return new $T<>(getModelClass())", ClassNames.CACHEABLE_MODEL_LOADER)
-                .returns(ClassNames.SINGLE_MODEL_LOADER).build());
+                    .addAnnotation(Override.class)
+                    .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
+                    .addStatement("return new $T<>(getModelClass())", ClassNames.CACHEABLE_MODEL_LOADER)
+                    .returns(ClassNames.SINGLE_MODEL_LOADER).build());
 
             typeBuilder.addMethod(MethodSpec.methodBuilder("createListModelLoader")
-                .addAnnotation(Override.class)
-                .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
-                .addStatement("return new $T<>(getModelClass())", ClassNames.CACHEABLE_LIST_MODEL_LOADER)
-                .returns(ClassNames.LIST_MODEL_LOADER).build());
+                    .addAnnotation(Override.class)
+                    .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
+                    .addStatement("return new $T<>(getModelClass())", ClassNames.CACHEABLE_LIST_MODEL_LOADER)
+                    .returns(ClassNames.LIST_MODEL_LOADER).build());
 
             typeBuilder.addMethod(MethodSpec.methodBuilder("cachingEnabled")
-                .addAnnotation(Override.class)
-                .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
-                .addStatement("return $L", true)
-                .returns(TypeName.BOOLEAN).build());
+                    .addAnnotation(Override.class)
+                    .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
+                    .addStatement("return $L", true)
+                    .returns(TypeName.BOOLEAN).build());
 
             List<ColumnDefinition> primaries = primaryColumnDefinitions;
             if (primaries == null || primaries.isEmpty()) {
@@ -487,8 +481,8 @@ public class TableDefinition extends BaseTableDefinition {
             InternalAdapterHelper.writeGetCachingId(typeBuilder, elementClassName, primaries, false);
 
             MethodSpec.Builder cachingbuilder = MethodSpec.methodBuilder("createCachingColumns")
-                .addAnnotation(Override.class)
-                .addModifiers(Modifier.PUBLIC, Modifier.FINAL);
+                    .addAnnotation(Override.class)
+                    .addModifiers(Modifier.PUBLIC, Modifier.FINAL);
             String columns = "return new String[]{";
             for (int i = 0; i < primaries.size(); i++) {
                 ColumnDefinition column = primaries.get(i);
@@ -500,43 +494,43 @@ public class TableDefinition extends BaseTableDefinition {
             columns += "}";
 
             cachingbuilder.addStatement(columns)
-                .returns(ArrayTypeName.of(ClassName.get(String.class)));
+                    .returns(ArrayTypeName.of(ClassName.get(String.class)));
 
             typeBuilder.addMethod(cachingbuilder.build());
 
             if (cacheSize != Table.DEFAULT_CACHE_SIZE) {
                 typeBuilder.addMethod(MethodSpec.methodBuilder("getCacheSize")
-                    .addAnnotation(Override.class)
-                    .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
-                    .addStatement("return $L", cacheSize)
-                    .returns(TypeName.INT).build());
+                        .addAnnotation(Override.class)
+                        .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
+                        .addStatement("return $L", cacheSize)
+                        .returns(TypeName.INT).build());
             }
 
             if (!StringUtils.isNullOrEmpty(customCacheFieldName)) {
                 typeBuilder.addMethod(MethodSpec.methodBuilder("createModelCache")
-                    .addAnnotation(Override.class)
-                    .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
-                    .addStatement("return $T.$L", elementClassName, customCacheFieldName)
-                    .returns(ParameterizedTypeName.get(ClassNames.MODEL_CACHE, elementClassName, WildcardTypeName.subtypeOf(Object.class))).build());
+                        .addAnnotation(Override.class)
+                        .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
+                        .addStatement("return $T.$L", elementClassName, customCacheFieldName)
+                        .returns(ParameterizedTypeName.get(ClassNames.MODEL_CACHE, elementClassName, WildcardTypeName.subtypeOf(Object.class))).build());
             }
 
             if (!StringUtils.isNullOrEmpty(customMultiCacheFieldName)) {
                 typeBuilder.addMethod(MethodSpec.methodBuilder("getCacheConverter")
-                    .addAnnotation(Override.class)
-                    .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
-                    .addStatement("return $T.$L", elementClassName, customMultiCacheFieldName)
-                    .returns(ParameterizedTypeName.get(ClassNames.MULTI_KEY_CACHE_CONVERTER, WildcardTypeName.subtypeOf(Object.class))).build());
+                        .addAnnotation(Override.class)
+                        .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
+                        .addStatement("return $T.$L", elementClassName, customMultiCacheFieldName)
+                        .returns(ParameterizedTypeName.get(ClassNames.MULTI_KEY_CACHE_CONVERTER, WildcardTypeName.subtypeOf(Object.class))).build());
             }
 
             MethodSpec.Builder reloadMethod = MethodSpec.methodBuilder("reloadRelationships")
-                .addAnnotation(Override.class)
-                .addParameter(elementClassName, ModelUtils.getVariable(false))
-                .addParameter(ClassNames.CURSOR, LoadFromCursorMethod.PARAM_CURSOR)
-                .addModifiers(Modifier.PUBLIC, Modifier.FINAL);
+                    .addAnnotation(Override.class)
+                    .addParameter(elementClassName, ModelUtils.getVariable(false))
+                    .addParameter(ClassNames.CURSOR, LoadFromCursorMethod.PARAM_CURSOR)
+                    .addModifiers(Modifier.PUBLIC, Modifier.FINAL);
             CodeBlock.Builder loadStatements = CodeBlock.builder();
             for (ColumnDefinition foreignColumn : foreignKeyDefinitions) {
                 CodeBlock.Builder codeBuilder = foreignColumn.getLoadFromCursorMethod(false, false,
-                    false).toBuilder();
+                        false).toBuilder();
                 if (!foreignColumn.elementTypeName.isPrimitive()) {
                     codeBuilder.nextControlFlow("else");
                     codeBuilder.addStatement(foreignColumn.setColumnAccessString(CodeBlock.builder().add("null").build(), false));
@@ -556,9 +550,9 @@ public class TableDefinition extends BaseTableDefinition {
         customTypeConverterPropertyMethod.addCode(constructorCode);
 
         typeBuilder.addMethod(MethodSpec.constructorBuilder()
-            .addParameter(ClassNames.DATABASE_HOLDER, "holder")
-            .addCode(constructorCode.build())
-            .addModifiers(Modifier.PUBLIC).build());
+                .addParameter(ClassNames.DATABASE_HOLDER, "holder")
+                .addCode(constructorCode.build())
+                .addModifiers(Modifier.PUBLIC).build());
 
         for (MethodDefinition methodDefinition : methods) {
             MethodSpec spec = methodDefinition.getMethodSpec();
@@ -568,35 +562,35 @@ public class TableDefinition extends BaseTableDefinition {
         }
 
         typeBuilder.addMethod(MethodSpec.methodBuilder("newInstance")
-            .addAnnotation(Override.class)
-            .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
-            .addStatement("return new $T()", elementClassName)
-            .returns(elementClassName)
-            .build());
+                .addAnnotation(Override.class)
+                .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
+                .addStatement("return new $T()", elementClassName)
+                .returns(elementClassName)
+                .build());
 
         typeBuilder.addMethod(MethodSpec.methodBuilder("getProperty")
-            .addAnnotation(Override.class)
-            .addParameter(ClassName.get(String.class), "name")
-            .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
-            .addStatement("return $T.getProperty($L)", outputClassName, "name")
-            .returns(ClassNames.BASE_PROPERTY)
-            .build());
+                .addAnnotation(Override.class)
+                .addParameter(ClassName.get(String.class), "name")
+                .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
+                .addStatement("return $T.getProperty($L)", outputClassName, "name")
+                .returns(ClassNames.BASE_PROPERTY)
+                .build());
 
         if (!updateConflictActionName.isEmpty()) {
             typeBuilder.addMethod(MethodSpec.methodBuilder("getUpdateOnConflictAction")
-                .addAnnotation(Override.class)
-                .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
-                .addStatement("return $T.$L", ClassNames.CONFLICT_ACTION, updateConflictActionName)
-                .returns(ClassNames.CONFLICT_ACTION)
-                .build());
+                    .addAnnotation(Override.class)
+                    .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
+                    .addStatement("return $T.$L", ClassNames.CONFLICT_ACTION, updateConflictActionName)
+                    .returns(ClassNames.CONFLICT_ACTION)
+                    .build());
         }
 
         if (!insertConflictActionName.isEmpty()) {
             typeBuilder.addMethod(MethodSpec.methodBuilder("getInsertOnConflictAction")
-                .addAnnotation(Override.class)
-                .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
-                .addStatement("return $T.$L", ClassNames.CONFLICT_ACTION, insertConflictActionName)
-                .returns(ClassNames.CONFLICT_ACTION).build());
+                    .addAnnotation(Override.class)
+                    .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
+                    .addStatement("return $T.$L", ClassNames.CONFLICT_ACTION, insertConflictActionName)
+                    .returns(ClassNames.CONFLICT_ACTION).build());
         }
 
 

--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/TableDefinition.java
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/TableDefinition.java
@@ -3,7 +3,6 @@ package com.raizlabs.android.dbflow.processor.definition;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.raizlabs.android.dbflow.annotation.Column;
-import com.raizlabs.android.dbflow.annotation.ColumnIgnore;
 import com.raizlabs.android.dbflow.annotation.ConflictAction;
 import com.raizlabs.android.dbflow.annotation.ContainerKey;
 import com.raizlabs.android.dbflow.annotation.ForeignKey;
@@ -42,6 +41,7 @@ import com.raizlabs.android.dbflow.sql.QueryBuilder;
 import com.squareup.javapoet.ArrayTypeName;
 import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.CodeBlock;
+import com.squareup.javapoet.FieldSpec;
 import com.squareup.javapoet.JavaFile;
 import com.squareup.javapoet.MethodSpec;
 import com.squareup.javapoet.ParameterizedTypeName;
@@ -401,6 +401,15 @@ public class TableDefinition extends BaseTableDefinition {
 
     @Override
     public void onWriteDefinition(TypeSpec.Builder typeBuilder) {
+
+        FieldSpec.Builder propertyConverter = FieldSpec.builder(ClassNames.PROPERTY_CONVERTER, "PROPERTY_CONVERTER", Modifier.FINAL, Modifier.PUBLIC, Modifier.STATIC)
+                .initializer(CodeBlock.builder()
+                        .add("new $T(){ \n", ClassNames.PROPERTY_CONVERTER)
+                        .add("public $T fromName(String columnName) {\n", ClassNames.IPROPERTY)
+                        .add("return $L.getProperty(columnName); \n}\n}", getPropertyClassName())
+                        .build());
+        typeBuilder.addField(propertyConverter.build());
+
         MethodSpec.Builder getPropertyForNameMethod = MethodSpec.methodBuilder("getProperty")
                 .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
                 .addParameter(String.class, "columnName")

--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/TableEndpointDefinition.java
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/TableEndpointDefinition.java
@@ -6,6 +6,7 @@ import com.raizlabs.android.dbflow.annotation.provider.ContentUri;
 import com.raizlabs.android.dbflow.annotation.provider.Notify;
 import com.raizlabs.android.dbflow.annotation.provider.TableEndpoint;
 import com.raizlabs.android.dbflow.processor.model.ProcessorManager;
+import com.squareup.javapoet.TypeName;
 
 import java.util.List;
 import java.util.Map;
@@ -13,6 +14,7 @@ import java.util.Map;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.PackageElement;
 import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.MirroredTypeException;
 
 /**
  * Description:
@@ -30,7 +32,7 @@ public class TableEndpointDefinition extends BaseDefinition {
 
     public String tableName;
 
-    public String contentProviderName;
+    public TypeName contentProviderName;
 
     public boolean isTopLevel = false;
 
@@ -42,7 +44,11 @@ public class TableEndpointDefinition extends BaseDefinition {
 
             tableName = endpoint.name();
 
-            contentProviderName = endpoint.contentProviderName();
+            try {
+                endpoint.contentProvider();
+            } catch (MirroredTypeException mte) {
+                contentProviderName = TypeName.get(mte.getTypeMirror());
+            }
         }
 
         isTopLevel = typeElement.getEnclosingElement() instanceof PackageElement;

--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/column/ColumnDefinition.java
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/column/ColumnDefinition.java
@@ -70,7 +70,6 @@ public class ColumnDefinition extends BaseDefinition {
 
     public Collate collate = Collate.NONE;
     public String defaultValue;
-    public boolean hasDefaultValue;
 
     public boolean isBoolean = false;
 
@@ -90,7 +89,6 @@ public class ColumnDefinition extends BaseDefinition {
             length = column.length();
             collate = column.collate();
             defaultValue = column.defaultValue();
-            hasDefaultValue = defaultValue != null;
             excludeFromToModelMethod = column.excludeFromToModelMethod();
         } else {
             this.columnName = element.getSimpleName()

--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/column/ColumnDefinition.java
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/column/ColumnDefinition.java
@@ -395,6 +395,10 @@ public class ColumnDefinition extends BaseDefinition {
         return codeBlockBuilder.build();
     }
 
+    public String getPrimaryKeyName() {
+        return QueryBuilder.quote(columnName);
+    }
+
     public CodeBlock getForeignKeyContainerMethod(ClassName tableClassName) {
 
         CodeBlock.Builder codeBuilder = CodeBlock.builder();

--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/column/ColumnDefinition.java
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/column/ColumnDefinition.java
@@ -75,7 +75,7 @@ public class ColumnDefinition extends BaseDefinition {
 
     public BaseColumnAccess columnAccess;
     public boolean hasCustomConverter;
-    private BaseTableDefinition tableDefinition;
+    public BaseTableDefinition tableDefinition;
 
     public ColumnDefinition(ProcessorManager processorManager, Element element,
                             BaseTableDefinition baseTableDefinition, boolean isPackagePrivate,

--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/column/ColumnDefinition.java
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/column/ColumnDefinition.java
@@ -347,7 +347,7 @@ public class ColumnDefinition extends BaseDefinition {
      * @return A string without any type conversion for this field.
      */
     public void appendPropertyComparisonAccessStatement(boolean isModelContainerAdapter, CodeBlock.Builder codeBuilder) {
-        codeBuilder.add("\n.and($T.$L.eq(", tableDefinition.getPropertyClassName(), columnName);
+        codeBuilder.add("\nclause.and($T.$L.eq(", tableDefinition.getPropertyClassName(), columnName);
         if (columnAccess instanceof TypeConverterAccess) {
             TypeConverterAccess converterAccess = ((TypeConverterAccess) columnAccess);
             TypeConverterDefinition converterDefinition = converterAccess.typeConverterDefinition;
@@ -365,7 +365,7 @@ public class ColumnDefinition extends BaseDefinition {
         } else {
             codeBuilder.add(getColumnAccessString(isModelContainerAdapter, false));
         }
-        codeBuilder.add("))");
+        codeBuilder.add("));");
     }
 
     public String getReferenceColumnName(ForeignKeyReference reference) {

--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/column/ColumnDefinition.java
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/column/ColumnDefinition.java
@@ -70,6 +70,7 @@ public class ColumnDefinition extends BaseDefinition {
 
     public Collate collate = Collate.NONE;
     public String defaultValue;
+    public boolean hasDefaultValue;
 
     public boolean isBoolean = false;
 
@@ -85,14 +86,15 @@ public class ColumnDefinition extends BaseDefinition {
         this.column = column;
         if (column != null) {
             this.columnName = column.name().equals("") ? element.getSimpleName()
-                    .toString() : column.name();
+                .toString() : column.name();
             length = column.length();
             collate = column.collate();
             defaultValue = column.defaultValue();
+            hasDefaultValue = defaultValue != null;
             excludeFromToModelMethod = column.excludeFromToModelMethod();
         } else {
             this.columnName = element.getSimpleName()
-                    .toString();
+                .toString();
         }
 
         if (isPackagePrivate) {
@@ -102,10 +104,10 @@ public class ColumnDefinition extends BaseDefinition {
             PackagePrivateAccess.putElement(((PackagePrivateAccess) columnAccess).helperClassName, columnName);
         } else {
             boolean isPrivate = element.getModifiers()
-                    .contains(Modifier.PRIVATE);
+                .contains(Modifier.PRIVATE);
             if (isPrivate) {
                 boolean useIs = elementTypeName.box().equals(TypeName.BOOLEAN.box())
-                        && (baseTableDefinition instanceof TableDefinition) && ((TableDefinition) baseTableDefinition).useIsForPrivateBooleans;
+                    && (baseTableDefinition instanceof TableDefinition) && ((TableDefinition) baseTableDefinition).useIsForPrivateBooleans;
                 columnAccess = new PrivateColumnAccess(column, useIs);
             } else {
                 columnAccess = new SimpleColumnAccess();
@@ -177,7 +179,7 @@ public class ColumnDefinition extends BaseDefinition {
             TypeConverterDefinition typeConverterDefinition = new TypeConverterDefinition(typeConverterElement, manager);
             if (!typeConverterDefinition.getModelTypeName().equals(elementTypeName)) {
                 manager.logError("The specified custom TypeConverter's Model Value %1s from %1s must match the type of the column %1s. ",
-                        typeConverterDefinition.getModelTypeName(), typeConverterClassName, elementTypeName);
+                    typeConverterDefinition.getModelTypeName(), typeConverterClassName, elementTypeName);
             } else {
                 hasCustomConverter = true;
                 String fieldName = baseTableDefinition.addColumnForCustomTypeConverter(this, typeConverterClassName);
@@ -197,7 +199,7 @@ public class ColumnDefinition extends BaseDefinition {
                     // do nothing.
                 } else if (elementTypeName instanceof ArrayTypeName) {
                     processorManager.getMessager()
-                            .printMessage(Diagnostic.Kind.ERROR, "Columns cannot be of array type.");
+                        .printMessage(Diagnostic.Kind.ERROR, "Columns cannot be of array type.");
                 } else {
                     if (elementTypeName.equals(TypeName.BOOLEAN.box())) {
                         isBoolean = true;
@@ -226,7 +228,7 @@ public class ColumnDefinition extends BaseDefinition {
     public ColumnDefinition(ProcessorManager processorManager, Element element,
                             BaseTableDefinition baseTableDefinition, boolean isPackagePrivate) {
         this(processorManager, element, baseTableDefinition, isPackagePrivate,
-                element.getAnnotation(Column.class), element.getAnnotation(PrimaryKey.class));
+            element.getAnnotation(Column.class), element.getAnnotation(PrimaryKey.class));
 
     }
 
@@ -248,8 +250,8 @@ public class ColumnDefinition extends BaseDefinition {
             propParam = ParameterizedTypeName.get(ClassNames.PROPERTY, elementTypeName.box());
         }
         typeBuilder.addField(FieldSpec.builder(propParam,
-                columnName, Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL)
-                .initializer("new $T($T.class, $S)", propParam, tableClass, columnName).build());
+            columnName, Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL)
+            .initializer("new $T($T.class, $S)", propParam, tableClass, columnName).build());
     }
 
     public void addPropertyCase(MethodSpec.Builder methodBuilder) {
@@ -260,24 +262,25 @@ public class ColumnDefinition extends BaseDefinition {
 
     public CodeBlock getInsertStatementColumnName() {
         return CodeBlock.builder()
-                .add("$L", QueryBuilder.quote(columnName))
-                .build();
+            .add("$L", QueryBuilder.quote(columnName))
+            .build();
     }
 
     public CodeBlock getInsertStatementValuesString() {
         return CodeBlock.builder()
-                .add("?")
-                .build();
+            .add("?")
+            .build();
     }
 
     public CodeBlock getContentValuesStatement(boolean isModelContainerAdapter) {
         return DefinitionUtils.getContentValuesStatement(containerKeyName, elementName,
-                columnName, elementTypeName, isModelContainerAdapter, columnAccess, ModelUtils.getVariable(isModelContainerAdapter)).build();
+            columnName, elementTypeName, isModelContainerAdapter, columnAccess, ModelUtils.getVariable(isModelContainerAdapter), defaultValue).build();
     }
 
     public CodeBlock getSQLiteStatementMethod(AtomicInteger index, boolean isModelContainerAdapter) {
         return DefinitionUtils.getSQLiteStatementMethod(index, containerKeyName, elementName,
-                elementTypeName, isModelContainerAdapter, columnAccess, ModelUtils.getVariable(isModelContainerAdapter), isPrimaryKeyAutoIncrement).build();
+            elementTypeName, isModelContainerAdapter, columnAccess,
+            ModelUtils.getVariable(isModelContainerAdapter), isPrimaryKeyAutoIncrement, defaultValue).build();
     }
 
     public CodeBlock getLoadFromCursorMethod(boolean isModelContainerAdapter, boolean putNullForContainerAdapter,
@@ -289,7 +292,7 @@ public class ColumnDefinition extends BaseDefinition {
             putDefaultValue = true;
         }
         return DefinitionUtils.getLoadFromCursorMethod(containerKeyName, elementName,
-                elementTypeName, columnName, isModelContainerAdapter, putDefaultValue, columnAccess).build();
+            elementTypeName, columnName, isModelContainerAdapter, putDefaultValue, columnAccess).build();
     }
 
     /**
@@ -299,12 +302,12 @@ public class ColumnDefinition extends BaseDefinition {
      */
     public CodeBlock getUpdateAutoIncrementMethod(boolean isModelContainerAdapter) {
         return DefinitionUtils.getUpdateAutoIncrementMethod(containerKeyName, elementName, elementTypeName,
-                isModelContainerAdapter, columnAccess).build();
+            isModelContainerAdapter, columnAccess).build();
     }
 
     public String setColumnAccessString(CodeBlock formattedAccess, boolean toModelMethod) {
         return columnAccess.setColumnAccessString(elementTypeName, containerKeyName, elementName,
-                false, ModelUtils.getVariable(false), formattedAccess, toModelMethod);
+            false, ModelUtils.getVariable(false), formattedAccess, toModelMethod);
     }
 
     public CodeBlock getToModelMethod() {
@@ -323,18 +326,18 @@ public class ColumnDefinition extends BaseDefinition {
             }
         }
         CodeBlock.Builder codeBuilder = CodeBlock.builder()
-                .add("$L.$LValue($S)", ModelUtils.getVariable(true), method, containerKeyName);
+            .add("$L.$LValue($S)", ModelUtils.getVariable(true), method, containerKeyName);
 
         BaseColumnAccess columnAccessToUse = columnAccess;
         if (columnAccess instanceof BooleanColumnAccess ||
-                (columnAccess instanceof TypeConverterAccess && ((TypeConverterAccess) columnAccess)
-                        .typeConverterDefinition.getModelTypeName().equals(TypeName.BOOLEAN.box()))) {
+            (columnAccess instanceof TypeConverterAccess && ((TypeConverterAccess) columnAccess)
+                .typeConverterDefinition.getModelTypeName().equals(TypeName.BOOLEAN.box()))) {
             columnAccessToUse = ((TypeConverterAccess) columnAccess).existingColumnAccess;
         }
         return CodeBlock.builder()
-                .addStatement(columnAccessToUse.setColumnAccessString(elementTypeName, containerKeyName, elementName,
-                        false, ModelUtils.getVariable(false), codeBuilder.build(), true))
-                .build();
+            .addStatement(columnAccessToUse.setColumnAccessString(elementTypeName, containerKeyName, elementName,
+                false, ModelUtils.getVariable(false), codeBuilder.build(), true))
+            .build();
     }
 
     public String getColumnAccessString(boolean isModelContainerAdapter, boolean isSqliteStatment) {
@@ -353,14 +356,14 @@ public class ColumnDefinition extends BaseDefinition {
             TypeConverterDefinition converterDefinition = converterAccess.typeConverterDefinition;
             if (!isModelContainerAdapter) {
                 codeBuilder.add(converterAccess.existingColumnAccess.getColumnAccessString(converterDefinition.getDbTypeName(), containerKeyName, elementName,
-                        ModelUtils.getVariable(isModelContainerAdapter), isModelContainerAdapter, false));
+                    ModelUtils.getVariable(isModelContainerAdapter), isModelContainerAdapter, false));
             } else {
                 codeBuilder.add(CodeBlock.builder()
-                        .add("$L.getTypeConvertedPropertyValue($T.class, $S)",
-                                ModelUtils.getVariable(isModelContainerAdapter),
-                                converterAccess.typeConverterDefinition.getModelTypeName(),
-                                containerKeyName)
-                        .build());
+                    .add("$L.getTypeConvertedPropertyValue($T.class, $S)",
+                        ModelUtils.getVariable(isModelContainerAdapter),
+                        converterAccess.typeConverterDefinition.getModelTypeName(),
+                        containerKeyName)
+                    .build());
             }
         } else {
             codeBuilder.add(getColumnAccessString(isModelContainerAdapter, false));
@@ -398,8 +401,8 @@ public class ColumnDefinition extends BaseDefinition {
 
         CodeBlock.Builder codeBuilder = CodeBlock.builder();
         codeBuilder.addStatement("$L.put($T.$L, $L)", ModelUtils.getVariable(true), tableClassName, columnName,
-                columnAccess.getColumnAccessString(elementTypeName, containerKeyName, elementName,
-                        ModelUtils.getVariable(false), false, false));
+            columnAccess.getColumnAccessString(elementTypeName, containerKeyName, elementName,
+                ModelUtils.getVariable(false), false, false));
         return codeBuilder.build();
     }
 }

--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/column/DefinitionUtils.java
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/column/DefinitionUtils.java
@@ -36,7 +36,9 @@ public class DefinitionUtils {
             finalAccessStatement = (isModelContainerAdapter ? (variableNameString + elementName) : ("ref" + fullElementName));
 
             if (columnAccess instanceof TypeConverterAccess) {
-                finalTypeName = ((TypeConverterAccess) columnAccess).typeConverterDefinition.getDbTypeName();
+                if (((TypeConverterAccess) columnAccess).typeConverterDefinition != null) {
+                    finalTypeName = ((TypeConverterAccess) columnAccess).typeConverterDefinition.getDbTypeName();
+                }
                 isBlobRaw = (finalTypeName.equals(ClassName.get(Blob.class)));
             } else {
                 if (columnAccess instanceof EnumColumnAccess) {
@@ -96,7 +98,9 @@ public class DefinitionUtils {
             finalAccessStatement = (isModelContainerAdapter ? (variableNameString + elementName) : ("ref" + fullElementName));
 
             if (columnAccess instanceof TypeConverterAccess) {
-                finalTypeName = ((TypeConverterAccess) columnAccess).typeConverterDefinition.getDbTypeName();
+                if (((TypeConverterAccess) columnAccess).typeConverterDefinition != null) {
+                    finalTypeName = ((TypeConverterAccess) columnAccess).typeConverterDefinition.getDbTypeName();
+                }
                 isBlobRaw = (finalTypeName.equals(ClassName.get(Blob.class)));
             } else {
                 if (columnAccess instanceof EnumColumnAccess) {
@@ -235,7 +239,7 @@ public class DefinitionUtils {
 
         if (SQLiteHelper.containsType(elementTypeName)) {
             statement = SQLiteHelper.get(elementTypeName).toString();
-        } else if (columnAccess instanceof TypeConverterAccess) {
+        } else if (columnAccess instanceof TypeConverterAccess && ((TypeConverterAccess) columnAccess).typeConverterDefinition != null) {
             statement = SQLiteHelper.get(((TypeConverterAccess) columnAccess).typeConverterDefinition.getDbTypeName()).toString();
         }
 
@@ -249,7 +253,7 @@ public class DefinitionUtils {
         String method = "";
         if (SQLiteHelper.containsMethod(elementTypeName)) {
             method = SQLiteHelper.getMethod(elementTypeName);
-        } else if (columnAccess instanceof TypeConverterAccess) {
+        } else if (columnAccess instanceof TypeConverterAccess && ((TypeConverterAccess) columnAccess).typeConverterDefinition != null) {
             method = SQLiteHelper.getMethod(((TypeConverterAccess) columnAccess).typeConverterDefinition.getDbTypeName());
         } else if (columnAccess instanceof EnumColumnAccess) {
             method = SQLiteHelper.getMethod(ClassName.get(String.class));

--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/column/DefinitionUtils.java
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/column/DefinitionUtils.java
@@ -32,7 +32,7 @@ public class DefinitionUtils {
 
         TypeName finalTypeName = elementTypeName;
         if (columnAccess instanceof WrapperColumnAccess && !(columnAccess instanceof BooleanTypeColumnAccess)
-            || isModelContainerAdapter && !elementTypeName.isPrimitive()) {
+                || isModelContainerAdapter && !elementTypeName.isPrimitive()) {
             finalAccessStatement = (isModelContainerAdapter ? (variableNameString + elementName) : ("ref" + fullElementName));
 
             if (columnAccess instanceof TypeConverterAccess) {
@@ -51,26 +51,26 @@ public class DefinitionUtils {
             if (!isModelContainerAdapter && !elementTypeName.isPrimitive()) {
                 String shortAccess = ((WrapperColumnAccess) columnAccess).existingColumnAccess.getShortAccessString(elementTypeName, elementName, isModelContainerAdapter, false);
                 codeBuilder.addStatement("$T $L = model.$L != null ? $L : null", finalTypeName,
-                    finalAccessStatement, shortAccess, statement);
+                        finalAccessStatement, shortAccess, statement);
             } else {
                 codeBuilder.addStatement("$T $L = $L", finalTypeName,
-                    finalAccessStatement, statement);
+                        finalAccessStatement, statement);
             }
         }
 
         String putAccess = applyAndGetPutAccess(finalAccessStatement, isBlobRaw, elementTypeName, finalTypeName,
-            isModelContainerAdapter, columnAccess, codeBuilder, variableNameString, elementName);
+                isModelContainerAdapter, columnAccess, codeBuilder, variableNameString, elementName);
 
         codeBuilder.addStatement("$L.put($S, $L)",
-            BindToContentValuesMethod.PARAM_CONTENT_VALUES,
-            QueryBuilder.quote(columnName), putAccess);
+                BindToContentValuesMethod.PARAM_CONTENT_VALUES,
+                QueryBuilder.quote(columnName), putAccess);
 
         if (!finalTypeName.isPrimitive()) {
             codeBuilder.nextControlFlow("else");
             if (defaultValue != null && !defaultValue.isEmpty()) {
                 codeBuilder.addStatement("$L.put($S, $L)",
-                    BindToContentValuesMethod.PARAM_CONTENT_VALUES,
-                    QueryBuilder.quote(columnName), defaultValue);
+                        BindToContentValuesMethod.PARAM_CONTENT_VALUES,
+                        QueryBuilder.quote(columnName), defaultValue);
             } else {
                 codeBuilder.addStatement("$L.putNull($S)", BindToContentValuesMethod.PARAM_CONTENT_VALUES, QueryBuilder.quote(columnName));
             }
@@ -92,7 +92,7 @@ public class DefinitionUtils {
 
         TypeName finalTypeName = elementTypeName;
         if (columnAccess instanceof WrapperColumnAccess && !(columnAccess instanceof BooleanTypeColumnAccess)
-            || isModelContainerAdapter && !elementTypeName.isPrimitive()) {
+                || isModelContainerAdapter && !elementTypeName.isPrimitive()) {
             finalAccessStatement = (isModelContainerAdapter ? (variableNameString + elementName) : ("ref" + fullElementName));
 
             if (columnAccess instanceof TypeConverterAccess) {
@@ -111,26 +111,26 @@ public class DefinitionUtils {
             if (!isModelContainerAdapter && !elementTypeName.isPrimitive()) {
                 String shortAccess = ((WrapperColumnAccess) columnAccess).existingColumnAccess.getShortAccessString(elementTypeName, elementName, isModelContainerAdapter, true);
                 codeBuilder.addStatement("$T $L = model.$L != null ? $L : null", finalTypeName,
-                    finalAccessStatement, shortAccess, statement);
+                        finalAccessStatement, shortAccess, statement);
             } else {
                 codeBuilder.addStatement("$T $L = $L", finalTypeName,
-                    finalAccessStatement, statement);
+                        finalAccessStatement, statement);
             }
         }
 
         String putAccess = applyAndGetPutAccess(finalAccessStatement, isBlobRaw, elementTypeName, finalTypeName,
-            isModelContainerAdapter, columnAccess, codeBuilder, variableNameString, elementName);
+                isModelContainerAdapter, columnAccess, codeBuilder, variableNameString, elementName);
 
         codeBuilder.addStatement("$L.bind$L($L, $L)",
-            BindToStatementMethod.PARAM_STATEMENT,
-            columnAccess.getSqliteTypeForTypeName(elementTypeName, isModelContainerAdapter).getSQLiteStatementMethod(),
-            index.intValue() + (!isAutoIncrement ? (" + " + BindToStatementMethod.PARAM_START) : ""), putAccess);
+                BindToStatementMethod.PARAM_STATEMENT,
+                columnAccess.getSqliteTypeForTypeName(elementTypeName, isModelContainerAdapter).getSQLiteStatementMethod(),
+                index.intValue() + (!isAutoIncrement ? (" + " + BindToStatementMethod.PARAM_START) : ""), putAccess);
         if (!finalTypeName.isPrimitive()) {
             codeBuilder.nextControlFlow("else");
             if (defaultValue != null && !defaultValue.isEmpty()) {
                 codeBuilder.addStatement("$L.bind$L($L, $L)", BindToStatementMethod.PARAM_STATEMENT,
-                    columnAccess.getSqliteTypeForTypeName(elementTypeName, isModelContainerAdapter).getSQLiteStatementMethod(),
-                    index.intValue() + (!isAutoIncrement ? (" + " + BindToStatementMethod.PARAM_START) : ""), defaultValue);
+                        columnAccess.getSqliteTypeForTypeName(elementTypeName, isModelContainerAdapter).getSQLiteStatementMethod(),
+                        index.intValue() + (!isAutoIncrement ? (" + " + BindToStatementMethod.PARAM_START) : ""), defaultValue);
             } else {
                 codeBuilder.addStatement("$L.bindNull($L)", BindToStatementMethod.PARAM_STATEMENT, index.intValue() + (!isAutoIncrement ? (" + " + BindToStatementMethod.PARAM_START) : ""));
             }
@@ -181,32 +181,21 @@ public class DefinitionUtils {
         }
 
         codeBuilder.addStatement(columnAccess.setColumnAccessString(elementTypeName, elementName, fullElementName,
-            isModelContainerAdapter, ModelUtils.getVariable(isModelContainerAdapter), cursorAssignment.build(), false));
+                isModelContainerAdapter, ModelUtils.getVariable(isModelContainerAdapter), cursorAssignment.build(), false));
 
         if (putDefaultValue) {
             codeBuilder.nextControlFlow("else");
             if (isModelContainerAdapter) {
                 codeBuilder.addStatement("$L.putDefault($S)", ModelUtils.getVariable(true), columnName);
             } else {
-                String defaultValue = "null";
-                if (elementTypeName.isPrimitive()) {
-                    if (elementTypeName.equals(TypeName.BOOLEAN)) {
-                        defaultValue = "false";
-                    } else if (elementTypeName.equals(TypeName.BYTE) || elementTypeName.equals(TypeName.INT)
-                        || elementTypeName.equals(TypeName.DOUBLE) || elementTypeName.equals(TypeName.FLOAT)
-                        || elementTypeName.equals(TypeName.LONG) || elementTypeName.equals(TypeName.SHORT)) {
-                        defaultValue = "0";
-                    } else if (elementTypeName.equals(TypeName.CHAR)) {
-                        defaultValue = "'\\u0000'";
-                    }
-                }
+
                 BaseColumnAccess baseColumnAccess = columnAccess;
                 if (columnAccess instanceof WrapperColumnAccess) {
                     baseColumnAccess = ((WrapperColumnAccess) columnAccess).existingColumnAccess;
                 }
                 codeBuilder.addStatement(baseColumnAccess.setColumnAccessString(elementTypeName, elementName, fullElementName,
-                    isModelContainerAdapter, ModelUtils.getVariable(isModelContainerAdapter),
-                    CodeBlock.builder().add(defaultValue).build(), false));
+                        isModelContainerAdapter, ModelUtils.getVariable(isModelContainerAdapter),
+                        CodeBlock.builder().add(getDefaultValueString(elementTypeName)).build(), false));
             }
         }
 
@@ -236,7 +225,7 @@ public class DefinitionUtils {
         accessBuilder.add("id.$LValue()", method);
 
         codeBuilder.addStatement(columnAccess.setColumnAccessString(elementTypeName, elementName, fullElementName,
-            isModelContainerAdapter, ModelUtils.getVariable(isModelContainerAdapter), accessBuilder.build(), false));
+                isModelContainerAdapter, ModelUtils.getVariable(isModelContainerAdapter), accessBuilder.build(), false));
 
         return codeBuilder;
     }
@@ -252,7 +241,7 @@ public class DefinitionUtils {
 
 
         return CodeBlock.builder()
-            .add("$L $L", QueryBuilder.quote(columnName), statement);
+                .add("$L $L", QueryBuilder.quote(columnName), statement);
 
     }
 
@@ -266,5 +255,21 @@ public class DefinitionUtils {
             method = SQLiteHelper.getMethod(ClassName.get(String.class));
         }
         return method;
+    }
+
+    public static String getDefaultValueString(TypeName elementTypeName) {
+        String defaultValue = "null";
+        if (elementTypeName.isPrimitive()) {
+            if (elementTypeName.equals(TypeName.BOOLEAN)) {
+                defaultValue = "false";
+            } else if (elementTypeName.equals(TypeName.BYTE) || elementTypeName.equals(TypeName.INT)
+                    || elementTypeName.equals(TypeName.DOUBLE) || elementTypeName.equals(TypeName.FLOAT)
+                    || elementTypeName.equals(TypeName.LONG) || elementTypeName.equals(TypeName.SHORT)) {
+                defaultValue = "0";
+            } else if (elementTypeName.equals(TypeName.CHAR)) {
+                defaultValue = "'\\u0000'";
+            }
+        }
+        return defaultValue;
     }
 }

--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/column/ForeignKeyColumnDefinition.java
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/column/ForeignKeyColumnDefinition.java
@@ -192,6 +192,20 @@ public class ForeignKeyColumnDefinition extends ColumnDefinition {
     }
 
     @Override
+    public String getPrimaryKeyName() {
+        checkNeedsReferences();
+        CodeBlock.Builder builder = CodeBlock.builder();
+        for (int i = 0; i < foreignKeyReferenceDefinitionList.size(); i++) {
+            if (i > 0) {
+                builder.add(" ,");
+            }
+            ForeignKeyReferenceDefinition referenceDefinition = foreignKeyReferenceDefinitionList.get(i);
+            builder.add(referenceDefinition.getPrimaryKeyName());
+        }
+        return builder.build().toString();
+    }
+
+    @Override
     public CodeBlock getContentValuesStatement(boolean isModelContainerAdapter) {
         if (nonModelColumn) {
             return super.getContentValuesStatement(isModelContainerAdapter);

--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/column/ForeignKeyColumnDefinition.java
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/column/ForeignKeyColumnDefinition.java
@@ -22,6 +22,7 @@ import com.squareup.javapoet.MethodSpec;
 import com.squareup.javapoet.ParameterizedTypeName;
 import com.squareup.javapoet.TypeName;
 import com.squareup.javapoet.TypeSpec;
+import com.squareup.javapoet.WildcardTypeName;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -89,7 +90,7 @@ public class ForeignKeyColumnDefinition extends ColumnDefinition {
         }
 
         TypeElement element = manager.getElements().getTypeElement(
-                manager.getTypeUtils().erasure(typeElement.asType()).toString());
+            manager.getTypeUtils().erasure(typeElement.asType()).toString());
 
         isModel = ProcessorUtils.implementsClass(manager.getProcessingEnvironment(), ClassNames.MODEL.toString(), element);
         isModelContainer = isModelContainer || ProcessorUtils.implementsClass(manager.getProcessingEnvironment(), ClassNames.MODEL_CONTAINER.toString(), element);
@@ -103,7 +104,7 @@ public class ForeignKeyColumnDefinition extends ColumnDefinition {
         if (columnAccess instanceof TypeConverterAccess) {
             if (typeElement.getModifiers().contains(Modifier.PRIVATE)) {
                 boolean useIs = elementTypeName.box().equals(TypeName.BOOLEAN.box())
-                        && tableDefinition.useIsForPrivateBooleans;
+                    && tableDefinition.useIsForPrivateBooleans;
                 columnAccess = new PrivateColumnAccess(typeElement.getAnnotation(Column.class), useIs);
             } else {
                 columnAccess = new SimpleColumnAccess();
@@ -135,7 +136,7 @@ public class ForeignKeyColumnDefinition extends ColumnDefinition {
                 propParam = ParameterizedTypeName.get(ClassNames.PROPERTY, reference.columnClassName.box());
             }
             typeBuilder.addField(FieldSpec.builder(propParam, reference.columnName, Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL)
-                    .initializer("new $T($T.class, $S)", propParam, tableClassName, reference.columnName).build());
+                .initializer("new $T($T.class, $S)", propParam, tableClassName, reference.columnName).build());
         }
     }
 
@@ -198,8 +199,8 @@ public class ForeignKeyColumnDefinition extends ColumnDefinition {
             checkNeedsReferences();
             CodeBlock.Builder builder = CodeBlock.builder();
             String statement = columnAccess
-                    .getColumnAccessString(elementTypeName, elementName, elementName,
-                            ModelUtils.getVariable(isModelContainerAdapter), isModelContainerAdapter, false);
+                .getColumnAccessString(elementTypeName, elementName, elementName,
+                    ModelUtils.getVariable(isModelContainerAdapter), isModelContainerAdapter, false);
             String finalAccessStatement = getFinalAccessStatement(builder, isModelContainerAdapter, statement);
             builder.beginControlFlow("if ($L != null)", finalAccessStatement);
             CodeBlock.Builder elseBuilder = CodeBlock.builder();
@@ -213,8 +214,8 @@ public class ForeignKeyColumnDefinition extends ColumnDefinition {
             }
 
             builder.nextControlFlow("else")
-                    .add(elseBuilder.build())
-                    .endControlFlow();
+                .add(elseBuilder.build())
+                .endControlFlow();
             return builder.build();
         }
     }
@@ -227,8 +228,8 @@ public class ForeignKeyColumnDefinition extends ColumnDefinition {
             checkNeedsReferences();
             CodeBlock.Builder builder = CodeBlock.builder();
             String statement = columnAccess
-                    .getColumnAccessString(elementTypeName, elementName, elementName,
-                            ModelUtils.getVariable(isModelContainerAdapter), isModelContainerAdapter, true);
+                .getColumnAccessString(elementTypeName, elementName, elementName,
+                    ModelUtils.getVariable(isModelContainerAdapter), isModelContainerAdapter, true);
             String finalAccessStatement = getFinalAccessStatement(builder, isModelContainerAdapter, statement);
             builder.beginControlFlow("if ($L != null)", finalAccessStatement);
 
@@ -247,8 +248,8 @@ public class ForeignKeyColumnDefinition extends ColumnDefinition {
             }
 
             builder.nextControlFlow("else")
-                    .add(elseBuilder.build())
-                    .endControlFlow();
+                .add(elseBuilder.build())
+                .endControlFlow();
             return builder.build();
         }
     }
@@ -261,9 +262,9 @@ public class ForeignKeyColumnDefinition extends ColumnDefinition {
         } else {
             checkNeedsReferences();
             CodeBlock.Builder builder = CodeBlock.builder()
-                    .add("//// Only load model if references match, for efficiency\n");
+                .add("//// Only load model if references match, for efficiency\n");
             CodeBlock.Builder ifNullBuilder = CodeBlock.builder()
-                    .add("if (");
+                .add("if (");
             CodeBlock.Builder selectBuilder = CodeBlock.builder();
 
             // used for foreignkey containers only.
@@ -279,16 +280,16 @@ public class ForeignKeyColumnDefinition extends ColumnDefinition {
                 ifNullBuilder.add("$L != -1 && !$L.isNull($L)", indexName, LoadFromCursorMethod.PARAM_CURSOR, indexName);
 
                 CodeBlock loadFromCursorBlock = CodeBlock.builder().add("$L.$L($L)", LoadFromCursorMethod.PARAM_CURSOR,
-                        DefinitionUtils.getLoadFromCursorMethodString(referenceDefinition.columnClassName,
-                                referenceDefinition.columnAccess), indexName).build();
+                    DefinitionUtils.getLoadFromCursorMethodString(referenceDefinition.columnClassName,
+                        referenceDefinition.columnAccess), indexName).build();
                 ClassName generatedTableRef = ClassName.get(referencedTableClassName.packageName(), referencedTableClassName.simpleName()
-                        + tableDefinition.databaseDefinition.classSeparator + TableDefinition.DBFLOW_TABLE_TAG);
+                    + tableDefinition.databaseDefinition.classSeparator + TableDefinition.DBFLOW_TABLE_TAG);
                 if (!isForeignKeyContainer) {
                     selectBuilder.add("\n.and($L.$L.eq($L))", generatedTableRef,
-                            referenceDefinition.foreignColumnName, loadFromCursorBlock);
+                        referenceDefinition.foreignColumnName, loadFromCursorBlock);
                 } else {
                     selectBuilder.add("\n$L.put($S, $L);", foreignKeyContainerRefName, referenceDefinition.foreignColumnName,
-                            loadFromCursorBlock);
+                        loadFromCursorBlock);
                 }
             }
             ifNullBuilder.add(")");
@@ -299,22 +300,22 @@ public class ForeignKeyColumnDefinition extends ColumnDefinition {
             if (isForeignKeyContainer) {
 
                 builder.addStatement("$T $L = new $T<>($T.class)",
-                        ParameterizedTypeName.get(ClassNames.FOREIGN_KEY_CONTAINER, referencedTableClassName),
-                        foreignKeyContainerRefName,
-                        ClassNames.FOREIGN_KEY_CONTAINER, referencedTableClassName);
+                    ParameterizedTypeName.get(ClassNames.FOREIGN_KEY_CONTAINER, referencedTableClassName),
+                    foreignKeyContainerRefName,
+                    ClassNames.FOREIGN_KEY_CONTAINER, referencedTableClassName);
 
                 builder.add(selectBuilder.build()).add("\n");
 
                 initializer.add(foreignKeyContainerRefName);
             } else {
                 initializer.add("new $T().from($T.class).where()", ClassNames.SELECT, referencedTableClassName)
-                        .add(selectBuilder.build());
+                    .add(selectBuilder.build());
                 if (!isModelContainerAdapter && !isModelContainer) {
                     initializer.add(".querySingle()");
                 } else {
                     if (isModelContainerAdapter) {
                         initializer.add(".queryModelContainer($L.getInstance($L.newDataInstance(), $T.class)).getData()", ModelUtils.getVariable(true),
-                                ModelUtils.getVariable(true), referencedTableClassName);
+                            ModelUtils.getVariable(true), referencedTableClassName);
                     } else {
                         initializer.add(".queryModelContainer(new $T($T.class))", elementTypeName, referencedTableClassName);
                     }
@@ -322,7 +323,7 @@ public class ForeignKeyColumnDefinition extends ColumnDefinition {
             }
 
             builder.addStatement(columnAccess.setColumnAccessString(elementTypeName, elementName, elementName,
-                    isModelContainerAdapter, ModelUtils.getVariable(isModelContainerAdapter), initializer.build(), false));
+                isModelContainerAdapter, ModelUtils.getVariable(isModelContainerAdapter), initializer.build(), false));
 
             boolean putDefaultValue = putNullForContainerAdapter;
             if (putContainerDefaultValue != putDefaultValue && isModelContainerAdapter) {
@@ -347,21 +348,21 @@ public class ForeignKeyColumnDefinition extends ColumnDefinition {
         } else {
             CodeBlock.Builder builder = CodeBlock.builder();
             String statement = columnAccess
-                    .getColumnAccessString(elementTypeName, elementName, elementName,
-                            ModelUtils.getVariable(true), true, true);
+                .getColumnAccessString(elementTypeName, elementName, elementName,
+                    ModelUtils.getVariable(true), true, true);
             String finalAccessStatement = getFinalAccessStatement(builder, true, statement);
 
             builder.beginControlFlow("if ($L != null)", finalAccessStatement);
             if (!isModelContainer) {
                 CodeBlock.Builder modelContainerRetrieval = CodeBlock.builder();
                 modelContainerRetrieval.add("$L.getContainerAdapter($T.class).toModel($L)", ClassNames.FLOW_MANAGER,
-                        referencedTableClassName, finalAccessStatement);
+                    referencedTableClassName, finalAccessStatement);
                 builder.addStatement(columnAccess.setColumnAccessString(elementTypeName, elementName, elementName,
-                        false, ModelUtils.getVariable(false), modelContainerRetrieval.build(), true));
+                    false, ModelUtils.getVariable(false), modelContainerRetrieval.build(), true));
             } else {
                 builder.addStatement(columnAccess.setColumnAccessString(elementTypeName, elementName, elementName,
-                        false, ModelUtils.getVariable(false), CodeBlock.builder().add("new $T($L)",
-                                elementTypeName, finalAccessStatement).build(), true));
+                    false, ModelUtils.getVariable(false), CodeBlock.builder().add("new $T($L)",
+                        elementTypeName, finalAccessStatement).build(), true));
             }
             builder.endControlFlow();
             return builder.build();
@@ -374,7 +375,7 @@ public class ForeignKeyColumnDefinition extends ColumnDefinition {
             return super.getForeignKeyContainerMethod(tableClassName);
         } else {
             String access = columnAccess.getColumnAccessString(elementTypeName, containerKeyName, elementName,
-                    ModelUtils.getVariable(false), false, false);
+                ModelUtils.getVariable(false), false, false);
             CodeBlock.Builder builder = CodeBlock.builder();
             CodeBlock.Builder elseBuilder = CodeBlock.builder();
             builder.beginControlFlow("if ($L != null)", access);
@@ -395,26 +396,36 @@ public class ForeignKeyColumnDefinition extends ColumnDefinition {
             String origStatement = getColumnAccessString(isModelContainerAdapter, false);
             if (isPrimaryKey) {
                 TableDefinition referenced = manager.getTableDefinition(tableDefinition.databaseDefinition.elementTypeName,
-                        referencedTableClassName);
+                    referencedTableClassName);
                 String statement = "";
+                String variableName = "container" + elementName;
+                TypeName typeName = elementTypeName;
+                if (isModelContainerAdapter) {
+                    typeName = ParameterizedTypeName.get(ClassNames.MODEL_CONTAINER, elementTypeName, WildcardTypeName.subtypeOf(Object.class));
+                }
+                codeBuilder.addStatement("\n$T $L = ($T) $L", typeName, variableName, typeName, origStatement);
+                codeBuilder.beginControlFlow("if ($L != null)", variableName);
+                CodeBlock.Builder elseBuilder = CodeBlock.builder();
                 for (ForeignKeyReferenceDefinition referenceDefinition : getForeignKeyReferenceDefinitionList()) {
-                    if (isModelContainer) {
+                    if (isModelContainer || isModelContainerAdapter) {
                         // check for null and retrieve proper value
                         String method = SQLiteHelper.getModelContainerMethod(referenceDefinition.columnClassName);
                         if (method == null) {
                             method = "get";
                         }
                         statement = String
-                                .format("%1s != null ? %1s.%1sValue(%1s.%1s.getContainerKey()) : null",
-                                        origStatement, origStatement, method, referenced.outputClassName, referenceDefinition.foreignColumnName);
+                            .format("%1s.%1sValue(%1s.%1s.getContainerKey())", variableName, method, referenced.outputClassName, referenceDefinition.foreignColumnName);
                     } else if (isModel) {
-                        statement = String.format("%1s != null ? %1s : null", origStatement, referenceDefinition.getPrimaryReferenceString(isModelContainerAdapter));
+                        statement = referenceDefinition.getPrimaryReferenceString(isModelContainerAdapter);
                     } else {
                         statement = origStatement;
                     }
-                    codeBuilder.add("\n.and($T.$L.eq($L))", tableDefinition.getPropertyClassName(), referenceDefinition.columnName, statement);
+                    codeBuilder.addStatement("clause.and($T.$L.eq($L))", tableDefinition.getPropertyClassName(), referenceDefinition.columnName, statement);
+                    elseBuilder.addStatement("clause.and($T.$L.eq(($T) null))", tableDefinition.getPropertyClassName(), referenceDefinition.columnName, referenceDefinition.columnClassName);
                 }
-
+                codeBuilder.nextControlFlow("else");
+                codeBuilder.add(elseBuilder.build());
+                codeBuilder.endControlFlow();
             }
         } else {
             super.appendPropertyComparisonAccessStatement(isModelContainerAdapter, codeBuilder);
@@ -424,8 +435,8 @@ public class ForeignKeyColumnDefinition extends ColumnDefinition {
     String getFinalAccessStatement(CodeBlock.Builder codeBuilder, boolean isModelContainerAdapter, String statement) {
         String finalAccessStatement = statement;
         if (columnAccess instanceof TypeConverterAccess ||
-                columnAccess instanceof ModelContainerAccess ||
-                isModelContainerAdapter) {
+            columnAccess instanceof ModelContainerAccess ||
+            isModelContainerAdapter) {
             finalAccessStatement = getRefName();
 
             TypeName typeName;
@@ -443,15 +454,15 @@ public class ForeignKeyColumnDefinition extends ColumnDefinition {
             }
 
             codeBuilder.addStatement("$T $L = $L", typeName,
-                    finalAccessStatement, statement);
+                finalAccessStatement, statement);
         }
         return finalAccessStatement;
     }
 
     String getForeignKeyReferenceAccess(boolean isModelContainerAdapter, String statement) {
         if (columnAccess instanceof TypeConverterAccess ||
-                columnAccess instanceof ModelContainerAccess ||
-                isModelContainerAdapter) {
+            columnAccess instanceof ModelContainerAccess ||
+            isModelContainerAdapter) {
             return getRefName();
         } else {
             return statement;
@@ -475,14 +486,14 @@ public class ForeignKeyColumnDefinition extends ColumnDefinition {
         TableDefinition referencedTableDefinition = manager.getTableDefinition(tableDefinition.databaseTypeName, referencedTableClassName);
         if (referencedTableDefinition == null) {
             manager.logError("Could not find the referenced table definition %1s from %1s. Ensure it exists in the same" +
-                    "database %1s", referencedTableClassName, tableDefinition.tableName, tableDefinition.databaseTypeName);
+                "database %1s", referencedTableClassName, tableDefinition.tableName, tableDefinition.databaseTypeName);
         } else {
             if (needsReferences) {
                 List<ColumnDefinition> primaryColumns = referencedTableDefinition.getPrimaryColumnDefinitions();
                 for (ColumnDefinition primaryColumn : primaryColumns) {
                     ForeignKeyReferenceDefinition foreignKeyReferenceDefinition =
-                            new ForeignKeyReferenceDefinition(manager, elementName, primaryColumn,
-                                    columnAccess, this, primaryColumns.size());
+                        new ForeignKeyReferenceDefinition(manager, elementName, primaryColumn,
+                            columnAccess, this, primaryColumns.size());
                     foreignKeyReferenceDefinitionList.add(foreignKeyReferenceDefinition);
                 }
                 if (nonModelColumn) {

--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/column/ForeignKeyColumnDefinition.java
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/column/ForeignKeyColumnDefinition.java
@@ -90,7 +90,7 @@ public class ForeignKeyColumnDefinition extends ColumnDefinition {
         }
 
         TypeElement element = manager.getElements().getTypeElement(
-            manager.getTypeUtils().erasure(typeElement.asType()).toString());
+                manager.getTypeUtils().erasure(typeElement.asType()).toString());
 
         isModel = ProcessorUtils.implementsClass(manager.getProcessingEnvironment(), ClassNames.MODEL.toString(), element);
         isModelContainer = isModelContainer || ProcessorUtils.implementsClass(manager.getProcessingEnvironment(), ClassNames.MODEL_CONTAINER.toString(), element);
@@ -104,7 +104,7 @@ public class ForeignKeyColumnDefinition extends ColumnDefinition {
         if (columnAccess instanceof TypeConverterAccess) {
             if (typeElement.getModifiers().contains(Modifier.PRIVATE)) {
                 boolean useIs = elementTypeName.box().equals(TypeName.BOOLEAN.box())
-                    && tableDefinition.useIsForPrivateBooleans;
+                        && tableDefinition.useIsForPrivateBooleans;
                 columnAccess = new PrivateColumnAccess(typeElement.getAnnotation(Column.class), useIs);
             } else {
                 columnAccess = new SimpleColumnAccess();
@@ -136,7 +136,7 @@ public class ForeignKeyColumnDefinition extends ColumnDefinition {
                 propParam = ParameterizedTypeName.get(ClassNames.PROPERTY, reference.columnClassName.box());
             }
             typeBuilder.addField(FieldSpec.builder(propParam, reference.columnName, Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL)
-                .initializer("new $T($T.class, $S)", propParam, tableClassName, reference.columnName).build());
+                    .initializer("new $T($T.class, $S)", propParam, tableClassName, reference.columnName).build());
         }
     }
 
@@ -213,8 +213,8 @@ public class ForeignKeyColumnDefinition extends ColumnDefinition {
             checkNeedsReferences();
             CodeBlock.Builder builder = CodeBlock.builder();
             String statement = columnAccess
-                .getColumnAccessString(elementTypeName, elementName, elementName,
-                    ModelUtils.getVariable(isModelContainerAdapter), isModelContainerAdapter, false);
+                    .getColumnAccessString(elementTypeName, elementName, elementName,
+                            ModelUtils.getVariable(isModelContainerAdapter), isModelContainerAdapter, false);
             String finalAccessStatement = getFinalAccessStatement(builder, isModelContainerAdapter, statement);
             builder.beginControlFlow("if ($L != null)", finalAccessStatement);
             CodeBlock.Builder elseBuilder = CodeBlock.builder();
@@ -228,8 +228,8 @@ public class ForeignKeyColumnDefinition extends ColumnDefinition {
             }
 
             builder.nextControlFlow("else")
-                .add(elseBuilder.build())
-                .endControlFlow();
+                    .add(elseBuilder.build())
+                    .endControlFlow();
             return builder.build();
         }
     }
@@ -242,8 +242,8 @@ public class ForeignKeyColumnDefinition extends ColumnDefinition {
             checkNeedsReferences();
             CodeBlock.Builder builder = CodeBlock.builder();
             String statement = columnAccess
-                .getColumnAccessString(elementTypeName, elementName, elementName,
-                    ModelUtils.getVariable(isModelContainerAdapter), isModelContainerAdapter, true);
+                    .getColumnAccessString(elementTypeName, elementName, elementName,
+                            ModelUtils.getVariable(isModelContainerAdapter), isModelContainerAdapter, true);
             String finalAccessStatement = getFinalAccessStatement(builder, isModelContainerAdapter, statement);
             builder.beginControlFlow("if ($L != null)", finalAccessStatement);
 
@@ -262,8 +262,8 @@ public class ForeignKeyColumnDefinition extends ColumnDefinition {
             }
 
             builder.nextControlFlow("else")
-                .add(elseBuilder.build())
-                .endControlFlow();
+                    .add(elseBuilder.build())
+                    .endControlFlow();
             return builder.build();
         }
     }
@@ -276,9 +276,9 @@ public class ForeignKeyColumnDefinition extends ColumnDefinition {
         } else {
             checkNeedsReferences();
             CodeBlock.Builder builder = CodeBlock.builder()
-                .add("//// Only load model if references match, for efficiency\n");
+                    .add("//// Only load model if references match, for efficiency\n");
             CodeBlock.Builder ifNullBuilder = CodeBlock.builder()
-                .add("if (");
+                    .add("if (");
             CodeBlock.Builder selectBuilder = CodeBlock.builder();
 
             // used for foreignkey containers only.
@@ -294,16 +294,16 @@ public class ForeignKeyColumnDefinition extends ColumnDefinition {
                 ifNullBuilder.add("$L != -1 && !$L.isNull($L)", indexName, LoadFromCursorMethod.PARAM_CURSOR, indexName);
 
                 CodeBlock loadFromCursorBlock = CodeBlock.builder().add("$L.$L($L)", LoadFromCursorMethod.PARAM_CURSOR,
-                    DefinitionUtils.getLoadFromCursorMethodString(referenceDefinition.columnClassName,
-                        referenceDefinition.columnAccess), indexName).build();
+                        DefinitionUtils.getLoadFromCursorMethodString(referenceDefinition.columnClassName,
+                                referenceDefinition.columnAccess), indexName).build();
                 ClassName generatedTableRef = ClassName.get(referencedTableClassName.packageName(), referencedTableClassName.simpleName()
-                    + tableDefinition.databaseDefinition.classSeparator + TableDefinition.DBFLOW_TABLE_TAG);
+                        + tableDefinition.databaseDefinition.classSeparator + TableDefinition.DBFLOW_TABLE_TAG);
                 if (!isForeignKeyContainer) {
                     selectBuilder.add("\n.and($L.$L.eq($L))", generatedTableRef,
-                        referenceDefinition.foreignColumnName, loadFromCursorBlock);
+                            referenceDefinition.foreignColumnName, loadFromCursorBlock);
                 } else {
                     selectBuilder.add("\n$L.put($S, $L);", foreignKeyContainerRefName, referenceDefinition.foreignColumnName,
-                        loadFromCursorBlock);
+                            loadFromCursorBlock);
                 }
             }
             ifNullBuilder.add(")");
@@ -314,22 +314,22 @@ public class ForeignKeyColumnDefinition extends ColumnDefinition {
             if (isForeignKeyContainer) {
 
                 builder.addStatement("$T $L = new $T<>($T.class)",
-                    ParameterizedTypeName.get(ClassNames.FOREIGN_KEY_CONTAINER, referencedTableClassName),
-                    foreignKeyContainerRefName,
-                    ClassNames.FOREIGN_KEY_CONTAINER, referencedTableClassName);
+                        ParameterizedTypeName.get(ClassNames.FOREIGN_KEY_CONTAINER, referencedTableClassName),
+                        foreignKeyContainerRefName,
+                        ClassNames.FOREIGN_KEY_CONTAINER, referencedTableClassName);
 
                 builder.add(selectBuilder.build()).add("\n");
 
                 initializer.add(foreignKeyContainerRefName);
             } else {
                 initializer.add("new $T().from($T.class).where()", ClassNames.SELECT, referencedTableClassName)
-                    .add(selectBuilder.build());
+                        .add(selectBuilder.build());
                 if (!isModelContainerAdapter && !isModelContainer) {
                     initializer.add(".querySingle()");
                 } else {
                     if (isModelContainerAdapter) {
                         initializer.add(".queryModelContainer($L.getInstance($L.newDataInstance(), $T.class)).getData()", ModelUtils.getVariable(true),
-                            ModelUtils.getVariable(true), referencedTableClassName);
+                                ModelUtils.getVariable(true), referencedTableClassName);
                     } else {
                         initializer.add(".queryModelContainer(new $T($T.class))", elementTypeName, referencedTableClassName);
                     }
@@ -337,7 +337,7 @@ public class ForeignKeyColumnDefinition extends ColumnDefinition {
             }
 
             builder.addStatement(columnAccess.setColumnAccessString(elementTypeName, elementName, elementName,
-                isModelContainerAdapter, ModelUtils.getVariable(isModelContainerAdapter), initializer.build(), false));
+                    isModelContainerAdapter, ModelUtils.getVariable(isModelContainerAdapter), initializer.build(), false));
 
             boolean putDefaultValue = putNullForContainerAdapter;
             if (putContainerDefaultValue != putDefaultValue && isModelContainerAdapter) {
@@ -362,21 +362,21 @@ public class ForeignKeyColumnDefinition extends ColumnDefinition {
         } else {
             CodeBlock.Builder builder = CodeBlock.builder();
             String statement = columnAccess
-                .getColumnAccessString(elementTypeName, elementName, elementName,
-                    ModelUtils.getVariable(true), true, true);
+                    .getColumnAccessString(elementTypeName, elementName, elementName,
+                            ModelUtils.getVariable(true), true, true);
             String finalAccessStatement = getFinalAccessStatement(builder, true, statement);
 
             builder.beginControlFlow("if ($L != null)", finalAccessStatement);
             if (!isModelContainer) {
                 CodeBlock.Builder modelContainerRetrieval = CodeBlock.builder();
                 modelContainerRetrieval.add("$L.getContainerAdapter($T.class).toModel($L)", ClassNames.FLOW_MANAGER,
-                    referencedTableClassName, finalAccessStatement);
+                        referencedTableClassName, finalAccessStatement);
                 builder.addStatement(columnAccess.setColumnAccessString(elementTypeName, elementName, elementName,
-                    false, ModelUtils.getVariable(false), modelContainerRetrieval.build(), true));
+                        false, ModelUtils.getVariable(false), modelContainerRetrieval.build(), true));
             } else {
                 builder.addStatement(columnAccess.setColumnAccessString(elementTypeName, elementName, elementName,
-                    false, ModelUtils.getVariable(false), CodeBlock.builder().add("new $T($L)",
-                        elementTypeName, finalAccessStatement).build(), true));
+                        false, ModelUtils.getVariable(false), CodeBlock.builder().add("new $T($L)",
+                                elementTypeName, finalAccessStatement).build(), true));
             }
             builder.endControlFlow();
             return builder.build();
@@ -389,7 +389,7 @@ public class ForeignKeyColumnDefinition extends ColumnDefinition {
             return super.getForeignKeyContainerMethod(tableClassName);
         } else {
             String access = columnAccess.getColumnAccessString(elementTypeName, containerKeyName, elementName,
-                ModelUtils.getVariable(false), false, false);
+                    ModelUtils.getVariable(false), false, false);
             CodeBlock.Builder builder = CodeBlock.builder();
             CodeBlock.Builder elseBuilder = CodeBlock.builder();
             builder.beginControlFlow("if ($L != null)", access);
@@ -410,7 +410,7 @@ public class ForeignKeyColumnDefinition extends ColumnDefinition {
             String origStatement = getColumnAccessString(isModelContainerAdapter, false);
             if (isPrimaryKey) {
                 TableDefinition referenced = manager.getTableDefinition(tableDefinition.databaseDefinition.elementTypeName,
-                    referencedTableClassName);
+                        referencedTableClassName);
                 String statement = "";
                 String variableName = "container" + elementName;
                 TypeName typeName = elementTypeName;
@@ -428,14 +428,14 @@ public class ForeignKeyColumnDefinition extends ColumnDefinition {
                             method = "get";
                         }
                         statement = String
-                            .format("%1s.%1sValue(%1s.%1s.getContainerKey())", variableName, method, referenced.outputClassName, referenceDefinition.foreignColumnName);
+                                .format("%1s.%1sValue(%1s.%1s.getContainerKey())", variableName, method, referenced.outputClassName, referenceDefinition.foreignColumnName);
                     } else if (isModel) {
                         statement = referenceDefinition.getPrimaryReferenceString(isModelContainerAdapter);
                     } else {
                         statement = origStatement;
                     }
                     codeBuilder.addStatement("clause.and($T.$L.eq($L))", tableDefinition.getPropertyClassName(), referenceDefinition.columnName, statement);
-                    elseBuilder.addStatement("clause.and($T.$L.eq(($T) null))", tableDefinition.getPropertyClassName(), referenceDefinition.columnName, referenceDefinition.columnClassName);
+                    elseBuilder.addStatement("clause.and($T.$L.eq(($T) $L))", tableDefinition.getPropertyClassName(), referenceDefinition.columnName, referenceDefinition.columnClassName, DefinitionUtils.getDefaultValueString(referenceDefinition.columnClassName));
                 }
                 codeBuilder.nextControlFlow("else");
                 codeBuilder.add(elseBuilder.build());
@@ -449,8 +449,8 @@ public class ForeignKeyColumnDefinition extends ColumnDefinition {
     String getFinalAccessStatement(CodeBlock.Builder codeBuilder, boolean isModelContainerAdapter, String statement) {
         String finalAccessStatement = statement;
         if (columnAccess instanceof TypeConverterAccess ||
-            columnAccess instanceof ModelContainerAccess ||
-            isModelContainerAdapter) {
+                columnAccess instanceof ModelContainerAccess ||
+                isModelContainerAdapter) {
             finalAccessStatement = getRefName();
 
             TypeName typeName;
@@ -468,15 +468,15 @@ public class ForeignKeyColumnDefinition extends ColumnDefinition {
             }
 
             codeBuilder.addStatement("$T $L = $L", typeName,
-                finalAccessStatement, statement);
+                    finalAccessStatement, statement);
         }
         return finalAccessStatement;
     }
 
     String getForeignKeyReferenceAccess(boolean isModelContainerAdapter, String statement) {
         if (columnAccess instanceof TypeConverterAccess ||
-            columnAccess instanceof ModelContainerAccess ||
-            isModelContainerAdapter) {
+                columnAccess instanceof ModelContainerAccess ||
+                isModelContainerAdapter) {
             return getRefName();
         } else {
             return statement;
@@ -500,14 +500,14 @@ public class ForeignKeyColumnDefinition extends ColumnDefinition {
         TableDefinition referencedTableDefinition = manager.getTableDefinition(tableDefinition.databaseTypeName, referencedTableClassName);
         if (referencedTableDefinition == null) {
             manager.logError("Could not find the referenced table definition %1s from %1s. Ensure it exists in the same" +
-                "database %1s", referencedTableClassName, tableDefinition.tableName, tableDefinition.databaseTypeName);
+                    "database %1s", referencedTableClassName, tableDefinition.tableName, tableDefinition.databaseTypeName);
         } else {
             if (needsReferences) {
                 List<ColumnDefinition> primaryColumns = referencedTableDefinition.getPrimaryColumnDefinitions();
                 for (ColumnDefinition primaryColumn : primaryColumns) {
                     ForeignKeyReferenceDefinition foreignKeyReferenceDefinition =
-                        new ForeignKeyReferenceDefinition(manager, elementName, primaryColumn,
-                            columnAccess, this, primaryColumns.size());
+                            new ForeignKeyReferenceDefinition(manager, elementName, primaryColumn,
+                                    columnAccess, this, primaryColumns.size());
                     foreignKeyReferenceDefinitionList.add(foreignKeyReferenceDefinition);
                 }
                 if (nonModelColumn) {

--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/column/ForeignKeyReferenceDefinition.java
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/column/ForeignKeyReferenceDefinition.java
@@ -140,7 +140,7 @@ public class ForeignKeyReferenceDefinition {
             combined = columnShortAccess;
         }
         return DefinitionUtils.getContentValuesStatement(columnShortAccess, combined,
-            columnName, columnClassName, isModelContainerAdapter, simpleColumnAccess, getForeignKeyColumnVariable(isModelContainerAdapter)).build();
+            columnName, columnClassName, isModelContainerAdapter, simpleColumnAccess, getForeignKeyColumnVariable(isModelContainerAdapter), null).build();
     }
 
     public String getPrimaryReferenceString(boolean isModelContainerAdapter) {
@@ -165,7 +165,7 @@ public class ForeignKeyReferenceDefinition {
         return DefinitionUtils.getSQLiteStatementMethod(
             index, columnShortAccess, combined,
             columnClassName, isModelContainerAdapter, simpleColumnAccess,
-            getForeignKeyColumnVariable(isModelContainerAdapter), false).build();
+            getForeignKeyColumnVariable(isModelContainerAdapter), false, null).build();
     }
 
     CodeBlock getForeignKeyContainerMethod(ClassName tableClassName) {

--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/column/ForeignKeyReferenceDefinition.java
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/column/ForeignKeyReferenceDefinition.java
@@ -168,6 +168,14 @@ public class ForeignKeyReferenceDefinition {
                 getForeignKeyColumnVariable(isModelContainerAdapter), false).build();
     }
 
+    CodeBlock getForeignKeyContainerMethod(ClassName tableClassName) {
+
+        CodeBlock.Builder codeBuilder = CodeBlock.builder();
+        codeBuilder.addStatement("$L.put($T.$L, $L)", ModelUtils.getVariable(true), tableClassName, columnName,
+                getShortColumnAccess(false, false, tableColumnAccess.getShortAccessString(foreignKeyColumnDefinition.elementClassName, foreignKeyFieldName, false, false)));
+        return codeBuilder.build();
+    }
+
     private String getForeignKeyColumnVariable(boolean isModelContainerAdapter) {
         return isModelContainerAdapter ? foreignKeyColumnDefinition.getRefName() : ModelUtils.getVariable(isModelContainerAdapter);
     }

--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/column/ForeignKeyReferenceDefinition.java
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/column/ForeignKeyReferenceDefinition.java
@@ -46,7 +46,7 @@ public class ForeignKeyReferenceDefinition {
         this.foreignKeyFieldName = foreignKeyFieldName;
 
         if (!foreignKeyColumnDefinition.isPrimaryKey && !foreignKeyColumnDefinition.isPrimaryKeyAutoIncrement
-                || referenceCount > 0) {
+            || referenceCount > 0) {
             columnName = foreignKeyFieldName + "_" + referencedColumn.columnName;
         } else {
             columnName = foreignKeyFieldName;
@@ -65,14 +65,14 @@ public class ForeignKeyReferenceDefinition {
             boolean isPackagePrivateNotInSamePackage = isPackagePrivate && !ElementUtility.isInSamePackage(manager, referencedColumn.element, foreignKeyColumnDefinition.element);
 
             isReferencedFieldPackagePrivate = referencedColumn.columnAccess instanceof PackagePrivateAccess
-                    || isPackagePrivateNotInSamePackage;
+                || isPackagePrivateNotInSamePackage;
         }
         if (isReferencedFieldPrivate && !foreignKeyColumnDefinition.isModelContainer) {
             columnAccess = new PrivateColumnAccess(referencedColumn.column, false);
         } else if (isReferencedFieldPackagePrivate && !foreignKeyColumnDefinition.isModelContainer) {
             columnAccess = new PackagePrivateAccess(referencedColumn.packageName,
-                    foreignKeyColumnDefinition.tableDefinition.databaseDefinition.classSeparator,
-                    ClassName.get((TypeElement) referencedColumn.element.getEnclosingElement()).simpleName());
+                foreignKeyColumnDefinition.tableDefinition.databaseDefinition.classSeparator,
+                ClassName.get((TypeElement) referencedColumn.element.getEnclosingElement()).simpleName());
         } else {
             if (foreignKeyColumnDefinition.isModelContainer) {
                 columnAccess = new ModelContainerAccess(tableColumnAccess, foreignColumnName);
@@ -108,8 +108,8 @@ public class ForeignKeyReferenceDefinition {
             columnAccess = new PrivateColumnAccess(foreignKeyReference);
         } else if (isReferencedFieldPackagePrivate && !foreignKeyColumnDefinition.isModelContainer) {
             columnAccess = new PackagePrivateAccess(foreignKeyColumnDefinition.referencedTableClassName.packageName(),
-                    foreignKeyColumnDefinition.tableDefinition.databaseDefinition.classSeparator,
-                    foreignKeyColumnDefinition.referencedTableClassName.simpleName());
+                foreignKeyColumnDefinition.tableDefinition.databaseDefinition.classSeparator,
+                foreignKeyColumnDefinition.referencedTableClassName.simpleName());
             PackagePrivateAccess.putElement(((PackagePrivateAccess) columnAccess).helperClassName, foreignColumnName);
         } else {
             if (foreignKeyColumnDefinition.isModelContainer) {
@@ -140,7 +140,7 @@ public class ForeignKeyReferenceDefinition {
             combined = columnShortAccess;
         }
         return DefinitionUtils.getContentValuesStatement(columnShortAccess, combined,
-                columnName, columnClassName, isModelContainerAdapter, simpleColumnAccess, getForeignKeyColumnVariable(isModelContainerAdapter)).build();
+            columnName, columnClassName, isModelContainerAdapter, simpleColumnAccess, getForeignKeyColumnVariable(isModelContainerAdapter)).build();
     }
 
     public String getPrimaryReferenceString(boolean isModelContainerAdapter) {
@@ -163,16 +163,20 @@ public class ForeignKeyReferenceDefinition {
         String columnShortAccess = getShortColumnAccess(isModelContainerAdapter, true, shortAccess);
         String combined = shortAccess + (isModelContainerAdapter ? "" : ".") + columnShortAccess;
         return DefinitionUtils.getSQLiteStatementMethod(
-                index, columnShortAccess, combined,
-                columnClassName, isModelContainerAdapter, simpleColumnAccess,
-                getForeignKeyColumnVariable(isModelContainerAdapter), false).build();
+            index, columnShortAccess, combined,
+            columnClassName, isModelContainerAdapter, simpleColumnAccess,
+            getForeignKeyColumnVariable(isModelContainerAdapter), false).build();
     }
 
     CodeBlock getForeignKeyContainerMethod(ClassName tableClassName) {
 
+        String access = getShortColumnAccess(false, false, tableColumnAccess.getShortAccessString(foreignKeyColumnDefinition.elementClassName, foreignKeyFieldName, false, false));
+        if (foreignKeyColumnDefinition.isModelContainer) {
+            access = foreignKeyColumnDefinition.getColumnAccessString(false, false) + "." + access;
+        }
+
         CodeBlock.Builder codeBuilder = CodeBlock.builder();
-        codeBuilder.addStatement("$L.put($T.$L, $L)", ModelUtils.getVariable(true), tableClassName, columnName,
-                getShortColumnAccess(false, false, tableColumnAccess.getShortAccessString(foreignKeyColumnDefinition.elementClassName, foreignKeyFieldName, false, false)));
+        codeBuilder.addStatement("$L.put($T.$L, $L)", ModelUtils.getVariable(true), tableClassName, columnName, access);
         return codeBuilder.build();
     }
 

--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/column/ForeignKeyReferenceDefinition.java
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/column/ForeignKeyReferenceDefinition.java
@@ -4,6 +4,7 @@ import com.raizlabs.android.dbflow.annotation.ForeignKeyReference;
 import com.raizlabs.android.dbflow.processor.model.ProcessorManager;
 import com.raizlabs.android.dbflow.processor.utils.ElementUtility;
 import com.raizlabs.android.dbflow.processor.utils.ModelUtils;
+import com.raizlabs.android.dbflow.sql.QueryBuilder;
 import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.CodeBlock;
 import com.squareup.javapoet.TypeName;
@@ -124,6 +125,10 @@ public class ForeignKeyReferenceDefinition {
 
     CodeBlock getCreationStatement() {
         return DefinitionUtils.getCreationStatement(columnClassName, null, columnName).build();
+    }
+
+    String getPrimaryKeyName() {
+        return QueryBuilder.quote(columnName);
     }
 
     CodeBlock getContentValuesStatement(boolean isModelContainerAdapter) {

--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/column/PrivateColumnAccess.java
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/column/PrivateColumnAccess.java
@@ -3,7 +3,6 @@ package com.raizlabs.android.dbflow.processor.definition.column;
 import com.raizlabs.android.dbflow.annotation.Column;
 import com.raizlabs.android.dbflow.annotation.ForeignKeyReference;
 import com.raizlabs.android.dbflow.processor.SQLiteHelper;
-import com.raizlabs.android.dbflow.processor.model.ProcessorManager;
 import com.raizlabs.android.dbflow.processor.utils.StringUtils;
 import com.squareup.javapoet.CodeBlock;
 import com.squareup.javapoet.TypeName;
@@ -38,11 +37,7 @@ public class PrivateColumnAccess extends BaseColumnAccess {
     @Override
     public String getColumnAccessString(TypeName fieldType, String elementName, String fullElementName, String variableNameString, boolean isModelContainerAdapter, boolean isSqliteStatement) {
         if (!isModelContainerAdapter) {
-            if (StringUtils.isNullOrEmpty(getterName)) {
-                return String.format("%1s.%1s()", variableNameString, getGetterName(elementName));
-            } else {
-                return String.format("%1s.%1s()", variableNameString, getterName);
-            }
+            return String.format("%1s.%1s()", variableNameString, getGetterNameElement(elementName));
         } else {
             String method = SQLiteHelper.getModelContainerMethod(fieldType);
             if (method == null) {
@@ -55,11 +50,7 @@ public class PrivateColumnAccess extends BaseColumnAccess {
     @Override
     public String getShortAccessString(TypeName fieldType, String elementName, boolean isModelContainerAdapter, boolean isSqliteStatement) {
         if (!isModelContainerAdapter) {
-            if (StringUtils.isNullOrEmpty(getterName)) {
-                return String.format("%1s()", getGetterName(elementName));
-            } else {
-                return String.format("%1s()", getterName);
-            }
+            return String.format("%1s()", getGetterNameElement(elementName));
         } else {
             return elementName;
         }
@@ -70,22 +61,33 @@ public class PrivateColumnAccess extends BaseColumnAccess {
         if (isModelContainerAdapter) {
             return variableNameString + ".put(\"" + elementName + "\", " + formattedAccess + ")";
         } else {
-            if (StringUtils.isNullOrEmpty(setterName)) {
-                return String.format("%1s.set%1s(%1s)", variableNameString, StringUtils.capitalize(elementName), formattedAccess);
+            return String.format("%1s.%1s(%1s)", variableNameString, getSetterNameElement(elementName), formattedAccess);
+        }
+    }
+
+    public String getGetterNameElement(String elementName) {
+        if (StringUtils.isNullOrEmpty(getterName)) {
+            if (useIsForGetter && !elementName.startsWith("is")) {
+                return "is" + StringUtils.capitalize(elementName);
+            } else if (!useIsForGetter && !elementName.startsWith("get")) {
+                return "get" + StringUtils.capitalize(elementName);
             } else {
-                return String.format("%1s.%1s(%1s)", variableNameString, setterName, formattedAccess);
+                return StringUtils.lower(elementName);
             }
+        } else {
+            return getterName;
         }
     }
 
-    private String getGetterName(String elementName) {
-        String finalName = elementName;
-        if (useIsForGetter && !finalName.startsWith("is")) {
-            finalName = "is" + StringUtils.capitalize(finalName);
-        } else if (!useIsForGetter && !finalName.startsWith("get")) {
-            finalName = "get" + StringUtils.capitalize(finalName);
+    public String getSetterNameElement(String elementName) {
+        if (StringUtils.isNullOrEmpty(setterName)) {
+            if (!elementName.startsWith("set")) {
+                return "set" + StringUtils.capitalize(elementName);
+            } else {
+                return StringUtils.lower(elementName);
+            }
+        } else {
+            return setterName;
         }
-        return finalName;
     }
-
 }

--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/column/TypeConverterAccess.java
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/column/TypeConverterAccess.java
@@ -25,6 +25,8 @@ public class TypeConverterAccess extends WrapperColumnAccess {
         super(columnDefinition);
         typeConverterDefinition = manager.getTypeConverterDefinition(columnDefinition.elementTypeName.box());
         this.manager = manager;
+
+        checkConverter(columnDefinition.elementTypeName, columnDefinition.columnName, columnDefinition.tableDefinition.elementTypeName.toString());
     }
 
     public TypeConverterAccess(ProcessorManager manager, ColumnDefinition columnDefinition, TypeConverterDefinition typeConverterDefinition, String typeConverterFieldName) {
@@ -32,6 +34,8 @@ public class TypeConverterAccess extends WrapperColumnAccess {
         this.manager = manager;
         this.typeConverterFieldName = typeConverterFieldName;
         this.typeConverterDefinition = typeConverterDefinition;
+
+        checkConverter(columnDefinition.elementTypeName, columnDefinition.columnName, columnDefinition.tableDefinition.elementTypeName.toString());
     }
 
     @Override
@@ -104,5 +108,12 @@ public class TypeConverterAccess extends WrapperColumnAccess {
             throw new RuntimeException("");
         }
         return super.getSqliteTypeForTypeName(typeConverterDefinition.getDbTypeName(), isModelContainerAdapter);
+    }
+
+    private void checkConverter(TypeName fieldType, String elementName, String tableName) {
+        if (typeConverterDefinition == null) {
+            manager.logError("No type converter for: " + fieldType + " -> " + elementName + " from class: " + tableName + ". Please" +
+                    "register with a TypeConverter.");
+        }
     }
 }

--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/column/WrapperColumnAccess.java
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/column/WrapperColumnAccess.java
@@ -13,7 +13,7 @@ public abstract class WrapperColumnAccess extends BaseColumnAccess {
         this.columnDefinition = columnDefinition;
     }
 
-    protected BaseColumnAccess getExistingColumnAccess() {
+    public BaseColumnAccess getExistingColumnAccess() {
         return existingColumnAccess;
     }
 

--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/method/CreationQueryMethod.java
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/method/CreationQueryMethod.java
@@ -66,7 +66,7 @@ public class CreationQueryMethod implements MethodDefinition {
             }
 
             ColumnDefinition primaryDefinition = tableDefinition.getPrimaryColumnDefinitions().get(i);
-            creationBuilder.add(primaryDefinition.getCreationName());
+            creationBuilder.add(primaryDefinition.getPrimaryKeyName());
 
             if (i == primarySize - 1) {
                 creationBuilder.add(")");

--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/method/CreationQueryMethod.java
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/method/CreationQueryMethod.java
@@ -31,14 +31,14 @@ public class CreationQueryMethod implements MethodDefinition {
     @Override
     public MethodSpec getMethodSpec() {
         MethodSpec.Builder methodBuilder = MethodSpec.methodBuilder("getCreationQuery")
-                .addAnnotation(Override.class)
-                .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
-                .returns(ClassName.get(String.class));
+            .addAnnotation(Override.class)
+            .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
+            .returns(ClassName.get(String.class));
 
         CodeBlock.Builder creationBuilder = CodeBlock.builder()
-                .add("CREATE TABLE IF NOT EXISTS ")
-                .add(QueryBuilder.quote(tableDefinition.tableName))
-                .add("(");
+            .add("CREATE TABLE IF NOT EXISTS ")
+            .add(QueryBuilder.quote(tableDefinition.tableName))
+            .add("(");
 
         for (int i = 0; i < tableDefinition.getColumnDefinitions().size(); i++) {
             if (i > 0) {
@@ -66,7 +66,7 @@ public class CreationQueryMethod implements MethodDefinition {
             }
 
             ColumnDefinition primaryDefinition = tableDefinition.getPrimaryColumnDefinitions().get(i);
-            creationBuilder.add(QueryBuilder.quote(primaryDefinition.columnName));
+            creationBuilder.add(primaryDefinition.getCreationName());
 
             if (i == primarySize - 1) {
                 creationBuilder.add(")");
@@ -100,7 +100,7 @@ public class CreationQueryMethod implements MethodDefinition {
             foreignKeyBlocks.add(foreignKeyBuilder.build());
 
             tableNameBlocks.add(CodeBlock.builder().add("$T.getTableName($T.class)",
-                    ClassNames.FLOW_MANAGER, foreignKeyColumnDefinition.referencedTableClassName).build());
+                ClassNames.FLOW_MANAGER, foreignKeyColumnDefinition.referencedTableClassName).build());
 
             referenceBuilder.add("(");
             for (int j = 0; j < foreignKeyColumnDefinition.foreignKeyReferenceDefinitionList.size(); j++) {
@@ -111,12 +111,12 @@ public class CreationQueryMethod implements MethodDefinition {
                 referenceBuilder.add("$L", QueryBuilder.quote(referenceDefinition.foreignColumnName));
             }
             referenceBuilder.add(") ON UPDATE $L ON DELETE $L", foreignKeyColumnDefinition.onUpdate.name().replace("_", " "),
-                    foreignKeyColumnDefinition.onDelete.name().replace("_", " "));
+                foreignKeyColumnDefinition.onDelete.name().replace("_", " "));
             referenceKeyBlocks.add(referenceBuilder.build());
         }
 
         CodeBlock.Builder codeBuilder = CodeBlock.builder()
-                .add("return $S", creationBuilder.build().toString());
+            .add("return $S", creationBuilder.build().toString());
 
         if (foreignSize > 0) {
             for (int i = 0; i < foreignSize; i++) {

--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/method/DatabaseDefinition.java
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/method/DatabaseDefinition.java
@@ -5,6 +5,7 @@ import com.raizlabs.android.dbflow.annotation.Database;
 import com.raizlabs.android.dbflow.processor.ClassNames;
 import com.raizlabs.android.dbflow.processor.ProcessorUtils;
 import com.raizlabs.android.dbflow.processor.definition.BaseDefinition;
+import com.raizlabs.android.dbflow.processor.definition.ManyToManyDefinition;
 import com.raizlabs.android.dbflow.processor.definition.MigrationDefinition;
 import com.raizlabs.android.dbflow.processor.definition.ModelContainerDefinition;
 import com.raizlabs.android.dbflow.processor.definition.ModelViewDefinition;
@@ -64,6 +65,7 @@ public class DatabaseDefinition extends BaseDefinition implements TypeDefinition
     public Map<TypeName, QueryModelDefinition> queryModelDefinitionMap = new HashMap<>();
     public Map<TypeName, ModelContainerDefinition> modelContainerDefinitionMap = new HashMap<>();
     public Map<TypeName, ModelViewDefinition> modelViewDefinitionMap = new HashMap<>();
+    public Map<TypeName, ManyToManyDefinition> manyToManyDefinitionMap = new HashMap<>();
 
     public DatabaseDefinition(ProcessorManager manager, Element element) {
         super(element, manager);

--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/method/InsertStatementQueryMethod.java
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/method/InsertStatementQueryMethod.java
@@ -25,14 +25,18 @@ public class InsertStatementQueryMethod implements MethodDefinition {
     @Override
     public MethodSpec getMethodSpec() {
         MethodSpec.Builder methodBuilder = MethodSpec.methodBuilder(isInsert ? "getInsertStatementQuery" : "getCompiledStatementQuery")
-                .addAnnotation(Override.class)
-                .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
-                .returns(ClassName.get(String.class));
+            .addAnnotation(Override.class)
+            .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
+            .returns(ClassName.get(String.class));
 
         CodeBlock.Builder codeBuilder = CodeBlock.builder()
-                .add("INSERT INTO ")
-                .add(QueryBuilder.quote(tableDefinition.tableName))
-                .add("(");
+            .add("INSERT ");
+        if (!tableDefinition.insertConflictActionName.isEmpty()) {
+            codeBuilder.add("OR $L ", tableDefinition.insertConflictActionName);
+        }
+        codeBuilder.add("INTO ")
+            .add(QueryBuilder.quote(tableDefinition.tableName))
+            .add("(");
 
         int columnSize = tableDefinition.getColumnDefinitions().size();
         int columnCount = 0;

--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/method/PrimaryConditionMethod.java
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/method/PrimaryConditionMethod.java
@@ -33,11 +33,12 @@ public class PrimaryConditionMethod implements MethodDefinition {
                 .addParameter(tableDefinition.getParameterClassName(isModelContainerAdapter),
                         ModelUtils.getVariable(isModelContainerAdapter))
                 .returns(ClassNames.CONDITION_GROUP);
-        CodeBlock.Builder code = CodeBlock.builder()
-                .add("return $T.clause()", ClassNames.CONDITION_GROUP);
+        CodeBlock.Builder code = CodeBlock.builder();
+        code.add("return $T.clause()", ClassNames.CONDITION_GROUP);
         for (ColumnDefinition columnDefinition : tableDefinition.getPrimaryColumnDefinitions()) {
-            code.add(".and($T.$L.eq($L))", tableDefinition.getPropertyClassName(), columnDefinition.columnName,
-                    columnDefinition.getPropertyComparisonAccessStatement(isModelContainerAdapter));
+            CodeBlock.Builder codeBuilder = CodeBlock.builder();
+            columnDefinition.appendPropertyComparisonAccessStatement(isModelContainerAdapter, codeBuilder);
+            code.add(codeBuilder.build());
         }
         methodBuilder.addCode(code.addStatement("").build());
         return methodBuilder.build();

--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/method/PrimaryConditionMethod.java
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/method/PrimaryConditionMethod.java
@@ -28,19 +28,20 @@ public class PrimaryConditionMethod implements MethodDefinition {
     @Override
     public MethodSpec getMethodSpec() {
         MethodSpec.Builder methodBuilder = MethodSpec.methodBuilder("getPrimaryConditionClause")
-                .addAnnotation(Override.class)
-                .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
-                .addParameter(tableDefinition.getParameterClassName(isModelContainerAdapter),
-                        ModelUtils.getVariable(isModelContainerAdapter))
-                .returns(ClassNames.CONDITION_GROUP);
+            .addAnnotation(Override.class)
+            .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
+            .addParameter(tableDefinition.getParameterClassName(isModelContainerAdapter),
+                ModelUtils.getVariable(isModelContainerAdapter))
+            .returns(ClassNames.CONDITION_GROUP);
         CodeBlock.Builder code = CodeBlock.builder();
-        code.add("return $T.clause()", ClassNames.CONDITION_GROUP);
+        code.add("$T clause = $T.clause();", ClassNames.CONDITION_GROUP, ClassNames.CONDITION_GROUP);
         for (ColumnDefinition columnDefinition : tableDefinition.getPrimaryColumnDefinitions()) {
             CodeBlock.Builder codeBuilder = CodeBlock.builder();
             columnDefinition.appendPropertyComparisonAccessStatement(isModelContainerAdapter, codeBuilder);
             code.add(codeBuilder.build());
         }
-        methodBuilder.addCode(code.addStatement("").build());
+        methodBuilder.addCode(code.build());
+        methodBuilder.addStatement("return clause");
         return methodBuilder.build();
     }
 }

--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/method/provider/DeleteMethod.java
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/method/provider/DeleteMethod.java
@@ -49,7 +49,11 @@ public class DeleteMethod implements MethodDefinition {
 
                     code.add("long count = new $T().from", ClassNames.DELETE);
                     ProviderMethodUtils.appendTableName(code, databaseName, tableEndpointDefinition.tableName);
-                    code.add(".where(toConditions(selection, selectionArgs))");
+                    if (contentProviderDefinition.useSafeQueryChecking) {
+                        code.add(".where(toConditions(selection, selectionArgs))");
+                    } else {
+                        code.add(".where(new $T(selection, selectionArgs))", ClassNames.UNSAFE_STRING_CONDITION);
+                    }
                     ProviderMethodUtils.appendPathSegments(code, manager, uriDefinition.segments,
                             contentProviderDefinition.databaseName, tableEndpointDefinition.tableName);
                     code.add(".count();\n");

--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/method/provider/DeleteMethod.java
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/method/provider/DeleteMethod.java
@@ -36,24 +36,17 @@ public class DeleteMethod implements MethodDefinition {
 
     @Override
     public MethodSpec getMethodSpec() {
-        MethodSpec.Builder method = MethodSpec.methodBuilder("delete")
-                .addAnnotation(Override.class)
-                .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
-                .addParameter(ClassNames.URI, PARAM_URI)
-                .addParameter(ClassName.get(String.class), PARAM_SELECTION)
-                .addParameter(ArrayTypeName.of(String.class), PARAM_SELECTION_ARGS)
-                .returns(TypeName.INT);
+        CodeBlock.Builder code = CodeBlock.builder();
 
-        method.beginControlFlow("switch(MATCHER.match($L))", PARAM_URI);
+        code.beginControlFlow("switch(MATCHER.match($L))", PARAM_URI);
         for (TableEndpointDefinition tableEndpointDefinition : contentProviderDefinition.endpointDefinitions) {
             for (ContentUriDefinition uriDefinition : tableEndpointDefinition.contentUriDefinitions) {
                 if (uriDefinition.deleteEnabled) {
 
                     String databaseName = manager.getDatabaseName(contentProviderDefinition.databaseName);
 
-                    method.beginControlFlow("case $L:", uriDefinition.name);
+                    code.beginControlFlow("case $L:", uriDefinition.name);
 
-                    CodeBlock.Builder code = CodeBlock.builder();
                     code.add("long count = new $T().from", ClassNames.DELETE);
                     ProviderMethodUtils.appendTableName(code, databaseName, tableEndpointDefinition.tableName);
                     code.add(".where(toConditions(selection, selectionArgs))");
@@ -61,23 +54,28 @@ public class DeleteMethod implements MethodDefinition {
                             contentProviderDefinition.databaseName, tableEndpointDefinition.tableName);
                     code.add(".count();\n");
 
-                    method.addCode(code.build());
-
                     new NotifyMethod(tableEndpointDefinition, uriDefinition, Notify.Method.DELETE)
                             .addCode(code);
 
-                    method.addStatement("return (int) count");
-                    method.endControlFlow();
+                    code.addStatement("return (int) count");
+                    code.endControlFlow();
                 }
             }
         }
 
-        method.beginControlFlow("default:")
+        code.beginControlFlow("default:")
                 .addStatement("throw new $T($S + $L)", ClassName.get(IllegalArgumentException.class), "Unknown URI", PARAM_URI)
                 .endControlFlow();
-        method.endControlFlow();
+        code.endControlFlow();
 
-        return method.build();
+        return MethodSpec.methodBuilder("delete")
+                .addAnnotation(Override.class)
+                .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
+                .addParameter(ClassNames.URI, PARAM_URI)
+                .addParameter(ClassName.get(String.class), PARAM_SELECTION)
+                .addParameter(ArrayTypeName.of(String.class), PARAM_SELECTION_ARGS)
+                .addCode(code.build())
+                .returns(TypeName.INT).build();
     }
 
 }

--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/method/provider/InsertMethod.java
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/method/provider/InsertMethod.java
@@ -48,10 +48,10 @@ public class InsertMethod implements MethodDefinition {
                                             "$T.getSQLiteDatabaseAlgorithmInt(adapter.getInsertOnConflictAction()));\n", tableEndpointDefinition.tableName,
                                     ClassNames.CONFLICT_ACTION);
 
-                    if (!isBulk) {
-                        new NotifyMethod(tableEndpointDefinition, uriDefinition,
-                                Notify.Method.INSERT).addCode(code);
+                    new NotifyMethod(tableEndpointDefinition, uriDefinition,
+                            Notify.Method.INSERT).addCode(code);
 
+                    if (!isBulk) {
                         code.addStatement("return $T.withAppendedId($L, id)", ClassNames.CONTENT_URIS, PARAM_URI);
                     } else {
                         code.addStatement("return id > 0 ? 1 : 0");

--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/method/provider/NotifyMethod.java
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/method/provider/NotifyMethod.java
@@ -6,6 +6,7 @@ import com.raizlabs.android.dbflow.processor.definition.CodeAdder;
 import com.raizlabs.android.dbflow.processor.definition.ContentUriDefinition;
 import com.raizlabs.android.dbflow.processor.definition.NotifyDefinition;
 import com.raizlabs.android.dbflow.processor.definition.TableEndpointDefinition;
+import com.raizlabs.android.dbflow.processor.model.ProcessorManager;
 import com.squareup.javapoet.CodeBlock;
 
 import java.util.List;

--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/method/provider/UpdateMethod.java
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/method/provider/UpdateMethod.java
@@ -60,7 +60,11 @@ public class UpdateMethod implements MethodDefinition {
                             manager.getDatabaseName(contentProviderDefinition.databaseName),
                             tableEndpointDefinition.tableName);
                     codeBuilder.add(".conflictAction(adapter.getUpdateOnConflictAction()).set().conditionValues(values)");
-                    codeBuilder.add(".where(toConditions(selection, selectionArgs))");
+                    if (contentProviderDefinition.useSafeQueryChecking) {
+                        codeBuilder.add(".where(toConditions(selection, selectionArgs))");
+                    } else {
+                        codeBuilder.add(".where(new $T(selection, selectionArgs))", ClassNames.UNSAFE_STRING_CONDITION);
+                    }
                     ProviderMethodUtils.appendPathSegments(codeBuilder, manager, uriDefinition.segments,
                             contentProviderDefinition.databaseName, tableEndpointDefinition.tableName);
                     codeBuilder.add(".count();\n");

--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/handler/TableHandler.java
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/handler/TableHandler.java
@@ -1,6 +1,8 @@
 package com.raizlabs.android.dbflow.processor.handler;
 
+import com.raizlabs.android.dbflow.annotation.ManyToMany;
 import com.raizlabs.android.dbflow.annotation.Table;
+import com.raizlabs.android.dbflow.processor.definition.ManyToManyDefinition;
 import com.raizlabs.android.dbflow.processor.definition.TableDefinition;
 import com.raizlabs.android.dbflow.processor.model.ProcessorManager;
 import com.raizlabs.android.dbflow.processor.validator.TableValidator;
@@ -32,6 +34,11 @@ public class TableHandler extends BaseContainerHandler<Table> {
             TableDefinition tableDefinition = new TableDefinition(processorManager, (TypeElement) element);
             if (definitionValidator.validate(processorManager, tableDefinition)) {
                 processorManager.addTableDefinition(tableDefinition);
+            }
+
+            if (element.getAnnotation(ManyToMany.class) != null) {
+                ManyToManyDefinition manyToManyDefinition = new ManyToManyDefinition((TypeElement) element, processorManager);
+                TableDefinition manyTableDefinition = new TableDefinition(processorManager, manyToManyDefinition.outputClassName);
             }
         }
     }

--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/handler/TableHandler.java
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/handler/TableHandler.java
@@ -38,7 +38,7 @@ public class TableHandler extends BaseContainerHandler<Table> {
 
             if (element.getAnnotation(ManyToMany.class) != null) {
                 ManyToManyDefinition manyToManyDefinition = new ManyToManyDefinition((TypeElement) element, processorManager);
-                TableDefinition manyTableDefinition = new TableDefinition(processorManager, manyToManyDefinition.outputClassName);
+                processorManager.addManyToManyDefinition(manyToManyDefinition);
             }
         }
     }

--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/model/ProcessorManager.java
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/model/ProcessorManager.java
@@ -60,7 +60,7 @@ public class ProcessorManager implements Handler {
 
     private Map<TypeName, DatabaseDefinition> databaseDefinitionMap = Maps.newHashMap();
     private List<BaseContainerHandler> handlers = new ArrayList<>();
-    private Map<String, ContentProviderDefinition> providerMap = Maps.newHashMap();
+    private Map<TypeName, ContentProviderDefinition> providerMap = Maps.newHashMap();
 
     public ProcessorManager(ProcessingEnvironment processingEnv) {
         processingEnvironment = processingEnv;
@@ -240,7 +240,7 @@ public class ProcessorManager implements Handler {
     }
 
     public void addContentProviderDefinition(ContentProviderDefinition contentProviderDefinition) {
-        providerMap.put(contentProviderDefinition.elementClassName.simpleName(), contentProviderDefinition);
+        providerMap.put(contentProviderDefinition.elementTypeName, contentProviderDefinition);
     }
 
     public void putTableEndpointForProvider(TableEndpointDefinition tableEndpointDefinition) {

--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/model/ProcessorManager.java
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/model/ProcessorManager.java
@@ -131,13 +131,13 @@ public class ProcessorManager implements Handler {
 
     public void addModelContainerDefinition(ModelContainerDefinition modelContainerDefinition) {
         databaseDefinitionMap.get(modelContainerDefinition.getDatabaseName())
-                .modelContainerDefinitionMap.put(modelContainerDefinition.elementClassName,
-                modelContainerDefinition);
+            .modelContainerDefinitionMap.put(modelContainerDefinition.elementClassName,
+            modelContainerDefinition);
     }
 
     public void addQueryModelDefinition(QueryModelDefinition queryModelDefinition) {
         databaseDefinitionMap.get(queryModelDefinition.databaseTypeName).queryModelDefinitionMap.
-                put(queryModelDefinition.elementClassName, queryModelDefinition);
+            put(queryModelDefinition.elementClassName, queryModelDefinition);
     }
 
     public void addTableDefinition(TableDefinition tableDefinition) {
@@ -160,7 +160,7 @@ public class ProcessorManager implements Handler {
 
     public void addModelViewDefinition(ModelViewDefinition modelViewDefinition) {
         databaseDefinitionMap.get(modelViewDefinition.databaseName).modelViewDefinitionMap
-                .put(modelViewDefinition.elementClassName, modelViewDefinition);
+            .put(modelViewDefinition.elementClassName, modelViewDefinition);
     }
 
     public Set<TypeConverterDefinition> getTypeConverters() {
@@ -202,7 +202,7 @@ public class ProcessorManager implements Handler {
 
     public void addMigrationDefinition(MigrationDefinition migrationDefinition) {
         Map<Integer, List<MigrationDefinition>> migrationDefinitionMap = migrations.get(
-                migrationDefinition.databaseName);
+            migrationDefinition.databaseName);
         if (migrationDefinitionMap == null) {
             migrationDefinitionMap = Maps.newHashMap();
             migrations.put(migrationDefinition.databaseName, migrationDefinitionMap);
@@ -234,10 +234,10 @@ public class ProcessorManager implements Handler {
 
     public void putTableEndpointForProvider(TableEndpointDefinition tableEndpointDefinition) {
         ContentProviderDefinition contentProviderDefinition = providerMap.get(
-                tableEndpointDefinition.contentProviderName);
+            tableEndpointDefinition.contentProviderName);
         if (contentProviderDefinition == null) {
             logError("Content Provider %1s was not found for the @TableEndpoint %1s",
-                    tableEndpointDefinition.contentProviderName, tableEndpointDefinition.elementClassName);
+                tableEndpointDefinition.contentProviderName, tableEndpointDefinition.elementClassName);
         } else {
             contentProviderDefinition.endpointDefinitions.add(tableEndpointDefinition);
         }
@@ -249,6 +249,14 @@ public class ProcessorManager implements Handler {
 
     public void logError(Class callingClass, String error, Object... args) {
         logError(callingClass + ": " + error, args);
+    }
+
+    public void logWarning(String error, Object... args) {
+        getMessager().printMessage(Diagnostic.Kind.WARNING, String.format("*==========*\n" + error + "\n*==========*", args));
+    }
+
+    public void logWarning(Class callingClass, String error, Object... args) {
+        logWarning(callingClass + ":" + error, args);
     }
 
     @Override
@@ -268,7 +276,7 @@ public class ProcessorManager implements Handler {
         for (DatabaseDefinition databaseDefinition : databaseDefinitions) {
             try {
                 JavaFile.builder(databaseDefinition.packageName, databaseDefinition.getTypeSpec())
-                        .build().writeTo(processorManager.getProcessingEnvironment().getFiler());
+                    .build().writeTo(processorManager.getProcessingEnvironment().getFiler());
 
                 Collection<TableDefinition> tableDefinitions = databaseDefinition.tableDefinitionMap.values();
                 for (TableDefinition tableDefinition : tableDefinitions) {
@@ -305,8 +313,8 @@ public class ProcessorManager implements Handler {
 
         try {
             JavaFile.builder(ClassNames.FLOW_MANAGER_PACKAGE,
-                    new FlowManagerHolderDefinition(processorManager).getTypeSpec())
-                    .build().writeTo(processorManager.getProcessingEnvironment().getFiler());
+                new FlowManagerHolderDefinition(processorManager).getTypeSpec())
+                .build().writeTo(processorManager.getProcessingEnvironment().getFiler());
         } catch (IOException e) {
         }
     }

--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/utils/ElementUtility.java
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/utils/ElementUtility.java
@@ -1,5 +1,7 @@
 package com.raizlabs.android.dbflow.processor.utils;
 
+import com.raizlabs.android.dbflow.annotation.ColumnIgnore;
+import com.raizlabs.android.dbflow.processor.ClassNames;
 import com.raizlabs.android.dbflow.processor.model.ProcessorManager;
 
 import java.util.ArrayList;
@@ -47,5 +49,13 @@ public class ElementUtility {
     public static boolean isPackagePrivate(Element element) {
         return !element.getModifiers().contains(Modifier.PUBLIC) && !element.getModifiers().contains(Modifier.PRIVATE)
                 && !element.getModifiers().contains(Modifier.STATIC);
+    }
+
+    public static boolean isValidAllFields(boolean allFields, Element element) {
+        return (allFields && (element.getKind().isField() &&
+                !element.getModifiers().contains(Modifier.STATIC) &&
+                !element.getModifiers().contains(Modifier.FINAL))) &&
+                element.getAnnotation(ColumnIgnore.class) == null &&
+                !element.asType().toString().equals(ClassNames.MODEL_ADAPTER.toString());
     }
 }

--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/utils/ModelUtils.java
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/utils/ModelUtils.java
@@ -1,12 +1,14 @@
 package com.raizlabs.android.dbflow.processor.utils;
 
 import com.raizlabs.android.dbflow.annotation.ForeignKeyReference;
+import com.raizlabs.android.dbflow.annotation.ManyToMany;
 import com.raizlabs.android.dbflow.processor.ClassNames;
 import com.raizlabs.android.dbflow.processor.model.ProcessorManager;
 import com.squareup.javapoet.ParameterizedTypeName;
 import com.squareup.javapoet.TypeName;
 
 import javax.lang.model.type.MirroredTypeException;
+import javax.lang.model.type.TypeMirror;
 
 /**
  * Author: andrewgrosner
@@ -21,6 +23,18 @@ public class ModelUtils {
                 annotation.columnType();
             } catch (MirroredTypeException mte) {
                 clazz = mte.getTypeMirror().toString();
+            }
+        }
+        return clazz;
+    }
+
+    public static TypeMirror getReferencedClassFromAnnotation(ManyToMany annotation) {
+        TypeMirror clazz = null;
+        if (annotation != null) {
+            try {
+                annotation.referencedTable();
+            } catch (MirroredTypeException mte) {
+                clazz = mte.getTypeMirror();
             }
         }
         return clazz;

--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/utils/StringUtils.java
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/utils/StringUtils.java
@@ -16,4 +16,12 @@ public class StringUtils {
 
         return str.substring(0, 1).toUpperCase() + str.substring(1);
     }
+
+    public static String lower(String str) {
+        if (str == null || str.trim().length() == 0) {
+            return str;
+        }
+
+        return str.substring(0, 1).toLowerCase() + str.substring(1);
+    }
 }

--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/validator/ColumnValidator.java
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/validator/ColumnValidator.java
@@ -27,7 +27,7 @@ public class ColumnValidator implements Validator<ColumnDefinition> {
                     (PrivateColumnAccess) ((WrapperColumnAccess) columnDefinition.columnAccess).getExistingColumnAccess();
             if (!columnDefinition.tableDefinition.classElementLookUpMap.containsKey(privateColumnAccess.getGetterNameElement(columnDefinition.elementName))) {
                 processorManager.logError(ColumnValidator.class, "Could not find getter for private element: " +
-                                "%1s from table class: %1s. Consider adding a getter with name %1s or making it more accessible.",
+                                "\"%1s\" from table class: %1s. Consider adding a getter with name %1s or making it more accessible.",
                         columnDefinition.elementName, columnDefinition.tableDefinition.elementName, privateColumnAccess.getGetterNameElement(columnDefinition.elementName));
                 success = false;
             }

--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/validator/ColumnValidator.java
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/validator/ColumnValidator.java
@@ -4,6 +4,7 @@ import com.raizlabs.android.dbflow.processor.definition.column.ColumnDefinition;
 import com.raizlabs.android.dbflow.processor.definition.column.EnumColumnAccess;
 import com.raizlabs.android.dbflow.processor.definition.column.ForeignKeyColumnDefinition;
 import com.raizlabs.android.dbflow.processor.model.ProcessorManager;
+import com.raizlabs.android.dbflow.processor.utils.StringUtils;
 
 /**
  * Description: Ensures the integrity of the annotation processor for columns.
@@ -17,33 +18,42 @@ public class ColumnValidator implements Validator<ColumnDefinition> {
 
         boolean success = true;
 
+        if (!StringUtils.isNullOrEmpty(columnDefinition.defaultValue)) {
+            if (columnDefinition instanceof ForeignKeyColumnDefinition && (((ForeignKeyColumnDefinition) columnDefinition).isModelContainer
+                || ((ForeignKeyColumnDefinition) columnDefinition).isModel)) {
+                processorManager.logError(ColumnValidator.class, "Default values cannot be specified for model or model container fields");
+            } else if (columnDefinition.elementTypeName.isPrimitive()) {
+                processorManager.logWarning(ColumnValidator.class, "Primitive column types will not respect default values");
+            }
+        }
+
         if (columnDefinition.columnName == null || columnDefinition.columnName.isEmpty()) {
             success = false;
             processorManager.logError("Field %1s cannot have a null column name for column: %1s and type: %1s",
-                    columnDefinition.elementName, columnDefinition.columnName,
-                    columnDefinition.elementTypeName);
+                columnDefinition.elementName, columnDefinition.columnName,
+                columnDefinition.elementTypeName);
         }
 
         if (columnDefinition.columnAccess instanceof EnumColumnAccess) {
             if (columnDefinition.isPrimaryKey) {
                 success = false;
                 processorManager.logError("Enums cannot be primary keys. Column: %1s and type: %1s", columnDefinition.columnName,
-                        columnDefinition.elementTypeName);
+                    columnDefinition.elementTypeName);
             } else if (columnDefinition instanceof ForeignKeyColumnDefinition) {
                 success = false;
                 processorManager.logError("Enums cannot be foreign keys. Column: %1s and type: %1s", columnDefinition.columnName,
-                        columnDefinition.elementTypeName);
+                    columnDefinition.elementTypeName);
             }
         }
 
         if (columnDefinition instanceof ForeignKeyColumnDefinition) {
             if (columnDefinition.column != null && columnDefinition.column.name()
-                    .length() > 0) {
+                .length() > 0) {
                 success = false;
                 processorManager.logError("Foreign Key %1s cannot specify the column() field. " +
-                                "Use a @ForeignKeyReference(columnName = {NAME} instead. Column: %1s and type: %1s",
-                        ((ForeignKeyColumnDefinition) columnDefinition).elementName, columnDefinition.columnName,
-                        columnDefinition.elementTypeName);
+                        "Use a @ForeignKeyReference(columnName = {NAME} instead. Column: %1s and type: %1s",
+                    ((ForeignKeyColumnDefinition) columnDefinition).elementName, columnDefinition.columnName,
+                    columnDefinition.elementTypeName);
             }
 
         } else {
@@ -57,8 +67,8 @@ public class ColumnValidator implements Validator<ColumnDefinition> {
                     autoIncrementingPrimaryKey = columnDefinition;
                 } else if (!autoIncrementingPrimaryKey.equals(columnDefinition)) {
                     processorManager.logError(
-                            "Only one autoincrementing primary key is allowed on a table. Found Column: %1s and type: %1s",
-                            columnDefinition.columnName, columnDefinition.elementTypeName);
+                        "Only one autoincrementing primary key is allowed on a table. Found Column: %1s and type: %1s",
+                        columnDefinition.columnName, columnDefinition.elementTypeName);
                     success = false;
                 }
             }

--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/validator/ColumnValidator.java
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/validator/ColumnValidator.java
@@ -3,6 +3,8 @@ package com.raizlabs.android.dbflow.processor.validator;
 import com.raizlabs.android.dbflow.processor.definition.column.ColumnDefinition;
 import com.raizlabs.android.dbflow.processor.definition.column.EnumColumnAccess;
 import com.raizlabs.android.dbflow.processor.definition.column.ForeignKeyColumnDefinition;
+import com.raizlabs.android.dbflow.processor.definition.column.PrivateColumnAccess;
+import com.raizlabs.android.dbflow.processor.definition.column.WrapperColumnAccess;
 import com.raizlabs.android.dbflow.processor.model.ProcessorManager;
 import com.raizlabs.android.dbflow.processor.utils.StringUtils;
 
@@ -18,9 +20,28 @@ public class ColumnValidator implements Validator<ColumnDefinition> {
 
         boolean success = true;
 
+        // validate getter and setters.
+        if (columnDefinition.columnAccess instanceof PrivateColumnAccess ||
+                columnDefinition.columnAccess instanceof WrapperColumnAccess && ((WrapperColumnAccess) columnDefinition.columnAccess).getExistingColumnAccess() instanceof PrivateColumnAccess) {
+            PrivateColumnAccess privateColumnAccess = columnDefinition.columnAccess instanceof PrivateColumnAccess ? ((PrivateColumnAccess) columnDefinition.columnAccess) :
+                    (PrivateColumnAccess) ((WrapperColumnAccess) columnDefinition.columnAccess).getExistingColumnAccess();
+            if (!columnDefinition.tableDefinition.classElementLookUpMap.containsKey(privateColumnAccess.getGetterNameElement(columnDefinition.elementName))) {
+                processorManager.logError(ColumnValidator.class, "Could not find getter for private element: " +
+                                "%1s from table class: %1s. Consider adding a getter with name %1s or making it more accessible.",
+                        columnDefinition.elementName, columnDefinition.tableDefinition.elementName, privateColumnAccess.getGetterNameElement(columnDefinition.elementName));
+                success = false;
+            }
+            if (!columnDefinition.tableDefinition.classElementLookUpMap.containsKey(privateColumnAccess.getSetterNameElement(columnDefinition.elementName))) {
+                processorManager.logError(ColumnValidator.class, "Could not find setter for private element: " +
+                                "\"%1s\" from table class: %1s. Consider adding a setter with name %1s or making it more accessible.",
+                        columnDefinition.elementName, columnDefinition.tableDefinition.elementName, privateColumnAccess.getSetterNameElement(columnDefinition.elementName));
+                success = false;
+            }
+        }
+
         if (!StringUtils.isNullOrEmpty(columnDefinition.defaultValue)) {
             if (columnDefinition instanceof ForeignKeyColumnDefinition && (((ForeignKeyColumnDefinition) columnDefinition).isModelContainer
-                || ((ForeignKeyColumnDefinition) columnDefinition).isModel)) {
+                    || ((ForeignKeyColumnDefinition) columnDefinition).isModel)) {
                 processorManager.logError(ColumnValidator.class, "Default values cannot be specified for model or model container fields");
             } else if (columnDefinition.elementTypeName.isPrimitive()) {
                 processorManager.logWarning(ColumnValidator.class, "Primitive column types will not respect default values");
@@ -30,30 +51,30 @@ public class ColumnValidator implements Validator<ColumnDefinition> {
         if (columnDefinition.columnName == null || columnDefinition.columnName.isEmpty()) {
             success = false;
             processorManager.logError("Field %1s cannot have a null column name for column: %1s and type: %1s",
-                columnDefinition.elementName, columnDefinition.columnName,
-                columnDefinition.elementTypeName);
+                    columnDefinition.elementName, columnDefinition.columnName,
+                    columnDefinition.elementTypeName);
         }
 
         if (columnDefinition.columnAccess instanceof EnumColumnAccess) {
             if (columnDefinition.isPrimaryKey) {
                 success = false;
                 processorManager.logError("Enums cannot be primary keys. Column: %1s and type: %1s", columnDefinition.columnName,
-                    columnDefinition.elementTypeName);
+                        columnDefinition.elementTypeName);
             } else if (columnDefinition instanceof ForeignKeyColumnDefinition) {
                 success = false;
                 processorManager.logError("Enums cannot be foreign keys. Column: %1s and type: %1s", columnDefinition.columnName,
-                    columnDefinition.elementTypeName);
+                        columnDefinition.elementTypeName);
             }
         }
 
         if (columnDefinition instanceof ForeignKeyColumnDefinition) {
             if (columnDefinition.column != null && columnDefinition.column.name()
-                .length() > 0) {
+                    .length() > 0) {
                 success = false;
                 processorManager.logError("Foreign Key %1s cannot specify the column() field. " +
-                        "Use a @ForeignKeyReference(columnName = {NAME} instead. Column: %1s and type: %1s",
-                    ((ForeignKeyColumnDefinition) columnDefinition).elementName, columnDefinition.columnName,
-                    columnDefinition.elementTypeName);
+                                "Use a @ForeignKeyReference(columnName = {NAME} instead. Column: %1s and type: %1s",
+                        ((ForeignKeyColumnDefinition) columnDefinition).elementName, columnDefinition.columnName,
+                        columnDefinition.elementTypeName);
             }
 
         } else {
@@ -67,8 +88,8 @@ public class ColumnValidator implements Validator<ColumnDefinition> {
                     autoIncrementingPrimaryKey = columnDefinition;
                 } else if (!autoIncrementingPrimaryKey.equals(columnDefinition)) {
                     processorManager.logError(
-                        "Only one autoincrementing primary key is allowed on a table. Found Column: %1s and type: %1s",
-                        columnDefinition.columnName, columnDefinition.elementTypeName);
+                            "Only one autoincrementing primary key is allowed on a table. Found Column: %1s and type: %1s",
+                            columnDefinition.columnName, columnDefinition.elementTypeName);
                     success = false;
                 }
             }

--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/validator/TableEndpointValidator.java
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/validator/TableEndpointValidator.java
@@ -17,12 +17,6 @@ public class TableEndpointValidator implements Validator<TableEndpointDefinition
             success = false;
         }
 
-        if (tableEndpointDefinition.isTopLevel && (tableEndpointDefinition.contentProviderName == null
-                || tableEndpointDefinition.contentProviderName.isEmpty())) {
-            processorManager.logError("A top-level @TableEndpoint %1s must specify the @ContentProvider it belongs to", tableEndpointDefinition.elementClassName);
-            success = false;
-        }
-
         return success;
     }
 }

--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/validator/TableValidator.java
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/validator/TableValidator.java
@@ -16,14 +16,14 @@ public class TableValidator implements Validator<TableDefinition> {
         boolean success = true;
 
         if (tableDefinition.getColumnDefinitions() == null || tableDefinition.getColumnDefinitions().isEmpty()) {
-            processorManager.logError("Table %1s needs to define at least one column", tableDefinition.tableName);
+            processorManager.logError(TableValidator.class, "Table %1s needs to define at least one column", tableDefinition.tableName);
             success = false;
         }
 
         boolean hasTwoKinds = (tableDefinition.hasAutoIncrement && !tableDefinition.primaryColumnDefinitions.isEmpty());
 
         if (hasTwoKinds) {
-            processorManager.logError("Table %1s cannot mix and match autoincrement and composite primary keys", tableDefinition.tableName);
+            processorManager.logError(TableValidator.class, "Table %1s cannot mix and match autoincrement and composite primary keys", tableDefinition.tableName);
             success = false;
         }
 
@@ -31,12 +31,12 @@ public class TableValidator implements Validator<TableDefinition> {
                 || !tableDefinition.hasAutoIncrement && !tableDefinition.primaryColumnDefinitions.isEmpty());
 
         if (!hasPrimary) {
-            processorManager.logError("Table %1s needs to define at least one primary key", tableDefinition.tableName);
+            processorManager.logError(TableValidator.class, "Table %1s needs to define at least one primary key", tableDefinition.tableName);
             success = false;
         }
 
         if (!ProcessorUtils.implementsClass(processorManager.getProcessingEnvironment(), ClassNames.MODEL.toString(), (TypeElement) tableDefinition.element)) {
-            processorManager.logError("The @Table annotation can only apply to a class that implements Model");
+            processorManager.logError(TableValidator.class, "The @Table annotation can only apply to a class that implements Model");
             success = false;
         }
 

--- a/dbflow-sqlcipher/src/main/java/com/raizlabs/dbflow/android/sqlcipher/SQLCipherOpenHelper.java
+++ b/dbflow-sqlcipher/src/main/java/com/raizlabs/dbflow/android/sqlcipher/SQLCipherOpenHelper.java
@@ -6,6 +6,7 @@ import com.raizlabs.android.dbflow.DatabaseHelperListener;
 import com.raizlabs.android.dbflow.annotation.Database;
 import com.raizlabs.android.dbflow.config.BaseDatabaseDefinition;
 import com.raizlabs.android.dbflow.config.FlowManager;
+import com.raizlabs.android.dbflow.structure.database.BaseDatabaseHelper;
 import com.raizlabs.android.dbflow.structure.database.DatabaseHelperDelegate;
 import com.raizlabs.android.dbflow.structure.database.DatabaseWrapper;
 import com.raizlabs.android.dbflow.structure.database.OpenHelper;
@@ -29,22 +30,7 @@ public abstract class SQLCipherOpenHelper extends SQLiteOpenHelper implements Op
         if (databaseDefinition.backupEnabled()) {
             // Temp database mirrors existing
             backupHelper = new BackupHelper(FlowManager.getContext(), DatabaseHelperDelegate.getTempDbFileName(databaseDefinition),
-                    databaseDefinition.getDatabaseVersion()) {
-                @Override
-                public void onOpen(SQLiteDatabase db) {
-                    SQLCipherOpenHelper.this.onOpen(db);
-                }
-
-                @Override
-                public void onCreate(SQLiteDatabase db) {
-                    SQLCipherOpenHelper.this.onCreate(db);
-                }
-
-                @Override
-                public void onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion) {
-                    SQLCipherOpenHelper.this.onUpgrade(db, oldVersion, newVersion);
-                }
-            };
+                    databaseDefinition.getDatabaseVersion(), databaseDefinition);
         }
 
         databaseHelperDelegate = new DatabaseHelperDelegate(listener, databaseDefinition, backupHelper);
@@ -106,12 +92,14 @@ public abstract class SQLCipherOpenHelper extends SQLiteOpenHelper implements Op
     /**
      * Simple helper to manage backup.
      */
-    private abstract class BackupHelper extends SQLiteOpenHelper implements OpenHelper {
+    private class BackupHelper extends SQLiteOpenHelper implements OpenHelper {
 
         private SQLCipherDatabase sqlCipherDatabase;
+        private final BaseDatabaseHelper baseDatabaseHelper;
 
-        public BackupHelper(Context context, String name, int version) {
+        public BackupHelper(Context context, String name, int version, BaseDatabaseDefinition databaseDefinition) {
             super(context, name, null, version);
+            this.baseDatabaseHelper = new BaseDatabaseHelper(databaseDefinition);
         }
 
         @Override
@@ -138,6 +126,21 @@ public abstract class SQLCipherOpenHelper extends SQLiteOpenHelper implements Op
 
         @Override
         public void setDatabaseListener(DatabaseHelperListener helperListener) {
+        }
+
+        @Override
+        public void onCreate(SQLiteDatabase db) {
+            baseDatabaseHelper.onCreate(SQLCipherDatabase.from(db));
+        }
+
+        @Override
+        public void onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion) {
+            baseDatabaseHelper.onUpgrade(SQLCipherDatabase.from(db), oldVersion, newVersion);
+        }
+
+        @Override
+        public void onOpen(SQLiteDatabase db) {
+            baseDatabaseHelper.onOpen(SQLCipherDatabase.from(db));
         }
     }
 }

--- a/dbflow-sqlcipher/src/main/java/com/raizlabs/dbflow/android/sqlcipher/SQLCipherStatement.java
+++ b/dbflow-sqlcipher/src/main/java/com/raizlabs/dbflow/android/sqlcipher/SQLCipherStatement.java
@@ -10,14 +10,18 @@ import net.sqlcipher.database.SQLiteStatement;
  */
 public class SQLCipherStatement implements DatabaseStatement {
 
-    private final SQLiteStatement statement;
-
     public static SQLCipherStatement from(SQLiteStatement statement) {
         return new SQLCipherStatement(statement);
     }
 
+    private final SQLiteStatement statement;
+
     SQLCipherStatement(SQLiteStatement statement) {
         this.statement = statement;
+    }
+
+    public SQLiteStatement getStatement() {
+        return statement;
     }
 
     @Override

--- a/dbflow-tests/src/androidTest/java/com/raizlabs/android/dbflow/test/provider/ContentProviderModel.java
+++ b/dbflow-tests/src/androidTest/java/com/raizlabs/android/dbflow/test/provider/ContentProviderModel.java
@@ -13,7 +13,7 @@ import com.raizlabs.android.dbflow.structure.provider.ContentUtils;
 /**
  * Description:
  */
-@TableEndpoint(name = ContentProviderModel.NAME, contentProviderName = "ContentDatabase")
+@TableEndpoint(name = ContentProviderModel.NAME, contentProvider = ContentDatabase.class)
 @Table(database = ContentDatabase.class, name = ContentProviderModel.NAME)
 public class ContentProviderModel extends BaseProviderModel<ContentProviderModel> {
 

--- a/dbflow-tests/src/androidTest/java/com/raizlabs/android/dbflow/test/provider/ContentProviderModel.java
+++ b/dbflow-tests/src/androidTest/java/com/raizlabs/android/dbflow/test/provider/ContentProviderModel.java
@@ -20,7 +20,7 @@ public class ContentProviderModel extends BaseProviderModel<ContentProviderModel
     public static final String NAME = "ContentProviderModel";
 
     @ContentUri(path = NAME, type = ContentUri.ContentType.VND_MULTIPLE + NAME)
-    public static final Uri CONTENT_URI = ContentUtils.buildUri(ContentDatabase.AUTHORITY);
+    public static final Uri CONTENT_URI = ContentUtils.buildUriWithAuthority(ContentDatabase.AUTHORITY);
 
     @Column
     @PrimaryKey(autoincrement = true)

--- a/dbflow-tests/src/androidTest/java/com/raizlabs/android/dbflow/test/provider/TestContentProvider.java
+++ b/dbflow-tests/src/androidTest/java/com/raizlabs/android/dbflow/test/provider/TestContentProvider.java
@@ -31,7 +31,7 @@ public class TestContentProvider {
         return builder.build();
     }
 
-    @TableEndpoint(name = ContentProviderModel.ENDPOINT)
+    @TableEndpoint(name = ContentProviderModel.ENDPOINT, contentProvider = ContentDatabase.class)
     public static class ContentProviderModel {
 
         public static final String ENDPOINT = "ContentProviderModel";
@@ -58,7 +58,7 @@ public class TestContentProvider {
 
     }
 
-    @TableEndpoint(name = NoteModel.ENDPOINT)
+    @TableEndpoint(name = NoteModel.ENDPOINT, contentProvider = ContentDatabase.class)
     public static class NoteModel {
 
         public static final String ENDPOINT = "NoteModel";
@@ -132,7 +132,7 @@ public class TestContentProvider {
         }
     }
 
-    @TableEndpoint(name = TestSyncableModel.ENDPOINT)
+    @TableEndpoint(name = TestSyncableModel.ENDPOINT, contentProvider = ContentDatabase.class)
     public static class TestSyncableModel {
 
         public static final String ENDPOINT = "TestSyncableModel";

--- a/dbflow-tests/src/androidTest/java/com/raizlabs/android/dbflow/test/provider/TestContentProvider.java
+++ b/dbflow-tests/src/androidTest/java/com/raizlabs/android/dbflow/test/provider/TestContentProvider.java
@@ -16,7 +16,7 @@ import com.raizlabs.android.dbflow.sql.SqlUtils;
  */
 @ContentProvider(authority = TestContentProvider.AUTHORITY,
         database = ContentDatabase.class,
-        baseContentUri = TestContentProvider.BASE_CONTENT_URI, useSafeQueryChecking = false)
+        baseContentUri = TestContentProvider.BASE_CONTENT_URI)
 public class TestContentProvider {
 
     public static final String AUTHORITY = "com.raizlabs.android.dbflow.test.provider";

--- a/dbflow-tests/src/androidTest/java/com/raizlabs/android/dbflow/test/provider/TestContentProvider.java
+++ b/dbflow-tests/src/androidTest/java/com/raizlabs/android/dbflow/test/provider/TestContentProvider.java
@@ -16,7 +16,7 @@ import com.raizlabs.android.dbflow.sql.SqlUtils;
  */
 @ContentProvider(authority = TestContentProvider.AUTHORITY,
         database = ContentDatabase.class,
-        baseContentUri = TestContentProvider.BASE_CONTENT_URI)
+        baseContentUri = TestContentProvider.BASE_CONTENT_URI, useSafeQueryChecking = false)
 public class TestContentProvider {
 
     public static final String AUTHORITY = "com.raizlabs.android.dbflow.test.provider";

--- a/dbflow-tests/src/androidTest/java/com/raizlabs/android/dbflow/test/sql/Activity.java
+++ b/dbflow-tests/src/androidTest/java/com/raizlabs/android/dbflow/test/sql/Activity.java
@@ -1,5 +1,6 @@
 package com.raizlabs.android.dbflow.test.sql;
 
+import com.raizlabs.android.dbflow.annotation.ColumnIgnore;
 import com.raizlabs.android.dbflow.annotation.PrimaryKey;
 import com.raizlabs.android.dbflow.annotation.Table;
 import com.raizlabs.android.dbflow.structure.BaseModel;
@@ -17,6 +18,7 @@ public class Activity extends BaseModel {
 
     int steps;
 
+    @ColumnIgnore
     private double calories;
 
 }

--- a/dbflow-tests/src/androidTest/java/com/raizlabs/android/dbflow/test/sql/Activity.java
+++ b/dbflow-tests/src/androidTest/java/com/raizlabs/android/dbflow/test/sql/Activity.java
@@ -17,5 +17,6 @@ public class Activity extends BaseModel {
 
     int steps;
 
-    double calories;
+    private double calories;
+
 }

--- a/dbflow-tests/src/androidTest/java/com/raizlabs/android/dbflow/test/sql/BuilderTest.java
+++ b/dbflow-tests/src/androidTest/java/com/raizlabs/android/dbflow/test/sql/BuilderTest.java
@@ -3,6 +3,7 @@ package com.raizlabs.android.dbflow.test.sql;
 import com.raizlabs.android.dbflow.annotation.Collate;
 import com.raizlabs.android.dbflow.sql.language.Condition;
 import com.raizlabs.android.dbflow.sql.language.ConditionGroup;
+import com.raizlabs.android.dbflow.sql.language.property.PropertyFactory;
 import com.raizlabs.android.dbflow.test.FlowTestCase;
 
 /**
@@ -64,12 +65,12 @@ public class BuilderTest extends FlowTestCase {
 
     public void testCombinedOperations() {
         // TODO: fix combined ops
-        //ConditionGroup combinedCondition = ConditionGroup
-        //        .begin(ConditionGroup
-        //                .begin(column(columnRaw("A"))).or(column(columnRaw("B"))))
-        //        .and(column(columnRaw("C")));
-        //ConditionQueryBuilder<ConditionModel> conditionQueryBuilder = new ConditionQueryBuilder<>(ConditionModel.class, combinedCondition);
-        //assertEquals("((A OR B) AND C)", conditionQueryBuilder.getQuery());
+        ConditionGroup combinedCondition = ConditionGroup.clause()
+                .and(ConditionGroup.clause()
+                        .and(PropertyFactory.from(String.class, "A").eq(PropertyFactory.from(String.class, "B")))
+                        .or(PropertyFactory.from(String.class, "B").eq(PropertyFactory.from(String.class, "C"))))
+                .and(PropertyFactory.from(String.class, "C").eq("D"));
+        assertEquals("(A=B OR B=C) AND C='D'", combinedCondition.getQuery());
     }
 
 }

--- a/dbflow-tests/src/androidTest/java/com/raizlabs/android/dbflow/test/sql/DefaultModel.java
+++ b/dbflow-tests/src/androidTest/java/com/raizlabs/android/dbflow/test/sql/DefaultModel.java
@@ -11,4 +11,6 @@ public class DefaultModel extends TestModel1 {
     @Column(defaultValue = "55")
     Integer count;
 
+    @Column(defaultValue = "\"this is\"")
+    String test;
 }

--- a/dbflow-tests/src/androidTest/java/com/raizlabs/android/dbflow/test/sql/DefaultModel.java
+++ b/dbflow-tests/src/androidTest/java/com/raizlabs/android/dbflow/test/sql/DefaultModel.java
@@ -10,4 +10,5 @@ public class DefaultModel extends TestModel1 {
 
     @Column(defaultValue = "55")
     Integer count;
+
 }

--- a/dbflow-tests/src/androidTest/java/com/raizlabs/android/dbflow/test/sql/InsertConflictModel.java
+++ b/dbflow-tests/src/androidTest/java/com/raizlabs/android/dbflow/test/sql/InsertConflictModel.java
@@ -1,0 +1,21 @@
+package com.raizlabs.android.dbflow.test.sql;
+
+import com.raizlabs.android.dbflow.annotation.Column;
+import com.raizlabs.android.dbflow.annotation.ConflictAction;
+import com.raizlabs.android.dbflow.annotation.PrimaryKey;
+import com.raizlabs.android.dbflow.annotation.Table;
+import com.raizlabs.android.dbflow.structure.BaseModel;
+import com.raizlabs.android.dbflow.test.TestDatabase;
+
+/**
+ * Description:
+ */
+@Table(database = TestDatabase.class, insertConflict = ConflictAction.ABORT)
+public class InsertConflictModel extends BaseModel {
+
+    @PrimaryKey
+    long id;
+
+    @Column
+    String name;
+}

--- a/dbflow-tests/src/androidTest/java/com/raizlabs/android/dbflow/test/structure/ManyToManyModel.java
+++ b/dbflow-tests/src/androidTest/java/com/raizlabs/android/dbflow/test/structure/ManyToManyModel.java
@@ -1,0 +1,25 @@
+package com.raizlabs.android.dbflow.test.structure;
+
+import com.raizlabs.android.dbflow.annotation.Column;
+import com.raizlabs.android.dbflow.annotation.ManyToMany;
+import com.raizlabs.android.dbflow.annotation.PrimaryKey;
+import com.raizlabs.android.dbflow.annotation.Table;
+import com.raizlabs.android.dbflow.structure.BaseModel;
+import com.raizlabs.android.dbflow.test.TestDatabase;
+
+/**
+ * Description: Tests code gen on many to many.
+ */
+@Table(database = TestDatabase.class)
+@ManyToMany(referencedTable = TestModel1.class)
+public class ManyToManyModel extends BaseModel {
+
+    @PrimaryKey
+    String name;
+
+    @PrimaryKey
+    int id;
+
+    @Column
+    char anotherColumn;
+}

--- a/dbflow-tests/src/androidTest/java/com/raizlabs/android/dbflow/test/structure/ManyToManyModel2.java
+++ b/dbflow-tests/src/androidTest/java/com/raizlabs/android/dbflow/test/structure/ManyToManyModel2.java
@@ -1,0 +1,25 @@
+package com.raizlabs.android.dbflow.test.structure;
+
+import com.raizlabs.android.dbflow.annotation.Column;
+import com.raizlabs.android.dbflow.annotation.ManyToMany;
+import com.raizlabs.android.dbflow.annotation.PrimaryKey;
+import com.raizlabs.android.dbflow.annotation.Table;
+import com.raizlabs.android.dbflow.structure.BaseModel;
+import com.raizlabs.android.dbflow.test.TestDatabase;
+
+/**
+ * Description: Test code gen of many to many with {@link ManyToMany#generateAutoIncrement()} false.
+ */
+@Table(database = TestDatabase.class)
+@ManyToMany(referencedTable = TestModel1.class, generateAutoIncrement = false)
+public class ManyToManyModel2 extends BaseModel {
+
+    @PrimaryKey
+    String name;
+
+    @PrimaryKey
+    int id;
+
+    @Column
+    char anotherColumn;
+}

--- a/dbflow-tests/src/androidTest/java/com/raizlabs/android/dbflow/test/structure/TestEmptyModel.java
+++ b/dbflow-tests/src/androidTest/java/com/raizlabs/android/dbflow/test/structure/TestEmptyModel.java
@@ -1,6 +1,7 @@
 package com.raizlabs.android.dbflow.test.structure;
 
 import com.raizlabs.android.dbflow.annotation.Column;
+import com.raizlabs.android.dbflow.annotation.ColumnIgnore;
 import com.raizlabs.android.dbflow.annotation.PrimaryKey;
 import com.raizlabs.android.dbflow.annotation.Table;
 import com.raizlabs.android.dbflow.structure.BaseModel;
@@ -24,5 +25,6 @@ public class TestEmptyModel extends BaseModel {
 
     final String finalName = "";
 
+    @ColumnIgnore
     private int hidden;
 }

--- a/dbflow-tests/src/androidTest/java/com/raizlabs/android/dbflow/test/structure/backup/BackupDatabase.java
+++ b/dbflow-tests/src/androidTest/java/com/raizlabs/android/dbflow/test/structure/backup/BackupDatabase.java
@@ -1,0 +1,14 @@
+package com.raizlabs.android.dbflow.test.structure.backup;
+
+import com.raizlabs.android.dbflow.annotation.Database;
+
+/**
+ * Description:
+ */
+@Database(name = BackupDatabase.NAME, version = BackupDatabase.VERSION, backupEnabled = true)
+public class BackupDatabase {
+
+    public static final String NAME = "BackupDB";
+
+    public static final int VERSION = 1;
+}

--- a/dbflow-tests/src/androidTest/java/com/raizlabs/android/dbflow/test/structure/backup/BackupModel.java
+++ b/dbflow-tests/src/androidTest/java/com/raizlabs/android/dbflow/test/structure/backup/BackupModel.java
@@ -1,0 +1,19 @@
+package com.raizlabs.android.dbflow.test.structure.backup;
+
+import com.raizlabs.android.dbflow.annotation.PrimaryKey;
+import com.raizlabs.android.dbflow.annotation.Table;
+import com.raizlabs.android.dbflow.structure.BaseModel;
+
+/**
+ * Description:
+ */
+@Table(database = BackupDatabase.class)
+public class BackupModel extends BaseModel {
+
+    @PrimaryKey
+    String name;
+
+    public String getName() {
+        return name;
+    }
+}

--- a/dbflow-tests/src/androidTest/java/com/raizlabs/android/dbflow/test/structure/backup/BackupTest.java
+++ b/dbflow-tests/src/androidTest/java/com/raizlabs/android/dbflow/test/structure/backup/BackupTest.java
@@ -1,0 +1,24 @@
+package com.raizlabs.android.dbflow.test.structure.backup;
+
+import com.raizlabs.android.dbflow.sql.language.Delete;
+import com.raizlabs.android.dbflow.test.FlowTestCase;
+
+/**
+ * Description:
+ */
+public class BackupTest extends FlowTestCase {
+
+    public void testBackup() {
+
+        Delete.table(BackupModel.class);
+
+        BackupModel backupModel = new BackupModel();
+        backupModel.name = "Test";
+        backupModel.save();
+
+        assertTrue(backupModel.exists());
+
+        Delete.table(BackupModel.class);
+
+    }
+}

--- a/dbflow-tests/src/androidTest/java/com/raizlabs/android/dbflow/test/structure/foreignkey/ForeignAsPrimaryModel.java
+++ b/dbflow-tests/src/androidTest/java/com/raizlabs/android/dbflow/test/structure/foreignkey/ForeignAsPrimaryModel.java
@@ -5,6 +5,7 @@ import com.raizlabs.android.dbflow.annotation.ModelContainer;
 import com.raizlabs.android.dbflow.annotation.PrimaryKey;
 import com.raizlabs.android.dbflow.annotation.Table;
 import com.raizlabs.android.dbflow.structure.BaseModel;
+import com.raizlabs.android.dbflow.structure.container.ForeignKeyContainer;
 import com.raizlabs.android.dbflow.test.TestDatabase;
 import com.raizlabs.android.dbflow.test.sql.BoxedModel;
 import com.raizlabs.android.dbflow.test.structure.TestModel1;
@@ -26,4 +27,8 @@ public class ForeignAsPrimaryModel extends BaseModel {
     @ForeignKey
     @PrimaryKey
     BoxedModel boxedModel;
+
+    @ForeignKey
+    @PrimaryKey
+    ForeignKeyContainer<BoxedModel> boxedModelForeignKeyContainer;
 }

--- a/dbflow-tests/src/androidTest/java/com/raizlabs/android/dbflow/test/structure/foreignkey/ForeignAsPrimaryModel.java
+++ b/dbflow-tests/src/androidTest/java/com/raizlabs/android/dbflow/test/structure/foreignkey/ForeignAsPrimaryModel.java
@@ -1,0 +1,27 @@
+package com.raizlabs.android.dbflow.test.structure.foreignkey;
+
+import com.raizlabs.android.dbflow.annotation.ForeignKey;
+import com.raizlabs.android.dbflow.annotation.PrimaryKey;
+import com.raizlabs.android.dbflow.annotation.Table;
+import com.raizlabs.android.dbflow.structure.BaseModel;
+import com.raizlabs.android.dbflow.test.TestDatabase;
+import com.raizlabs.android.dbflow.test.sql.BoxedModel;
+import com.raizlabs.android.dbflow.test.structure.TestModel1;
+
+/**
+ * Description:
+ */
+@Table(database = TestDatabase.class)
+public class ForeignAsPrimaryModel extends BaseModel {
+
+    @PrimaryKey
+    long id;
+
+    @ForeignKey
+    @PrimaryKey
+    TestModel1 testModel1;
+
+    @ForeignKey
+    @PrimaryKey
+    BoxedModel boxedModel;
+}

--- a/dbflow-tests/src/androidTest/java/com/raizlabs/android/dbflow/test/structure/foreignkey/ForeignAsPrimaryModel.java
+++ b/dbflow-tests/src/androidTest/java/com/raizlabs/android/dbflow/test/structure/foreignkey/ForeignAsPrimaryModel.java
@@ -1,6 +1,7 @@
 package com.raizlabs.android.dbflow.test.structure.foreignkey;
 
 import com.raizlabs.android.dbflow.annotation.ForeignKey;
+import com.raizlabs.android.dbflow.annotation.ModelContainer;
 import com.raizlabs.android.dbflow.annotation.PrimaryKey;
 import com.raizlabs.android.dbflow.annotation.Table;
 import com.raizlabs.android.dbflow.structure.BaseModel;
@@ -11,6 +12,7 @@ import com.raizlabs.android.dbflow.test.structure.TestModel1;
 /**
  * Description:
  */
+@ModelContainer
 @Table(database = TestDatabase.class)
 public class ForeignAsPrimaryModel extends BaseModel {
 

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/BaseModelQueriable.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/BaseModelQueriable.java
@@ -112,7 +112,12 @@ public abstract class BaseModelQueriable<ModelClass extends Model> implements Mo
 
     @Override
     public DatabaseStatement compileStatement() {
-        return FlowManager.getDatabaseForTable(table).getWritableDatabase().compileStatement(getQuery());
+        return compileStatement(FlowManager.getDatabaseForTable(table).getWritableDatabase());
+    }
+
+    @Override
+    public DatabaseStatement compileStatement(DatabaseWrapper databaseWrapper) {
+        return databaseWrapper.compileStatement(getQuery());
     }
 
     @Override

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/BaseModelQueriable.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/BaseModelQueriable.java
@@ -14,6 +14,7 @@ import com.raizlabs.android.dbflow.structure.BaseQueryModel;
 import com.raizlabs.android.dbflow.structure.InstanceAdapter;
 import com.raizlabs.android.dbflow.structure.Model;
 import com.raizlabs.android.dbflow.structure.container.ModelContainer;
+import com.raizlabs.android.dbflow.structure.database.DatabaseStatement;
 import com.raizlabs.android.dbflow.structure.database.DatabaseWrapper;
 
 import java.util.List;
@@ -107,6 +108,11 @@ public abstract class BaseModelQueriable<ModelClass extends Model> implements Mo
         if (cursor != null) {
             cursor.close();
         }
+    }
+
+    @Override
+    public DatabaseStatement compileStatement() {
+        return FlowManager.getDatabaseForTable(table).getWritableDatabase().compileStatement(getQuery());
     }
 
     @Override

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/BaseModelQueriable.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/BaseModelQueriable.java
@@ -1,6 +1,5 @@
 package com.raizlabs.android.dbflow.sql.language;
 
-import android.database.Cursor;
 import android.support.annotation.NonNull;
 
 import com.raizlabs.android.dbflow.config.FlowManager;
@@ -14,7 +13,6 @@ import com.raizlabs.android.dbflow.structure.BaseQueryModel;
 import com.raizlabs.android.dbflow.structure.InstanceAdapter;
 import com.raizlabs.android.dbflow.structure.Model;
 import com.raizlabs.android.dbflow.structure.container.ModelContainer;
-import com.raizlabs.android.dbflow.structure.database.DatabaseStatement;
 import com.raizlabs.android.dbflow.structure.database.DatabaseWrapper;
 
 import java.util.List;
@@ -22,9 +20,8 @@ import java.util.List;
 /**
  * Description: Provides a base implementation of {@link ModelQueriable} to simplify a lot of code.
  */
-public abstract class BaseModelQueriable<ModelClass extends Model> implements ModelQueriable<ModelClass>, Query {
+public abstract class BaseModelQueriable<ModelClass extends Model> extends BaseQueriable<ModelClass> implements ModelQueriable<ModelClass>, Query {
 
-    private final Class<ModelClass> table;
     private final InstanceAdapter<?, ModelClass> retrievalAdapter;
 
     /**
@@ -33,7 +30,7 @@ public abstract class BaseModelQueriable<ModelClass extends Model> implements Mo
      * @param table the table that belongs to this query.
      */
     protected BaseModelQueriable(Class<ModelClass> table) {
-        this.table = table;
+        super(table);
         //noinspection unchecked
         retrievalAdapter = FlowManager.getInstanceAdapter(table);
     }
@@ -61,12 +58,7 @@ public abstract class BaseModelQueriable<ModelClass extends Model> implements Mo
     @SuppressWarnings("unchecked")
     @Override
     public <ModelContainerClass extends ModelContainer<ModelClass, ?>> ModelContainerClass queryModelContainer(@NonNull ModelContainerClass instance) {
-        return (ModelContainerClass) FlowManager.getContainerAdapter(table).getModelContainerLoader().load(getQuery(), instance);
-    }
-
-    @Override
-    public Class<ModelClass> getTable() {
-        return table;
+        return (ModelContainerClass) FlowManager.getContainerAdapter(getTable()).getModelContainerLoader().load(getQuery(), instance);
     }
 
     @Override
@@ -94,34 +86,4 @@ public abstract class BaseModelQueriable<ModelClass extends Model> implements Mo
         return FlowManager.getQueryModelAdapter(queryModelClass).getSingleModelLoader().load(getQuery());
     }
 
-    @Override
-    public void execute(DatabaseWrapper wrapper) {
-        Cursor cursor = query(wrapper);
-        if (cursor != null) {
-            cursor.close();
-        }
-    }
-
-    @Override
-    public void execute() {
-        Cursor cursor = query();
-        if (cursor != null) {
-            cursor.close();
-        }
-    }
-
-    @Override
-    public DatabaseStatement compileStatement() {
-        return compileStatement(FlowManager.getDatabaseForTable(table).getWritableDatabase());
-    }
-
-    @Override
-    public DatabaseStatement compileStatement(DatabaseWrapper databaseWrapper) {
-        return databaseWrapper.compileStatement(getQuery());
-    }
-
-    @Override
-    public String toString() {
-        return getQuery();
-    }
 }

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/BaseModelQueriable.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/BaseModelQueriable.java
@@ -47,6 +47,16 @@ public abstract class BaseModelQueriable<ModelClass extends Model> implements Mo
         return retrievalAdapter.getSingleModelLoader().load(getQuery());
     }
 
+    @Override
+    public ModelClass querySingle(DatabaseWrapper wrapper) {
+        return retrievalAdapter.getSingleModelLoader().load(wrapper, getQuery());
+    }
+
+    @Override
+    public List<ModelClass> queryList(DatabaseWrapper wrapper) {
+        return retrievalAdapter.getListModelLoader().load(wrapper, getQuery());
+    }
+
     @SuppressWarnings("unchecked")
     @Override
     public <ModelContainerClass extends ModelContainer<ModelClass, ?>> ModelContainerClass queryModelContainer(@NonNull ModelContainerClass instance) {

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/BaseModelQueriable.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/BaseModelQueriable.java
@@ -14,6 +14,7 @@ import com.raizlabs.android.dbflow.structure.BaseQueryModel;
 import com.raizlabs.android.dbflow.structure.InstanceAdapter;
 import com.raizlabs.android.dbflow.structure.Model;
 import com.raizlabs.android.dbflow.structure.container.ModelContainer;
+import com.raizlabs.android.dbflow.structure.database.DatabaseWrapper;
 
 import java.util.List;
 
@@ -80,6 +81,14 @@ public abstract class BaseModelQueriable<ModelClass extends Model> implements Mo
     @Override
     public <QueryClass extends BaseQueryModel> QueryClass queryCustomSingle(Class<QueryClass> queryModelClass) {
         return FlowManager.getQueryModelAdapter(queryModelClass).getSingleModelLoader().load(getQuery());
+    }
+
+    @Override
+    public void execute(DatabaseWrapper wrapper) {
+        Cursor cursor = query(wrapper);
+        if (cursor != null) {
+            cursor.close();
+        }
     }
 
     @Override

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/BaseQueriable.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/BaseQueriable.java
@@ -79,4 +79,10 @@ public abstract class BaseQueriable<ModelClass extends Model> implements Queriab
     public DatabaseStatement compileStatement(DatabaseWrapper databaseWrapper) {
         return databaseWrapper.compileStatement(getQuery());
     }
+
+
+    @Override
+    public String toString() {
+        return getQuery();
+    }
 }

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/BaseQueriable.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/BaseQueriable.java
@@ -1,0 +1,82 @@
+package com.raizlabs.android.dbflow.sql.language;
+
+import android.database.Cursor;
+
+import com.raizlabs.android.dbflow.config.FlowManager;
+import com.raizlabs.android.dbflow.sql.Query;
+import com.raizlabs.android.dbflow.sql.SqlUtils;
+import com.raizlabs.android.dbflow.sql.queriable.Queriable;
+import com.raizlabs.android.dbflow.structure.Model;
+import com.raizlabs.android.dbflow.structure.database.DatabaseStatement;
+import com.raizlabs.android.dbflow.structure.database.DatabaseWrapper;
+
+/**
+ * Description:
+ */
+public abstract class BaseQueriable<ModelClass extends Model> implements Queriable, Query {
+
+
+    private final Class<ModelClass> table;
+
+    protected BaseQueriable(Class<ModelClass> table) {
+        this.table = table;
+    }
+
+    /**
+     * @return The table associated with this INSERT
+     */
+    public Class<ModelClass> getTable() {
+        return table;
+    }
+
+    /**
+     * @return Exeuctes and returns the count of rows affected by this query.
+     */
+    @Override
+    public long count(DatabaseWrapper databaseWrapper) {
+        return SqlUtils.longForQuery(databaseWrapper, getQuery());
+    }
+
+    @Override
+    public long count() {
+        return count(FlowManager.getDatabaseForTable(getTable()).getWritableDatabase());
+    }
+
+    @Override
+    public Cursor query() {
+        query(FlowManager.getDatabaseForTable(table).getWritableDatabase());
+        return null;
+    }
+
+    @Override
+    public Cursor query(DatabaseWrapper databaseWrapper) {
+        databaseWrapper.execSQL(getQuery());
+        return null;
+    }
+
+    @Override
+    public void execute() {
+        Cursor cursor = query();
+        if (cursor != null) {
+            cursor.close();
+        }
+    }
+
+    @Override
+    public void execute(DatabaseWrapper databaseWrapper) {
+        Cursor cursor = query(databaseWrapper);
+        if (cursor != null) {
+            cursor.close();
+        }
+    }
+
+    @Override
+    public DatabaseStatement compileStatement() {
+        return compileStatement(FlowManager.getDatabaseForTable(table).getWritableDatabase());
+    }
+
+    @Override
+    public DatabaseStatement compileStatement(DatabaseWrapper databaseWrapper) {
+        return databaseWrapper.compileStatement(getQuery());
+    }
+}

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/ConditionGroup.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/ConditionGroup.java
@@ -20,11 +20,20 @@ public class ConditionGroup extends BaseCondition implements Query, Iterable<SQL
         return new ConditionGroup();
     }
 
+    /**
+     * @return Starts an arbitrary clause of conditions to use, that when included in other {@link SQLCondition},
+     * does not append paranthesis to group it.
+     */
+    public static ConditionGroup nonGroupingClause() {
+        return new ConditionGroup();
+    }
+
     private final List<SQLCondition> conditionsList = new ArrayList<>();
 
     private QueryBuilder query;
     private boolean isChanged;
     private boolean allCommaSeparated;
+    private boolean useParenthesis = true;
 
     ConditionGroup(NameAlias columnName) {
         super(columnName);
@@ -47,6 +56,17 @@ public class ConditionGroup extends BaseCondition implements Query, Iterable<SQL
     public ConditionGroup setAllCommaSeparated(boolean allCommaSeparated) {
         this.allCommaSeparated = allCommaSeparated;
         isChanged = true;
+        return this;
+    }
+
+    /**
+     * Sets whether we use paranthesis when grouping this within other {@link SQLCondition}. The default
+     * is true, but if no conditions exist there are no paranthesis anyways.
+     *
+     * @param useParenthesis true if we use them, false if not.
+     */
+    public ConditionGroup setUseParenthesis(boolean useParenthesis) {
+        this.useParenthesis = useParenthesis;
         return this;
     }
 
@@ -141,7 +161,7 @@ public class ConditionGroup extends BaseCondition implements Query, Iterable<SQL
 
     @Override
     public void appendConditionToQuery(QueryBuilder queryBuilder) {
-        if (conditionsList.size() > 0) {
+        if (useParenthesis && conditionsList.size() > 0) {
             queryBuilder.append("(");
         }
         for (SQLCondition condition : conditionsList) {
@@ -150,7 +170,7 @@ public class ConditionGroup extends BaseCondition implements Query, Iterable<SQL
                 queryBuilder.appendSpaceSeparated(condition.separator());
             }
         }
-        if (conditionsList.size() > 0) {
+        if (useParenthesis && conditionsList.size() > 0) {
             queryBuilder.append(")");
         }
     }

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/ConditionGroup.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/ConditionGroup.java
@@ -35,14 +35,14 @@ public class ConditionGroup extends BaseCondition implements Query, Iterable<SQL
     private boolean allCommaSeparated;
     private boolean useParenthesis = true;
 
-    ConditionGroup(NameAlias columnName) {
+    protected ConditionGroup(NameAlias columnName) {
         super(columnName);
 
         // default is AND
         separator = Operation.AND;
     }
 
-    public ConditionGroup() {
+    protected ConditionGroup() {
         this(null);
     }
 

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/ConditionGroup.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/ConditionGroup.java
@@ -22,7 +22,7 @@ public class ConditionGroup extends BaseCondition implements Query, Iterable<SQL
 
     /**
      * @return Starts an arbitrary clause of conditions to use, that when included in other {@link SQLCondition},
-     * does not append paranthesis to group it.
+     * does not append parenthesis to group it.
      */
     public static ConditionGroup nonGroupingClause() {
         return new ConditionGroup();

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/ConditionGroup.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/ConditionGroup.java
@@ -25,7 +25,7 @@ public class ConditionGroup extends BaseCondition implements Query, Iterable<SQL
      * does not append parenthesis to group it.
      */
     public static ConditionGroup nonGroupingClause() {
-        return new ConditionGroup();
+        return new ConditionGroup().setUseParenthesis(false);
     }
 
     private final List<SQLCondition> conditionsList = new ArrayList<>();

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/ConditionGroup.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/ConditionGroup.java
@@ -141,11 +141,17 @@ public class ConditionGroup extends BaseCondition implements Query, Iterable<SQL
 
     @Override
     public void appendConditionToQuery(QueryBuilder queryBuilder) {
+        if (conditionsList.size() > 0) {
+            queryBuilder.append("(");
+        }
         for (SQLCondition condition : conditionsList) {
             condition.appendConditionToQuery(queryBuilder);
             if (condition.hasSeparator()) {
                 queryBuilder.appendSpaceSeparated(condition.separator());
             }
+        }
+        if (conditionsList.size() > 0) {
+            queryBuilder.append(")");
         }
     }
 

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/From.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/From.java
@@ -162,11 +162,6 @@ public class From<ModelClass extends Model> extends BaseModelQueriable<ModelClas
     }
 
     @Override
-    public String toString() {
-        return getQuery();
-    }
-
-    @Override
     public String getQuery() {
         QueryBuilder queryBuilder = new QueryBuilder()
                 .append(queryBase.getQuery());

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/From.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/From.java
@@ -4,8 +4,6 @@ import android.database.Cursor;
 import android.support.annotation.NonNull;
 
 import com.raizlabs.android.dbflow.config.FlowManager;
-import com.raizlabs.android.dbflow.list.FlowCursorList;
-import com.raizlabs.android.dbflow.list.FlowQueryList;
 import com.raizlabs.android.dbflow.sql.Query;
 import com.raizlabs.android.dbflow.sql.QueryBuilder;
 import com.raizlabs.android.dbflow.sql.language.property.IProperty;
@@ -128,45 +126,14 @@ public class From<ModelClass extends Model> extends BaseModelQueriable<ModelClas
         return where().andAll(conditions);
     }
 
-    /**
-     * @return the result of the query as a {@link Cursor}.
-     */
-    @Override
-    public Cursor query(DatabaseWrapper wrapper) {
-        return where().query(wrapper);
-    }
-
     @Override
     public Cursor query() {
         return where().query();
     }
 
-    /**
-     * Queries for all of the results this statement returns from a DB cursor in the form of the {@link ModelClass}
-     *
-     * @return All of the entries in the DB converted into {@link ModelClass}
-     */
     @Override
-    public List<ModelClass> queryList() {
-        return where().queryList();
-    }
-
-    /**
-     * @return The first result of this query. It forces a {@link Where#limit(int)} of 1 for more efficient querying.
-     */
-    @Override
-    public ModelClass querySingle() {
-        return where().querySingle();
-    }
-
-    @Override
-    public FlowCursorList<ModelClass> queryCursorList() {
-        return new FlowCursorList<>(false, this);
-    }
-
-    @Override
-    public FlowQueryList<ModelClass> queryTableList() {
-        return new FlowQueryList<>(this);
+    public Cursor query(DatabaseWrapper databaseWrapper) {
+        return where().query(databaseWrapper);
     }
 
     /**

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/From.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/From.java
@@ -141,8 +141,14 @@ public class From<ModelClass extends Model> extends BaseModelQueriable<ModelClas
      *
      * @return The number of rows this query returns
      */
+    @Override
     public long count() {
         return where().count();
+    }
+
+    @Override
+    public long count(DatabaseWrapper databaseWrapper) {
+        return where().count(databaseWrapper);
     }
 
     /**

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/From.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/From.java
@@ -12,6 +12,7 @@ import com.raizlabs.android.dbflow.sql.language.property.IProperty;
 import com.raizlabs.android.dbflow.sql.language.property.IndexProperty;
 import com.raizlabs.android.dbflow.sql.queriable.ModelQueriable;
 import com.raizlabs.android.dbflow.structure.Model;
+import com.raizlabs.android.dbflow.structure.database.DatabaseWrapper;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -131,6 +132,11 @@ public class From<ModelClass extends Model> extends BaseModelQueriable<ModelClas
      * @return the result of the query as a {@link Cursor}.
      */
     @Override
+    public Cursor query(DatabaseWrapper wrapper) {
+        return where().query(wrapper);
+    }
+
+    @Override
     public Cursor query() {
         return where().query();
     }
@@ -151,14 +157,6 @@ public class From<ModelClass extends Model> extends BaseModelQueriable<ModelClas
     @Override
     public ModelClass querySingle() {
         return where().querySingle();
-    }
-
-    @Override
-    public void execute() {
-        Cursor query = query();
-        if (query != null) {
-            query.close();
-        }
     }
 
     @Override

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/Insert.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/Insert.java
@@ -4,7 +4,6 @@ import android.content.ContentValues;
 import android.database.Cursor;
 
 import com.raizlabs.android.dbflow.annotation.ConflictAction;
-import com.raizlabs.android.dbflow.config.BaseDatabaseDefinition;
 import com.raizlabs.android.dbflow.config.FlowManager;
 import com.raizlabs.android.dbflow.sql.Query;
 import com.raizlabs.android.dbflow.sql.SqlUtils;
@@ -28,11 +27,6 @@ public class Insert<ModelClass extends Model> implements Query, Queriable {
     private Class<ModelClass> table;
 
     /**
-     * The database manager
-     */
-    private BaseDatabaseDefinition baseDatabaseDefinition;
-
-    /**
      * The columns to specify in this query (optional)
      */
     private IProperty[] columns;
@@ -54,7 +48,6 @@ public class Insert<ModelClass extends Model> implements Query, Queriable {
      */
     public Insert(Class<ModelClass> table) {
         this.table = table;
-        baseDatabaseDefinition = FlowManager.getDatabaseForTable(table);
     }
 
     /**
@@ -204,8 +197,14 @@ public class Insert<ModelClass extends Model> implements Query, Queriable {
     /**
      * @return Exeuctes and returns the count of rows affected by this query.
      */
+    @Override
+    public long count(DatabaseWrapper databaseWrapper) {
+        return SqlUtils.longForQuery(databaseWrapper, getQuery());
+    }
+
+    @Override
     public long count() {
-        return SqlUtils.longForQuery(baseDatabaseDefinition.getWritableDatabase(), getQuery());
+        return count(FlowManager.getDatabaseForTable(table).getWritableDatabase());
     }
 
     @Override

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/Insert.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/Insert.java
@@ -13,6 +13,7 @@ import com.raizlabs.android.dbflow.sql.language.property.IProperty;
 import com.raizlabs.android.dbflow.sql.queriable.Queriable;
 import com.raizlabs.android.dbflow.structure.Model;
 import com.raizlabs.android.dbflow.structure.ModelAdapter;
+import com.raizlabs.android.dbflow.structure.database.DatabaseWrapper;
 
 import java.util.Map;
 
@@ -244,12 +245,29 @@ public class Insert<ModelClass extends Model> implements Query, Queriable {
 
     @Override
     public Cursor query() {
-        FlowManager.getDatabaseForTable(table).getWritableDatabase().execSQL(getQuery());
+        query(FlowManager.getDatabaseForTable(table).getWritableDatabase());
+        return null;
+    }
+
+    @Override
+    public Cursor query(DatabaseWrapper databaseWrapper) {
+        databaseWrapper.execSQL(getQuery());
         return null;
     }
 
     @Override
     public void execute() {
-        query();
+        Cursor cursor = query();
+        if (cursor != null) {
+            cursor.close();
+        }
+    }
+
+    @Override
+    public void execute(DatabaseWrapper databaseWrapper) {
+        Cursor cursor = query(databaseWrapper);
+        if (cursor != null) {
+            cursor.close();
+        }
     }
 }

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/OrderBy.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/OrderBy.java
@@ -18,6 +18,7 @@ public class OrderBy implements Query {
     private boolean isAscending;
 
     private Collate collation;
+    private String orderByString;
 
     public static OrderBy fromProperty(IProperty property) {
         return new OrderBy(property.getNameAlias());
@@ -27,6 +28,10 @@ public class OrderBy implements Query {
         return new OrderBy(nameAlias);
     }
 
+    public static OrderBy fromString(String orderByString) {
+        return new OrderBy(orderByString);
+    }
+
     OrderBy(NameAlias column) {
         this.column = column;
     }
@@ -34,6 +39,10 @@ public class OrderBy implements Query {
     OrderBy(NameAlias column, boolean isAscending) {
         this(column);
         this.isAscending = isAscending;
+    }
+
+    OrderBy(String orderByString) {
+        this.orderByString = orderByString;
     }
 
     public OrderBy ascending() {
@@ -53,14 +62,18 @@ public class OrderBy implements Query {
 
     @Override
     public String getQuery() {
-        StringBuilder query = new StringBuilder()
-                .append(column)
-                .append(" ");
-        if (collation != null) {
-            query.append("COLLATE").append(" ").append(collation).append(" ");
+        if (orderByString == null) {
+            StringBuilder query = new StringBuilder()
+                    .append(column)
+                    .append(" ");
+            if (collation != null) {
+                query.append("COLLATE").append(" ").append(collation).append(" ");
+            }
+            query.append(isAscending ? "ASC" : "DESC");
+            return query.toString();
+        } else {
+            return orderByString;
         }
-        query.append(isAscending ? "ASC" : "DESC");
-        return query.toString();
     }
 
     @Override

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/Set.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/Set.java
@@ -10,6 +10,7 @@ import com.raizlabs.android.dbflow.sql.SqlUtils;
 import com.raizlabs.android.dbflow.sql.language.property.IProperty;
 import com.raizlabs.android.dbflow.sql.queriable.Queriable;
 import com.raizlabs.android.dbflow.structure.Model;
+import com.raizlabs.android.dbflow.structure.database.DatabaseWrapper;
 
 /**
  * Description: Used to specify the SET part of an {@link com.raizlabs.android.dbflow.sql.language.Update} query.
@@ -131,12 +132,29 @@ public class Set<ModelClass extends Model> implements WhereBase<ModelClass>, Que
 
     @Override
     public Cursor query() {
-        FlowManager.getDatabaseForTable(table).getWritableDatabase().execSQL(getQuery());
+        query(FlowManager.getDatabaseForTable(table).getWritableDatabase());
+        return null;
+    }
+
+    @Override
+    public Cursor query(DatabaseWrapper databaseWrapper) {
+        databaseWrapper.execSQL(getQuery());
         return null;
     }
 
     @Override
     public void execute() {
-        query();
+        Cursor cursor = query();
+        if (cursor != null) {
+            cursor.close();
+        }
+    }
+
+    @Override
+    public void execute(DatabaseWrapper databaseWrapper) {
+        Cursor cursor = query(databaseWrapper);
+        if (cursor != null) {
+            cursor.close();
+        }
     }
 }

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/Set.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/Set.java
@@ -1,9 +1,7 @@
 package com.raizlabs.android.dbflow.sql.language;
 
 import android.content.ContentValues;
-import android.database.Cursor;
 
-import com.raizlabs.android.dbflow.config.FlowManager;
 import com.raizlabs.android.dbflow.sql.Query;
 import com.raizlabs.android.dbflow.sql.QueryBuilder;
 import com.raizlabs.android.dbflow.sql.SqlUtils;
@@ -15,17 +13,15 @@ import com.raizlabs.android.dbflow.structure.database.DatabaseWrapper;
 /**
  * Description: Used to specify the SET part of an {@link com.raizlabs.android.dbflow.sql.language.Update} query.
  */
-public class Set<ModelClass extends Model> implements WhereBase<ModelClass>, Queriable, Transformable<ModelClass> {
+public class Set<ModelClass extends Model> extends BaseQueriable<ModelClass> implements WhereBase<ModelClass>, Queriable, Transformable<ModelClass> {
 
     private ConditionGroup conditionGroup;
 
     private Query update;
 
-    private Class<ModelClass> table;
-
     Set(Query update, Class<ModelClass> table) {
+        super(table);
         this.update = update;
-        this.table = table;
         conditionGroup = new ConditionGroup();
         conditionGroup.setAllCommaSeparated(true);
     }
@@ -127,40 +123,8 @@ public class Set<ModelClass extends Model> implements WhereBase<ModelClass>, Que
     }
 
     @Override
-    public Class<ModelClass> getTable() {
-        return table;
-    }
-
-    @Override
     public Query getQueryBuilderBase() {
         return update;
     }
 
-    @Override
-    public Cursor query() {
-        query(FlowManager.getDatabaseForTable(table).getWritableDatabase());
-        return null;
-    }
-
-    @Override
-    public Cursor query(DatabaseWrapper databaseWrapper) {
-        databaseWrapper.execSQL(getQuery());
-        return null;
-    }
-
-    @Override
-    public void execute() {
-        Cursor cursor = query();
-        if (cursor != null) {
-            cursor.close();
-        }
-    }
-
-    @Override
-    public void execute(DatabaseWrapper databaseWrapper) {
-        Cursor cursor = query(databaseWrapper);
-        if (cursor != null) {
-            cursor.close();
-        }
-    }
 }

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/Set.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/Set.java
@@ -107,8 +107,14 @@ public class Set<ModelClass extends Model> implements WhereBase<ModelClass>, Que
      *
      * @return The number of rows this query returns
      */
+    @Override
     public long count() {
         return where().count();
+    }
+
+    @Override
+    public long count(DatabaseWrapper databaseWrapper) {
+        return where().count(databaseWrapper);
     }
 
     @Override

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/UnsafeStringCondition.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/UnsafeStringCondition.java
@@ -1,0 +1,62 @@
+package com.raizlabs.android.dbflow.sql.language;
+
+import com.raizlabs.android.dbflow.StringUtils;
+import com.raizlabs.android.dbflow.annotation.provider.ContentProvider;
+import com.raizlabs.android.dbflow.sql.QueryBuilder;
+
+/**
+ * Description: Meant for {@link ContentProvider} generated, this class will use a String to describe its condition.
+ * Not recommended for normal queries.
+ */
+public class UnSafeStringCondition implements SQLCondition {
+
+    private final String conditionString;
+    private String separator = "";
+
+    public UnSafeStringCondition(String selection, String[] selectionArgs) {
+        String newSelection = selection;
+        // replace question marks in order
+        if (newSelection != null) {
+            for (String selectionArg : selectionArgs) {
+                newSelection = newSelection.replaceFirst("\\?", selectionArg);
+            }
+        }
+        this.conditionString = newSelection;
+    }
+
+    @Override
+    public void appendConditionToQuery(QueryBuilder queryBuilder) {
+        queryBuilder.append(conditionString);
+    }
+
+    @Override
+    public String columnName() {
+        return "";
+    }
+
+    @Override
+    public String separator() {
+        return separator;
+    }
+
+    @Override
+    public SQLCondition separator(String separator) {
+        this.separator = separator;
+        return this;
+    }
+
+    @Override
+    public boolean hasSeparator() {
+        return StringUtils.isNotNullOrEmpty(separator);
+    }
+
+    @Override
+    public String operation() {
+        return "";
+    }
+
+    @Override
+    public Object value() {
+        return "";
+    }
+}

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/Where.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/Where.java
@@ -245,6 +245,11 @@ public class Where<ModelClass extends Model> extends BaseModelQueriable<ModelCla
         return cursor;
     }
 
+    @Override
+    public Cursor query() {
+        return query(databaseWrapper);
+    }
+
     /**
      * Queries for all of the results this statement returns from a DB cursor in the form of the {@link ModelClass}
      *

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/Where.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/Where.java
@@ -199,7 +199,8 @@ public class Where<ModelClass extends Model> extends BaseModelQueriable<ModelCla
      *
      * @return The number of rows this query returns or affects.
      */
-    public long count() {
+    @Override
+    public long count(DatabaseWrapper databaseWrapper) {
         long count;
         if ((whereBase instanceof Set) || whereBase.getQueryBuilderBase() instanceof Delete) {
             count = SQLiteCompatibilityUtils.executeUpdateDelete(databaseWrapper, getQuery());
@@ -207,6 +208,11 @@ public class Where<ModelClass extends Model> extends BaseModelQueriable<ModelCla
             count = SqlUtils.longForQuery(databaseWrapper, getQuery());
         }
         return count;
+    }
+
+    @Override
+    public long count() {
+        return count(databaseWrapper);
     }
 
     @Override

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/Where.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/Where.java
@@ -22,7 +22,7 @@ import java.util.List;
  * Description: Defines the SQL WHERE statement of the query.
  */
 public class Where<ModelClass extends Model> extends BaseModelQueriable<ModelClass>
-        implements Query, ModelQueriable<ModelClass>, Transformable<ModelClass> {
+    implements Query, ModelQueriable<ModelClass>, Transformable<ModelClass> {
 
     private static final int VALUE_UNSET = -1;
 
@@ -30,10 +30,6 @@ public class Where<ModelClass extends Model> extends BaseModelQueriable<ModelCla
      * The first chunk of the SQL statement before this query.
      */
     private final WhereBase<ModelClass> whereBase;
-    /**
-     * The database manager we run this query on
-     */
-    private final DatabaseWrapper databaseWrapper;
 
     /**
      * Helps to build the where statement easily
@@ -61,7 +57,6 @@ public class Where<ModelClass extends Model> extends BaseModelQueriable<ModelCla
     Where(WhereBase<ModelClass> whereBase, SQLCondition... conditions) {
         super(whereBase.getTable());
         this.whereBase = whereBase;
-        databaseWrapper = FlowManager.getDatabaseForTable(this.whereBase.getTable()).getWritableDatabase();
         conditionGroup = new ConditionGroup();
         havingGroup = new ConditionGroup();
 
@@ -189,7 +184,7 @@ public class Where<ModelClass extends Model> extends BaseModelQueriable<ModelCla
      */
     public Where<ModelClass> exists(@NonNull Where where) {
         conditionGroup.and(new ExistenceCondition()
-                .where(where));
+            .where(where));
         return this;
     }
 
@@ -212,17 +207,17 @@ public class Where<ModelClass extends Model> extends BaseModelQueriable<ModelCla
 
     @Override
     public long count() {
-        return count(databaseWrapper);
+        return count(FlowManager.getDatabaseForTable(getTable()).getWritableDatabase());
     }
 
     @Override
     public String getQuery() {
         String fromQuery = whereBase.getQuery().trim();
         QueryBuilder queryBuilder = new QueryBuilder().append(fromQuery).appendSpace()
-                .appendQualifier("WHERE", conditionGroup.getQuery())
-                .appendQualifier("GROUP BY", QueryBuilder.join(",", groupByList))
-                .appendQualifier("HAVING", havingGroup.getQuery())
-                .appendQualifier("ORDER BY", QueryBuilder.join(",", orderByList));
+            .appendQualifier("WHERE", conditionGroup.getQuery())
+            .appendQualifier("GROUP BY", QueryBuilder.join(",", groupByList))
+            .appendQualifier("HAVING", havingGroup.getQuery())
+            .appendQualifier("ORDER BY", QueryBuilder.join(",", orderByList));
 
         if (limit > VALUE_UNSET) {
             queryBuilder.appendQualifier("LIMIT", String.valueOf(limit));
@@ -253,7 +248,7 @@ public class Where<ModelClass extends Model> extends BaseModelQueriable<ModelCla
 
     @Override
     public Cursor query() {
-        return query(databaseWrapper);
+        return query(FlowManager.getDatabaseForTable(getTable()).getWritableDatabase());
     }
 
     /**

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/Where.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/Where.java
@@ -202,9 +202,9 @@ public class Where<ModelClass extends Model> extends BaseModelQueriable<ModelCla
     public long count() {
         long count;
         if ((whereBase instanceof Set) || whereBase.getQueryBuilderBase() instanceof Delete) {
-            count = SQLiteCompatibilityUtils.executeUpdateDelete(databaseWrapper.getWritableDatabase(), getQuery());
+            count = SQLiteCompatibilityUtils.executeUpdateDelete(databaseWrapper, getQuery());
         } else {
-            count = SqlUtils.longForQuery(databaseWrapper.getWritableDatabase(), getQuery());
+            count = SqlUtils.longForQuery(databaseWrapper, getQuery());
         }
         return count;
     }

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/property/IndexProperty.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/property/IndexProperty.java
@@ -43,7 +43,7 @@ public class IndexProperty<T extends Model> {
     }
 
     public void drop(DatabaseWrapper writableDatabase) {
-        writableDatabase.execSQL(getDropQuery())
+        writableDatabase.execSQL(getDropQuery());
     }
 
     public String getCreateQuery() {

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/property/IndexProperty.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/property/IndexProperty.java
@@ -1,8 +1,10 @@
 package com.raizlabs.android.dbflow.sql.language.property;
 
+import com.raizlabs.android.dbflow.annotation.Table;
 import com.raizlabs.android.dbflow.config.FlowManager;
 import com.raizlabs.android.dbflow.sql.QueryBuilder;
 import com.raizlabs.android.dbflow.structure.Model;
+import com.raizlabs.android.dbflow.structure.database.DatabaseWrapper;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -28,12 +30,20 @@ public class IndexProperty<T extends Model> {
         this.unique = unique;
     }
 
+    public void createIfNotExists(DatabaseWrapper wrapper) {
+        wrapper.execSQL(getCreateQuery());
+    }
+
     public void createIfNotExists() {
-        FlowManager.getDatabaseForTable(table).getWritableDatabase().execSQL(getCreateQuery());
+        createIfNotExists(FlowManager.getDatabaseForTable(table).getWritableDatabase());
     }
 
     public void drop() {
-        FlowManager.getDatabaseForTable(table).getWritableDatabase().execSQL(getDropQuery());
+        drop(FlowManager.getDatabaseForTable(table).getWritableDatabase());
+    }
+
+    private void drop(DatabaseWrapper writableDatabase) {
+        writableDatabase.execSQL(getDropQuery())
     }
 
     public String getCreateQuery() {

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/property/IndexProperty.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/property/IndexProperty.java
@@ -42,7 +42,7 @@ public class IndexProperty<T extends Model> {
         drop(FlowManager.getDatabaseForTable(table).getWritableDatabase());
     }
 
-    private void drop(DatabaseWrapper writableDatabase) {
+    public void drop(DatabaseWrapper writableDatabase) {
         writableDatabase.execSQL(getDropQuery())
     }
 

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/migration/IndexPropertyMigration.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/migration/IndexPropertyMigration.java
@@ -1,0 +1,31 @@
+package com.raizlabs.android.dbflow.sql.migration;
+
+import com.raizlabs.android.dbflow.sql.language.property.IndexProperty;
+import com.raizlabs.android.dbflow.structure.database.DatabaseWrapper;
+
+/**
+ * Description: Allows you to specify if and when an {@link IndexProperty} gets used or created.
+ */
+public class IndexPropertyMigration extends BaseMigration {
+
+    private final IndexProperty indexProperty;
+    private boolean shouldCreate = true;
+
+    public IndexPropertyMigration(IndexProperty indexProperty) {
+        this.indexProperty = indexProperty;
+    }
+
+    /**
+     * If you wish to drop the index, set this method to false. Call this in the subclasses constructor.
+     *
+     * @param shouldCreate 
+     */
+    public void setShouldCreate(boolean shouldCreate) {
+        this.shouldCreate = shouldCreate;
+    }
+
+    @Override
+    public void migrate(DatabaseWrapper database) {
+        indexProperty.createIfNotExists(database);
+    }
+}

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/migration/IndexPropertyMigration.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/migration/IndexPropertyMigration.java
@@ -18,7 +18,7 @@ public class IndexPropertyMigration extends BaseMigration {
     /**
      * If you wish to drop the index, set this method to false. Call this in the subclasses constructor.
      *
-     * @param shouldCreate 
+     * @param shouldCreate
      */
     public void setShouldCreate(boolean shouldCreate) {
         this.shouldCreate = shouldCreate;
@@ -26,6 +26,10 @@ public class IndexPropertyMigration extends BaseMigration {
 
     @Override
     public void migrate(DatabaseWrapper database) {
-        indexProperty.createIfNotExists(database);
+        if (shouldCreate) {
+            indexProperty.createIfNotExists(database);
+        } else {
+            indexProperty.drop(database);
+        }
     }
 }

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/migration/UpdateTableMigration.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/migration/UpdateTableMigration.java
@@ -54,7 +54,7 @@ public class UpdateTableMigration<ModelClass extends Model> extends BaseMigratio
      */
     public UpdateTableMigration<ModelClass> set(SQLCondition... conditions) {
         if (setConditionGroup == null) {
-            setConditionGroup = new ConditionGroup();
+            setConditionGroup = ConditionGroup.nonGroupingClause();
         }
 
         setConditionGroup.andAll(conditions);
@@ -63,7 +63,7 @@ public class UpdateTableMigration<ModelClass extends Model> extends BaseMigratio
 
     public UpdateTableMigration<ModelClass> where(SQLCondition... conditions) {
         if (whereConditionGroup == null) {
-            whereConditionGroup = new ConditionGroup();
+            whereConditionGroup = ConditionGroup.nonGroupingClause();
         }
 
         whereConditionGroup.andAll(conditions);

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/queriable/ModelLoader.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/queriable/ModelLoader.java
@@ -9,6 +9,7 @@ import com.raizlabs.android.dbflow.config.BaseDatabaseDefinition;
 import com.raizlabs.android.dbflow.config.FlowManager;
 import com.raizlabs.android.dbflow.structure.InstanceAdapter;
 import com.raizlabs.android.dbflow.structure.Model;
+import com.raizlabs.android.dbflow.structure.database.DatabaseWrapper;
 
 /**
  * Description: Represents how models load from DB. It will query a {@link SQLiteDatabase}
@@ -32,14 +33,29 @@ public abstract class ModelLoader<TModel extends Model, TReturn> {
      * @param query The query to call.
      * @return The data loaded from the database.
      */
-    @Nullable
     public TReturn load(String query) {
-        return load(query, null);
+        return load(databaseDefinition.getWritableDatabase(), query);
+    }
+
+    public TReturn load(String query, @Nullable TReturn data) {
+        return load(databaseDefinition.getWritableDatabase(), query, data);
+    }
+
+    /**
+     * Loads the data from a query and returns it as a {@link TReturn}.
+     *
+     * @param databaseWrapper A custom database wrapper object to use.
+     * @param query           The query to call.
+     * @return The data loaded from the database.
+     */
+    @Nullable
+    public TReturn load(@NonNull DatabaseWrapper databaseWrapper, String query) {
+        return load(databaseWrapper, query, null);
     }
 
     @Nullable
-    public TReturn load(String query, @Nullable TReturn data) {
-        final Cursor cursor = databaseDefinition.getWritableDatabase().rawQuery(query, null);
+    public TReturn load(@NonNull DatabaseWrapper databaseWrapper, String query, @Nullable TReturn data) {
+        final Cursor cursor = databaseWrapper.rawQuery(query, null);
         if (cursor != null) {
             try {
                 data = convertToData(cursor, data);

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/queriable/ModelQueriable.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/queriable/ModelQueriable.java
@@ -9,6 +9,7 @@ import com.raizlabs.android.dbflow.sql.language.Where;
 import com.raizlabs.android.dbflow.structure.BaseQueryModel;
 import com.raizlabs.android.dbflow.structure.Model;
 import com.raizlabs.android.dbflow.structure.container.ModelContainer;
+import com.raizlabs.android.dbflow.structure.database.DatabaseWrapper;
 
 import java.util.List;
 
@@ -24,9 +25,23 @@ public interface ModelQueriable<ModelClass extends Model> extends Queriable {
     List<ModelClass> queryList();
 
     /**
+     * Allows you to specify a DB, useful for migrations.
+     *
+     * @return a list of model converted items
+     */
+    List<ModelClass> queryList(DatabaseWrapper wrapper);
+
+    /**
      * @return Single model, the first of potentially many results
      */
     ModelClass querySingle();
+
+    /**
+     * Allows you to specify a DB, useful for migrations.
+     *
+     * @return Single model, the first of potentially many results
+     */
+    ModelClass querySingle(DatabaseWrapper wrapper);
 
     /**
      * Queries and populates the specified {@link ModelContainer} from the database.

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/queriable/ModelQueriable.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/queriable/ModelQueriable.java
@@ -76,11 +76,6 @@ public interface ModelQueriable<ModelClass extends Model> extends Queriable {
     AsyncQuery<ModelClass> async();
 
     /**
-     * @return A new {@link DatabaseStatement} from this query.
-     */
-    DatabaseStatement compileStatement();
-
-    /**
      * Returns a {@link List} based on the custom {@link QueryClass} you pass in.
      *
      * @param queryModelClass The query model class to use.

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/queriable/ModelQueriable.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/queriable/ModelQueriable.java
@@ -9,6 +9,7 @@ import com.raizlabs.android.dbflow.sql.language.Where;
 import com.raizlabs.android.dbflow.structure.BaseQueryModel;
 import com.raizlabs.android.dbflow.structure.Model;
 import com.raizlabs.android.dbflow.structure.container.ModelContainer;
+import com.raizlabs.android.dbflow.structure.database.DatabaseStatement;
 import com.raizlabs.android.dbflow.structure.database.DatabaseWrapper;
 
 import java.util.List;
@@ -73,6 +74,11 @@ public interface ModelQueriable<ModelClass extends Model> extends Queriable {
      * @return an async version of this query to run.
      */
     AsyncQuery<ModelClass> async();
+
+    /**
+     * @return A new {@link DatabaseStatement} from this query.
+     */
+    DatabaseStatement compileStatement();
 
     /**
      * Returns a {@link List} based on the custom {@link QueryClass} you pass in.

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/queriable/Queriable.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/queriable/Queriable.java
@@ -5,6 +5,7 @@ import android.database.Cursor;
 import com.raizlabs.android.dbflow.sql.language.Delete;
 import com.raizlabs.android.dbflow.sql.language.Insert;
 import com.raizlabs.android.dbflow.sql.language.Set;
+import com.raizlabs.android.dbflow.structure.database.DatabaseStatement;
 import com.raizlabs.android.dbflow.structure.database.DatabaseWrapper;
 
 /**
@@ -25,6 +26,18 @@ public interface Queriable {
      * @return A cursor from the DB based on this query
      */
     Cursor query(DatabaseWrapper databaseWrapper);
+
+
+    /**
+     * @return A new {@link DatabaseStatement} from this query.
+     */
+    DatabaseStatement compileStatement();
+
+    /**
+     * @param databaseWrapper The wrapper to use.
+     * @return A new {@link DatabaseStatement} from this query with database specified.
+     */
+    DatabaseStatement compileStatement(DatabaseWrapper databaseWrapper);
 
     /**
      * @return the count of the results of the query. This may return the

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/queriable/Queriable.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/queriable/Queriable.java
@@ -2,6 +2,7 @@ package com.raizlabs.android.dbflow.sql.queriable;
 
 import android.database.Cursor;
 
+import com.raizlabs.android.dbflow.sql.language.Delete;
 import com.raizlabs.android.dbflow.sql.language.Insert;
 import com.raizlabs.android.dbflow.sql.language.Set;
 import com.raizlabs.android.dbflow.structure.database.DatabaseWrapper;
@@ -24,6 +25,20 @@ public interface Queriable {
      * @return A cursor from the DB based on this query
      */
     Cursor query(DatabaseWrapper databaseWrapper);
+
+    /**
+     * @return the count of the results of the query. This may return the
+     * number of rows affected from a {@link Set} or {@link Delete} statement.
+     */
+    long count();
+
+    /**
+     * Allows you to pass in a {@link DatabaseWrapper} manually.
+     *
+     * @return the count of the results of the query. This may return the
+     * number of rows affected from a {@link Set} or {@link Delete} statement.
+     */
+    long count(DatabaseWrapper databaseWrapper);
 
     /**
      * Will not return a result, rather simply will execute a SQL statement. Use this for non-SELECT statements or when

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/queriable/Queriable.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/queriable/Queriable.java
@@ -4,6 +4,7 @@ import android.database.Cursor;
 
 import com.raizlabs.android.dbflow.sql.language.Insert;
 import com.raizlabs.android.dbflow.sql.language.Set;
+import com.raizlabs.android.dbflow.structure.database.DatabaseWrapper;
 
 /**
  * Description: The most basic interface that some of the classes such as {@link Insert}, {@link ModelQueriable},
@@ -12,14 +13,28 @@ import com.raizlabs.android.dbflow.sql.language.Set;
 public interface Queriable {
 
     /**
-     * @return a cursor from the DB based on this query
+     * @return A cursor from the DB based on this query
      */
     Cursor query();
+
+    /**
+     * Allows you to pass in a {@link DatabaseWrapper} manually.
+     *
+     * @param databaseWrapper The wrapper to pass in.
+     * @return A cursor from the DB based on this query
+     */
+    Cursor query(DatabaseWrapper databaseWrapper);
 
     /**
      * Will not return a result, rather simply will execute a SQL statement. Use this for non-SELECT statements or when
      * you're not interested in the result.
      */
     void execute();
+
+    /**
+     * Will not return a result, rather simply will execute a SQL statement. Use this for non-SELECT statements or when
+     * you're not interested in the result.
+     */
+    void execute(DatabaseWrapper databaseWrapper);
 
 }

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/queriable/StringQuery.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/queriable/StringQuery.java
@@ -6,6 +6,7 @@ import com.raizlabs.android.dbflow.config.FlowManager;
 import com.raizlabs.android.dbflow.sql.Query;
 import com.raizlabs.android.dbflow.sql.language.BaseModelQueriable;
 import com.raizlabs.android.dbflow.structure.Model;
+import com.raizlabs.android.dbflow.structure.database.DatabaseWrapper;
 
 /**
  * Description: Provides a very basic query mechanism for strings. Allows you to easily perform custom SQL query string
@@ -41,4 +42,8 @@ public class StringQuery<ModelClass extends Model> extends BaseModelQueriable<Mo
         return FlowManager.getDatabaseForTable(getTable()).getWritableDatabase().rawQuery(query, null);
     }
 
+    @Override
+    public Cursor query(DatabaseWrapper databaseWrapper) {
+        return databaseWrapper.rawQuery(query, null);
+    }
 }

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/queriable/StringQuery.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/queriable/StringQuery.java
@@ -40,7 +40,7 @@ public class StringQuery<ModelClass extends Model> extends BaseModelQueriable<Mo
 
     @Override
     public Cursor query() {
-        return FlowManager.getDatabaseForTable(getTable()).getWritableDatabase().rawQuery(query, null);
+        return query(FlowManager.getDatabaseForTable(getTable()).getWritableDatabase());
     }
 
     @Override

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/queriable/StringQuery.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/queriable/StringQuery.java
@@ -4,6 +4,7 @@ import android.database.Cursor;
 
 import com.raizlabs.android.dbflow.config.FlowManager;
 import com.raizlabs.android.dbflow.sql.Query;
+import com.raizlabs.android.dbflow.sql.SqlUtils;
 import com.raizlabs.android.dbflow.sql.language.BaseModelQueriable;
 import com.raizlabs.android.dbflow.structure.Model;
 import com.raizlabs.android.dbflow.structure.database.DatabaseWrapper;
@@ -45,5 +46,15 @@ public class StringQuery<ModelClass extends Model> extends BaseModelQueriable<Mo
     @Override
     public Cursor query(DatabaseWrapper databaseWrapper) {
         return databaseWrapper.rawQuery(query, null);
+    }
+
+    @Override
+    public long count() {
+        return count(FlowManager.getDatabaseForTable(getTable()).getWritableDatabase());
+    }
+
+    @Override
+    public long count(DatabaseWrapper databaseWrapper) {
+        return SqlUtils.longForQuery(databaseWrapper, getQuery());
     }
 }

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/BaseModel.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/BaseModel.java
@@ -1,5 +1,6 @@
 package com.raizlabs.android.dbflow.structure;
 
+import com.raizlabs.android.dbflow.annotation.ColumnIgnore;
 import com.raizlabs.android.dbflow.config.FlowManager;
 import com.raizlabs.android.dbflow.runtime.DBTransactionQueue;
 
@@ -9,7 +10,7 @@ import com.raizlabs.android.dbflow.runtime.DBTransactionQueue;
  * If you wish not to extend from this class you will need to implement {@link com.raizlabs.android.dbflow.structure.Model}
  * instead.
  */
-public abstract class BaseModel implements Model {
+public class BaseModel implements Model {
 
     /**
      * Specifies the Action that was taken when data changes
@@ -42,6 +43,7 @@ public abstract class BaseModel implements Model {
         CHANGE
     }
 
+    @ColumnIgnore
     private transient ModelAdapter modelAdapter;
 
     @SuppressWarnings("unchecked")

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/container/BaseModelContainer.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/container/BaseModelContainer.java
@@ -194,6 +194,11 @@ public abstract class BaseModelContainer<ModelClass extends Model, DataClass> im
     }
 
     @Override
+    public void putDefault(IProperty property) {
+        putDefault(property.getContainerKey());
+    }
+
+    @Override
     public ModelAdapter<ModelClass> getModelAdapter() {
         return modelAdapter;
     }

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/container/BaseModelContainer.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/container/BaseModelContainer.java
@@ -10,8 +10,7 @@ import com.raizlabs.android.dbflow.structure.InvalidDBConfiguration;
 import com.raizlabs.android.dbflow.structure.Model;
 import com.raizlabs.android.dbflow.structure.ModelAdapter;
 
-import java.util.Map;
-import java.util.Set;
+import java.util.Iterator;
 
 /**
  * Description: The base class that all ModelContainers should extend.
@@ -60,10 +59,12 @@ public abstract class BaseModelContainer<ModelClass extends Model, DataClass> im
     public BaseModelContainer(@NonNull ModelContainer<ModelClass, ?> existingContainer) {
         this(existingContainer.getTable());
 
-        Map<String, Class> columnMap = modelContainerAdapter.getColumnMap();
-        Set<String> keys = columnMap.keySet();
-        for (String key : keys) {
-            put(key, existingContainer.getValue(key));
+        Iterator<String> keys = existingContainer.iterator();
+        if (keys != null) {
+            while (keys.hasNext()) {
+                String key = keys.next();
+                put(key, existingContainer.getValue(key));
+            }
         }
     }
 

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/container/ForeignKeyContainer.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/container/ForeignKeyContainer.java
@@ -6,6 +6,7 @@ import android.support.annotation.Nullable;
 import com.raizlabs.android.dbflow.sql.language.Select;
 import com.raizlabs.android.dbflow.structure.Model;
 
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -53,7 +54,11 @@ public class ForeignKeyContainer<ModelClass extends Model> extends SimpleModelCo
     @Override
     @SuppressWarnings("unchecked")
     public BaseModelContainer getInstance(Object inValue, Class<? extends Model> columnClass) {
-        return new ForeignKeyContainer(columnClass, (Map<String, Object>) inValue);
+        if (inValue instanceof ModelContainer) {
+            return new ForeignKeyContainer((ModelContainer) inValue);
+        } else {
+            return new ForeignKeyContainer(columnClass, (Map<String, Object>) inValue);
+        }
     }
 
     @Override
@@ -76,6 +81,12 @@ public class ForeignKeyContainer<ModelClass extends Model> extends SimpleModelCo
             setData(data);
         }
         data.put(columnName, value);
+    }
+
+    @Nullable
+    @Override
+    public Iterator<String> iterator() {
+        return data != null ? data.keySet().iterator() : null;
     }
 
     /**

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/container/JSONModel.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/container/JSONModel.java
@@ -1,14 +1,16 @@
 package com.raizlabs.android.dbflow.structure.container;
 
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 
 import com.raizlabs.android.dbflow.config.FlowLog;
 import com.raizlabs.android.dbflow.data.Blob;
 import com.raizlabs.android.dbflow.structure.Model;
-import com.raizlabs.android.dbflow.structure.ModelAdapter;
 
 import org.json.JSONException;
 import org.json.JSONObject;
+
+import java.util.Iterator;
 
 /**
  * Description: This eliminates the need for converting json into a {@link com.raizlabs.android.dbflow.structure.Model}
@@ -42,7 +44,17 @@ public class JSONModel<ModelClass extends Model> extends BaseModelContainer<Mode
     @Override
     @SuppressWarnings("unchecked")
     public BaseModelContainer getInstance(Object inValue, Class<? extends Model> columnClass) {
-        return new JSONModel((JSONObject) inValue, columnClass);
+        if (inValue instanceof ModelContainer) {
+            return new JSONModel((ModelContainer) inValue);
+        } else {
+            return new JSONModel((JSONObject) inValue, columnClass);
+        }
+    }
+
+    @Nullable
+    @Override
+    public Iterator<String> iterator() {
+        return data != null ? data.keys() : null;
     }
 
     @NonNull

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/container/MapModelContainer.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/container/MapModelContainer.java
@@ -1,10 +1,12 @@
 package com.raizlabs.android.dbflow.structure.container;
 
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 
 import com.raizlabs.android.dbflow.structure.Model;
 
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Map;
 
 /**
@@ -24,7 +26,11 @@ public class MapModelContainer<ModelClass extends Model> extends SimpleModelCont
     @Override
     @SuppressWarnings("unchecked")
     public BaseModelContainer getInstance(Object inValue, Class<? extends Model> columnClass) {
-        return new MapModelContainer((Map<String, Object>) inValue, columnClass);
+        if (inValue instanceof ModelContainer) {
+            return new MapModelContainer((ModelContainer) inValue);
+        } else {
+            return new MapModelContainer((Map<String, Object>) inValue, columnClass);
+        }
     }
 
     @Override
@@ -44,12 +50,21 @@ public class MapModelContainer<ModelClass extends Model> extends SimpleModelCont
 
     @Override
     public Object getValue(String key) {
-        return getData().get(key);
+        return getData() != null ? getData().get(key) : null;
     }
 
     @Override
     public void put(String columnName, Object value) {
+        if (getData() == null) {
+            setData(newDataInstance());
+        }
+        //noinspection ConstantConditions
         getData().put(columnName, value);
     }
 
+    @Nullable
+    @Override
+    public Iterator<String> iterator() {
+        return data != null ? data.keySet().iterator() : null;
+    }
 }

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/container/ModelContainer.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/container/ModelContainer.java
@@ -8,6 +8,8 @@ import com.raizlabs.android.dbflow.sql.language.property.Property;
 import com.raizlabs.android.dbflow.structure.Model;
 import com.raizlabs.android.dbflow.structure.ModelAdapter;
 
+import java.util.Iterator;
+
 /**
  * Author: andrewgrosner
  * Description: The primary interface for converting data that acts like a {@link com.raizlabs.android.dbflow.structure.Model} into a model object
@@ -71,6 +73,9 @@ public interface ModelContainer<ModelClass extends Model, DataClass> extends Mod
      * @return true if this container contains a value with the specified key. Nulls do not count.
      */
     boolean containsValue(String key);
+
+    @Nullable
+    Iterator<String> iterator();
 
     /**
      * @param key The key in the container.

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/container/ModelContainer.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/container/ModelContainer.java
@@ -223,6 +223,14 @@ public interface ModelContainer<ModelClass extends Model, DataClass> extends Mod
     void putDefault(String columnName);
 
     /**
+     * Puts the default value of this {@link ModelContainer} as data. It may be null for objects,
+     * or 0 for primitives.
+     *
+     * @param property The property to put.
+     */
+    void putDefault(IProperty property);
+
+    /**
      * @return The associated model adapter from the table for this {@link com.raizlabs.android.dbflow.structure.container.ModelContainer}
      */
     ModelAdapter<ModelClass> getModelAdapter();

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/database/AndroidDatabaseStatement.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/database/AndroidDatabaseStatement.java
@@ -23,6 +23,10 @@ public class AndroidDatabaseStatement implements DatabaseStatement {
         this.database = database;
     }
 
+    public SQLiteStatement getStatement() {
+        return statement;
+    }
+
     @Override
     public long executeUpdateDelete() {
         long count = 0;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/database/BaseDatabaseHelper.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/database/BaseDatabaseHelper.java
@@ -1,0 +1,215 @@
+package com.raizlabs.android.dbflow.structure.database;
+
+import android.database.sqlite.SQLiteException;
+
+import com.raizlabs.android.dbflow.config.BaseDatabaseDefinition;
+import com.raizlabs.android.dbflow.config.FlowLog;
+import com.raizlabs.android.dbflow.config.FlowManager;
+import com.raizlabs.android.dbflow.config.NaturalOrderComparator;
+import com.raizlabs.android.dbflow.runtime.TransactionManager;
+import com.raizlabs.android.dbflow.sql.QueryBuilder;
+import com.raizlabs.android.dbflow.sql.migration.Migration;
+import com.raizlabs.android.dbflow.structure.ModelAdapter;
+import com.raizlabs.android.dbflow.structure.ModelViewAdapter;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Description:
+ */
+public class BaseDatabaseHelper {
+
+    /**
+     * Location where the migration files should exist.
+     */
+    public static final String MIGRATION_PATH = "migrations";
+    private final BaseDatabaseDefinition databaseDefinition;
+
+    public BaseDatabaseHelper(BaseDatabaseDefinition databaseDefinition) {
+        this.databaseDefinition = databaseDefinition;
+    }
+
+    public BaseDatabaseDefinition getDatabaseDefinition() {
+        return databaseDefinition;
+    }
+
+    public void onCreate(DatabaseWrapper db) {
+        checkForeignKeySupport(db);
+        executeCreations(db);
+        executeMigrations(db, -1, db.getVersion());
+    }
+
+    public void onUpgrade(DatabaseWrapper db, int oldVersion, int newVersion) {
+        checkForeignKeySupport(db);
+        executeCreations(db);
+        executeMigrations(db, oldVersion, newVersion);
+    }
+
+    public void onOpen(DatabaseWrapper db) {
+        checkForeignKeySupport(db);
+    }
+
+    /**
+     * If foreign keys are supported, we turn it on the DB.
+     *
+     * @param database
+     */
+    protected void checkForeignKeySupport(DatabaseWrapper database) {
+        if (databaseDefinition.isForeignKeysSupported()) {
+            database.execSQL("PRAGMA foreign_keys=ON;");
+            FlowLog.log(FlowLog.Level.I, "Foreign Keys supported. Enabling foreign key features.");
+        }
+    }
+
+    /**
+     * This generates the SQLite commands to create the DB
+     *
+     * @param database
+     */
+    protected void executeCreations(final DatabaseWrapper database) {
+
+        TransactionManager.transact(database, new Runnable() {
+            @Override
+            public void run() {
+
+                List<ModelAdapter> modelAdapters = databaseDefinition.getModelAdapters();
+                for (ModelAdapter modelAdapter : modelAdapters) {
+                    database.execSQL(modelAdapter.getCreationQuery());
+                }
+
+                // create our model views
+                List<ModelViewAdapter> modelViews = databaseDefinition.getModelViewAdapters();
+                for (ModelViewAdapter modelView : modelViews) {
+                    QueryBuilder queryBuilder = new QueryBuilder()
+                            .append("CREATE VIEW")
+                            .appendSpaceSeparated(modelView.getViewName())
+                            .append("AS ")
+                            .append(modelView.getCreationQuery());
+                    try {
+                        database.execSQL(queryBuilder.getQuery());
+                    } catch (SQLiteException e) {
+                        FlowLog.logError(e);
+                    }
+                }
+            }
+        });
+    }
+
+    protected void executeMigrations(final DatabaseWrapper db, final int oldVersion, final int newVersion) {
+
+        // will try migrations file or execute migrations from code
+        try {
+            final List<String> files = Arrays.asList(FlowManager.getContext().getAssets().list(
+                    MIGRATION_PATH + "/" + databaseDefinition.getDatabaseName()));
+            Collections.sort(files, new NaturalOrderComparator());
+
+            final Map<Integer, List<String>> migrationFileMap = new HashMap<>();
+            for (String file : files) {
+                try {
+                    final Integer version = Integer.valueOf(file.replace(".sql", ""));
+                    List<String> fileList = migrationFileMap.get(version);
+                    if (fileList == null) {
+                        fileList = new ArrayList<>();
+                        migrationFileMap.put(version, fileList);
+                    }
+                    fileList.add(file);
+                } catch (NumberFormatException e) {
+                    FlowLog.log(FlowLog.Level.W, "Skipping invalidly named file: " + file, e);
+                }
+            }
+
+            final Map<Integer, List<Migration>> migrationMap = databaseDefinition.getMigrations();
+
+            final int curVersion = oldVersion + 1;
+
+            TransactionManager.transact(db, new Runnable() {
+                @Override
+                public void run() {
+
+                    // execute migrations in order, migration file first before wrapped migration classes.
+                    for (int i = curVersion; i <= newVersion; i++) {
+                        List<String> migrationFiles = migrationFileMap.get(i);
+                        if (migrationFiles != null) {
+                            for (String migrationFile : migrationFiles) {
+                                executeSqlScript(db, migrationFile);
+                                FlowLog.log(FlowLog.Level.I, migrationFile + " executed successfully.");
+                            }
+                        }
+
+                        if (migrationMap != null) {
+                            List<Migration> migrationsList = migrationMap.get(i);
+                            if (migrationsList != null) {
+                                for (Migration migration : migrationsList) {
+                                    // before migration
+                                    migration.onPreMigrate();
+
+                                    // migrate
+                                    migration.migrate(db);
+
+                                    // after migration cleanup
+                                    migration.onPostMigrate();
+                                    FlowLog.log(FlowLog.Level.I, migration.getClass() + " executed successfully.");
+                                }
+                            }
+                        }
+                    }
+                }
+            });
+        } catch (IOException e) {
+            FlowLog.log(FlowLog.Level.E, "Failed to execute migrations.", e);
+        }
+
+    }
+
+    /**
+     * Supports multiline sql statements with ended with the standard ";"
+     *
+     * @param db   The database to run it on
+     * @param file the file name in assets/migrations that we read from
+     */
+    private void executeSqlScript(DatabaseWrapper db, String file) {
+        try {
+            final InputStream input = FlowManager.getContext().getAssets().open(MIGRATION_PATH + "/" + getDatabaseDefinition().getDatabaseName() + "/" + file);
+            final BufferedReader reader = new BufferedReader(new InputStreamReader(input));
+            String line;
+
+            // ends line with SQL
+            String querySuffix = ";";
+
+            // standard java comments
+            String queryCommentPrefix = "\\";
+            StringBuffer query = new StringBuffer();
+
+            while ((line = reader.readLine()) != null) {
+                line = line.trim();
+                boolean isEndOfQuery = line.endsWith(querySuffix);
+                if (line.startsWith(queryCommentPrefix)) {
+                    continue;
+                }
+                if (isEndOfQuery) {
+                    line = line.substring(0, line.length() - querySuffix.length());
+                }
+                query.append(" ").append(line);
+                if (isEndOfQuery) {
+                    db.execSQL(query.toString());
+                    query = new StringBuffer();
+                }
+            }
+
+            if (query.length() > 0) {
+                db.execSQL(query.toString());
+            }
+        } catch (IOException e) {
+            FlowLog.log(FlowLog.Level.E, "Failed to execute " + file, e);
+        }
+    }
+}

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/database/DatabaseHelperDelegate.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/database/DatabaseHelperDelegate.java
@@ -1,67 +1,47 @@
 package com.raizlabs.android.dbflow.structure.database;
 
 import android.content.Context;
-import android.database.sqlite.SQLiteException;
 import android.support.annotation.Nullable;
 
 import com.raizlabs.android.dbflow.DatabaseHelperListener;
 import com.raizlabs.android.dbflow.config.BaseDatabaseDefinition;
 import com.raizlabs.android.dbflow.config.FlowLog;
 import com.raizlabs.android.dbflow.config.FlowManager;
-import com.raizlabs.android.dbflow.config.NaturalOrderComparator;
 import com.raizlabs.android.dbflow.runtime.DBTransactionInfo;
 import com.raizlabs.android.dbflow.runtime.TransactionManager;
 import com.raizlabs.android.dbflow.runtime.transaction.BaseTransaction;
-import com.raizlabs.android.dbflow.sql.QueryBuilder;
-import com.raizlabs.android.dbflow.sql.migration.Migration;
-import com.raizlabs.android.dbflow.structure.ModelAdapter;
-import com.raizlabs.android.dbflow.structure.ModelViewAdapter;
 
-import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.OutputStream;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
 /**
  * Description: An abstraction from {@link FlowSQLiteOpenHelper} where this can be used in other helper class definitions.
  */
-public class DatabaseHelperDelegate {
+public class DatabaseHelperDelegate extends BaseDatabaseHelper {
 
     public static final String TEMP_DB_NAME = "temp-";
-
-    /**
-     * Location where the migration files should exist.
-     */
-    public static final String MIGRATION_PATH = "migrations";
 
     public static String getTempDbFileName(BaseDatabaseDefinition databaseDefinition) {
         return TEMP_DB_NAME + databaseDefinition.getDatabaseName() + ".db";
     }
 
     private DatabaseHelperListener databaseHelperListener;
-    private BaseDatabaseDefinition databaseDefinition;
 
     @Nullable private final OpenHelper backupHelper;
 
     public DatabaseHelperDelegate(DatabaseHelperListener databaseHelperListener,
                                   BaseDatabaseDefinition databaseDefinition, @Nullable OpenHelper backupHelper) {
+        super(databaseDefinition);
         this.databaseHelperListener = databaseHelperListener;
-        this.databaseDefinition = databaseDefinition;
         this.backupHelper = backupHelper;
-        movePrepackagedDB(this.databaseDefinition.getDatabaseFileName(), this.databaseDefinition.getDatabaseFileName());
+        movePrepackagedDB(getDatabaseDefinition().getDatabaseFileName(), getDatabaseDefinition().getDatabaseFileName());
 
         if (databaseDefinition.backupEnabled()) {
-            restoreDatabase(getTempDbFileName(), this.databaseDefinition.getDatabaseFileName());
+            restoreDatabase(getTempDbFileName(), getDatabaseDefinition().getDatabaseFileName());
             if (backupHelper == null) {
                 throw new IllegalStateException("the passed backup helper was null, even though backup is enabled. " +
                         "Ensure that its passed in.");
@@ -74,39 +54,35 @@ public class DatabaseHelperDelegate {
         this.databaseHelperListener = databaseHelperListener;
     }
 
+    @Override
     public void onCreate(DatabaseWrapper db) {
         if (databaseHelperListener != null) {
             databaseHelperListener.onCreate(db);
         }
-
-        checkForeignKeySupport(db);
-        executeCreations(db);
-        executeMigrations(db, -1, db.getVersion());
+        super.onCreate(db);
     }
 
+    @Override
     public void onUpgrade(DatabaseWrapper db, int oldVersion, int newVersion) {
         if (databaseHelperListener != null) {
             databaseHelperListener.onUpgrade(db, oldVersion, newVersion);
         }
-
-        checkForeignKeySupport(db);
-        executeCreations(db);
-        executeMigrations(db, oldVersion, newVersion);
+        super.onUpgrade(db, oldVersion, newVersion);
     }
 
+    @Override
     public void onOpen(DatabaseWrapper db) {
         if (databaseHelperListener != null) {
             databaseHelperListener.onOpen(db);
         }
-
-        checkForeignKeySupport(db);
+        super.onOpen(db);
     }
 
     /**
      * @return the temporary database file name for when we have backups enabled {@link BaseDatabaseDefinition#backupEnabled()}
      */
     private String getTempDbFileName() {
-        return getTempDbFileName(databaseDefinition);
+        return getTempDbFileName(getDatabaseDefinition());
     }
 
     /**
@@ -120,8 +96,8 @@ public class DatabaseHelperDelegate {
         final File dbPath = FlowManager.getContext().getDatabasePath(databaseName);
 
         // If the database already exists, and is ok return
-        if (dbPath.exists() && (!databaseDefinition.areConsistencyChecksEnabled() ||
-                (databaseDefinition.areConsistencyChecksEnabled() && isDatabaseIntegrityOk()))) {
+        if (dbPath.exists() && (!getDatabaseDefinition().areConsistencyChecksEnabled() ||
+                (getDatabaseDefinition().areConsistencyChecksEnabled() && isDatabaseIntegrityOk()))) {
             return;
         }
 
@@ -134,7 +110,7 @@ public class DatabaseHelperDelegate {
             File existingDb = FlowManager.getContext().getDatabasePath(getTempDbFileName());
             InputStream inputStream;
             // if it exists and the integrity is ok we use backup as the main DB is no longer valid
-            if (existingDb.exists() && (!databaseDefinition.backupEnabled() || databaseDefinition.backupEnabled()
+            if (existingDb.exists() && (!getDatabaseDefinition().backupEnabled() || getDatabaseDefinition().backupEnabled()
                     && FlowManager.isDatabaseIntegrityOk(backupHelper))) {
                 inputStream = new FileInputStream(existingDb);
             } else {
@@ -163,11 +139,11 @@ public class DatabaseHelperDelegate {
             String rslt = prog.simpleQueryForString();
             if (!rslt.equalsIgnoreCase("ok")) {
                 // integrity_checker failed on main or attached databases
-                FlowLog.log(FlowLog.Level.E, "PRAGMA integrity_check on " + databaseDefinition.getDatabaseName() + " returned: " + rslt);
+                FlowLog.log(FlowLog.Level.E, "PRAGMA integrity_check on " + getDatabaseDefinition().getDatabaseName() + " returned: " + rslt);
 
                 integrityOk = false;
 
-                if (databaseDefinition.backupEnabled()) {
+                if (getDatabaseDefinition().backupEnabled()) {
                     integrityOk = restoreBackUp();
                 }
             }
@@ -186,8 +162,8 @@ public class DatabaseHelperDelegate {
     public boolean restoreBackUp() {
         boolean success = true;
 
-        File db = FlowManager.getContext().getDatabasePath(TEMP_DB_NAME + databaseDefinition.getDatabaseName());
-        File corrupt = FlowManager.getContext().getDatabasePath(databaseDefinition.getDatabaseName());
+        File db = FlowManager.getContext().getDatabasePath(TEMP_DB_NAME + getDatabaseDefinition().getDatabaseName());
+        File corrupt = FlowManager.getContext().getDatabasePath(getDatabaseDefinition().getDatabaseName());
         if (corrupt.delete()) {
             try {
                 writeDB(corrupt, new FileInputStream(db));
@@ -244,10 +220,10 @@ public class DatabaseHelperDelegate {
         // Try to copy database file
         try {
             // check existing and use that as backup
-            File existingDb = FlowManager.getContext().getDatabasePath(databaseDefinition.getDatabaseFileName());
+            File existingDb = FlowManager.getContext().getDatabasePath(getDatabaseDefinition().getDatabaseFileName());
             InputStream inputStream;
             // if it exists and the integrity is ok
-            if (existingDb.exists() && (databaseDefinition.backupEnabled() && FlowManager.isDatabaseIntegrityOk(
+            if (existingDb.exists() && (getDatabaseDefinition().backupEnabled() && FlowManager.isDatabaseIntegrityOk(
                     backupHelper))) {
                 inputStream = new FileInputStream(existingDb);
             } else {
@@ -259,168 +235,14 @@ public class DatabaseHelperDelegate {
         }
     }
 
-    /**
-     * If foreign keys are supported, we turn it on the DB.
-     *
-     * @param database
-     */
-    private void checkForeignKeySupport(DatabaseWrapper database) {
-        if (databaseDefinition.isForeignKeysSupported()) {
-            database.execSQL("PRAGMA foreign_keys=ON;");
-            FlowLog.log(FlowLog.Level.I, "Foreign Keys supported. Enabling foreign key features.");
-        }
-    }
-
-    /**
-     * This generates the SQLite commands to create the DB
-     *
-     * @param database
-     */
-    private void executeCreations(final DatabaseWrapper database) {
-
-        TransactionManager.transact(database, new Runnable() {
-            @Override
-            public void run() {
-
-                List<ModelAdapter> modelAdapters = databaseDefinition.getModelAdapters();
-                for (ModelAdapter modelAdapter : modelAdapters) {
-                    database.execSQL(modelAdapter.getCreationQuery());
-                }
-
-                // create our model views
-                List<ModelViewAdapter> modelViews = databaseDefinition.getModelViewAdapters();
-                for (ModelViewAdapter modelView : modelViews) {
-                    QueryBuilder queryBuilder = new QueryBuilder()
-                            .append("CREATE VIEW")
-                            .appendSpaceSeparated(modelView.getViewName())
-                            .append("AS ")
-                            .append(modelView.getCreationQuery());
-                    try {
-                        database.execSQL(queryBuilder.getQuery());
-                    } catch (SQLiteException e) {
-                        FlowLog.logError(e);
-                    }
-                }
-            }
-        });
-    }
-
-    private void executeMigrations(final DatabaseWrapper db, final int oldVersion, final int newVersion) {
-
-        // will try migrations file or execute migrations from code
-        try {
-            final List<String> files = Arrays.asList(FlowManager.getContext().getAssets().list(
-                    MIGRATION_PATH + "/" + databaseDefinition.getDatabaseName()));
-            Collections.sort(files, new NaturalOrderComparator());
-
-            final Map<Integer, List<String>> migrationFileMap = new HashMap<>();
-            for (String file : files) {
-                try {
-                    final Integer version = Integer.valueOf(file.replace(".sql", ""));
-                    List<String> fileList = migrationFileMap.get(version);
-                    if (fileList == null) {
-                        fileList = new ArrayList<>();
-                        migrationFileMap.put(version, fileList);
-                    }
-                    fileList.add(file);
-                } catch (NumberFormatException e) {
-                    FlowLog.log(FlowLog.Level.W, "Skipping invalidly named file: " + file, e);
-                }
-            }
-
-            final Map<Integer, List<Migration>> migrationMap = databaseDefinition.getMigrations();
-
-            final int curVersion = oldVersion + 1;
-
-            TransactionManager.transact(db, new Runnable() {
-                @Override
-                public void run() {
-
-                    // execute migrations in order, migration file first before wrapped migration classes.
-                    for (int i = curVersion; i <= newVersion; i++) {
-                        List<String> migrationFiles = migrationFileMap.get(i);
-                        if (migrationFiles != null) {
-                            for (String migrationFile : migrationFiles) {
-                                executeSqlScript(db, migrationFile);
-                                FlowLog.log(FlowLog.Level.I, migrationFile + " executed successfully.");
-                            }
-                        }
-
-                        if (migrationMap != null) {
-                            List<Migration> migrationsList = migrationMap.get(i);
-                            if (migrationsList != null) {
-                                for (Migration migration : migrationsList) {
-                                    // before migration
-                                    migration.onPreMigrate();
-
-                                    // migrate
-                                    migration.migrate(db);
-
-                                    // after migration cleanup
-                                    migration.onPostMigrate();
-                                    FlowLog.log(FlowLog.Level.I, migration.getClass() + " executed successfully.");
-                                }
-                            }
-                        }
-                    }
-                }
-            });
-        } catch (IOException e) {
-            FlowLog.log(FlowLog.Level.E, "Failed to execute migrations.", e);
-        }
-
-    }
-
-    /**
-     * Supports multiline sql statements with ended with the standard ";"
-     *
-     * @param db   The database to run it on
-     * @param file the file name in assets/migrations that we read from
-     */
-    private void executeSqlScript(DatabaseWrapper db, String file) {
-        try {
-            final InputStream input = FlowManager.getContext().getAssets().open(MIGRATION_PATH + "/" + databaseDefinition.getDatabaseName() + "/" + file);
-            final BufferedReader reader = new BufferedReader(new InputStreamReader(input));
-            String line;
-
-            // ends line with SQL
-            String querySuffix = ";";
-
-            // standard java comments
-            String queryCommentPrefix = "\\";
-            StringBuffer query = new StringBuffer();
-
-            while ((line = reader.readLine()) != null) {
-                line = line.trim();
-                boolean isEndOfQuery = line.endsWith(querySuffix);
-                if (line.startsWith(queryCommentPrefix)) {
-                    continue;
-                }
-                if (isEndOfQuery) {
-                    line = line.substring(0, line.length() - querySuffix.length());
-                }
-                query.append(" ").append(line);
-                if (isEndOfQuery) {
-                    db.execSQL(query.toString());
-                    query = new StringBuffer();
-                }
-            }
-
-            if (query.length() > 0) {
-                db.execSQL(query.toString());
-            }
-        } catch (IOException e) {
-            FlowLog.log(FlowLog.Level.E, "Failed to execute " + file, e);
-        }
-    }
 
     /**
      * Saves the database as a backup on the {@link com.raizlabs.android.dbflow.runtime.DBTransactionQueue} as
      * the highest priority ever. This will create a THIRD database to use as a backup to the backup in case somehow the overwrite fails.
      */
     public void backupDB() {
-        if (!databaseDefinition.backupEnabled() || !databaseDefinition.areConsistencyChecksEnabled()) {
-            throw new IllegalStateException("Backups are not enabled for : " + databaseDefinition.getDatabaseName() + ". Please consider adding " +
+        if (!getDatabaseDefinition().backupEnabled() || !getDatabaseDefinition().areConsistencyChecksEnabled()) {
+            throw new IllegalStateException("Backups are not enabled for : " + getDatabaseDefinition().getDatabaseName() + ". Please consider adding " +
                     "both backupEnabled and consistency checks enabled to the Database annotation");
         }
         // highest priority ever!
@@ -430,7 +252,7 @@ public class DatabaseHelperDelegate {
 
                 Context context = FlowManager.getContext();
                 File backup = context.getDatabasePath(getTempDbFileName());
-                File temp = context.getDatabasePath(TEMP_DB_NAME + "-2-" + databaseDefinition.getDatabaseFileName());
+                File temp = context.getDatabasePath(TEMP_DB_NAME + "-2-" + getDatabaseDefinition().getDatabaseFileName());
 
                 // if exists we want to delete it before rename
                 if (temp.exists()) {
@@ -441,7 +263,7 @@ public class DatabaseHelperDelegate {
                 if (backup.exists()) {
                     backup.delete();
                 }
-                File existing = context.getDatabasePath(databaseDefinition.getDatabaseFileName());
+                File existing = context.getDatabasePath(getDatabaseDefinition().getDatabaseFileName());
 
                 try {
                     backup.getParentFile().mkdirs();
@@ -459,6 +281,6 @@ public class DatabaseHelperDelegate {
     }
 
     public DatabaseWrapper getWritableDatabase() {
-        return databaseDefinition.getWritableDatabase();
+        return getDatabaseDefinition().getWritableDatabase();
     }
 }

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/provider/ContentUtils.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/provider/ContentUtils.java
@@ -34,7 +34,7 @@ public class ContentUtils {
      * @return A complete Uri for a {@link com.raizlabs.android.dbflow.annotation.provider.ContentProvider}
      */
     public static Uri buildUri(String authority, String... paths) {
-        return buildUri(BASE_CONTENT_URI, authority, paths);
+        return buildUriWithAuthority(BASE_CONTENT_URI, authority, paths);
     }
 
     /**
@@ -45,7 +45,7 @@ public class ContentUtils {
      * @param paths          The list of paths to append.
      * @return A complete Uri for a {@link com.raizlabs.android.dbflow.annotation.provider.ContentProvider}
      */
-    public static Uri buildUri(String baseContentUri, String authority, String... paths) {
+    public static Uri buildUriWithAuthority(String baseContentUri, String authority, String... paths) {
         Uri.Builder builder = Uri.parse(baseContentUri + authority).buildUpon();
         for (String path : paths) {
             builder.appendPath(path);

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/provider/ContentUtils.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/provider/ContentUtils.java
@@ -33,8 +33,8 @@ public class ContentUtils {
      * @param paths     The list of paths to append.
      * @return A complete Uri for a {@link com.raizlabs.android.dbflow.annotation.provider.ContentProvider}
      */
-    public static Uri buildUri(String authority, String... paths) {
-        return buildUriWithAuthority(BASE_CONTENT_URI, authority, paths);
+    public static Uri buildUriWithAuthority(String authority, String... paths) {
+        return buildUri(BASE_CONTENT_URI, authority, paths);
     }
 
     /**
@@ -45,7 +45,7 @@ public class ContentUtils {
      * @param paths          The list of paths to append.
      * @return A complete Uri for a {@link com.raizlabs.android.dbflow.annotation.provider.ContentProvider}
      */
-    public static Uri buildUriWithAuthority(String baseContentUri, String authority, String... paths) {
+    public static Uri buildUri(String baseContentUri, String authority, String... paths) {
         Uri.Builder builder = Uri.parse(baseContentUri + authority).buildUpon();
         for (String path : paths) {
             builder.appendPath(path);

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=3.0.0-beta2
+version=3.0.0-beta3
 version_code=1
 group=com.raizlabs.android
 

--- a/usage/DBStructure.md
+++ b/usage/DBStructure.md
@@ -216,3 +216,88 @@ public class UniqueModel extends BaseModel {
 
 }
 ```
+
+### Many-To-Many Source Gen
+
+Making an "association" table between two tables that are related via many-to-many
+has become drastically easier in DBFlow 3.0+.
+
+#### How It works
+
+1. Annotate your target `Model` class with `@ManyToMany(referencedTable = MyRefTable.class)`
+2. DBFlow generates the associated `@Table` class named `{target}{dbflow class separator}{referencedTable}`, with all of its other `_Adapter` and `_Table` counterparts. So for a target of `Shop` with a reference of `Customer`, by default the name of the `Table` generated is `Shop_Customer`.
+3. The generated `Model` uses the `@PrimaryKey` of each table as `@ForeignKey` fields along with a single auto-incrementing `Long` `@PrimaryKey`.
+3. It also generates getters and setters for the joined table (except a setter on the "_id" field).
+
+
+#### Example
+
+To define a relationship,
+simply define the `@ManyToMany` annotation on a class pointing to another `Model` table:
+```java@Table(database = TestDatabase.class)
+@ManyToMany(referencedTable = TestModel1.class)
+public class ManyToManyModel extends BaseModel {
+
+    @PrimaryKey
+    String name;
+
+    @PrimaryKey
+    int id;
+
+    @Column
+    char anotherColumn;
+}
+```
+
+With the associated table as follows:
+```java
+
+@Table(database = TestDatabase.class)
+public class TestModel1 extends BaseModel {
+    @Column
+    @PrimaryKey
+    String name;
+}
+
+```
+
+Which generates a `Model` class as:
+```java
+@Table(
+    database = TestDatabase.class
+)
+public final class ManyToManyModel_TestModel1 extends BaseModel {
+  @PrimaryKey(
+      autoincrement = true
+  )
+  long _id;
+
+  @ForeignKey
+  TestModel1 testModel1;
+
+  @ForeignKey
+  ManyToManyModel manyToManyModel;
+
+  public final long getId() {
+    return _id;
+  }
+
+  public final TestModel1 getTestModel1() {
+    return testModel1;
+  }
+
+  public final void setTestModel1(TestModel1 param) {
+    testModel1 = param;
+  }
+
+  public final ManyToManyModel getManyToManyModel() {
+    return manyToManyModel;
+  }
+
+  public final void setManyToManyModel(ManyToManyModel param) {
+    manyToManyModel = param;
+  }
+}
+```
+
+Which saves you even more code to maintain or write!

--- a/usage/DBStructure.md
+++ b/usage/DBStructure.md
@@ -54,21 +54,21 @@ be `public`, and point the `sqlHelperClass()` to the custom class in the `@Datab
 All standard tables must use the `@Table` annotation and implement `Model`. As a convenience, `BaseModel` provides a default implementation.
 
 **Models Support**:
-1. Any default java class is supported such as the primitives, boxed primitives, and `String`.
-2. A non-default object with a `TypeConverter` is also save-able. Objects with type-parameters are _not_ supported. Also `List`, `Map` or multi-value fields are not recommended. If you must, you have to leave out the type parameters.
-3. Composite primary keys
-4. Nested `Model` defined as a `@ForeignKey`, enabling 1-1 relationships.
-5. Any `ModelContainer` as a `@ForeignKey`
-6. Composite `@ForeignKey`
-7. Custom `TypeConverter` via `@Column(typeConverter = SomeTypeConverter.class)`
+  1. Any default java class is supported such as the primitives, boxed primitives, and `String`.
+  2. A non-default object with a `TypeConverter` is also save-able. Objects with type-parameters are _not_ supported. Also `List`, `Map` or multi-value fields are not recommended. If you must, you have to leave out the type parameters.
+  3. Composite primary keys
+  4. Nested `Model` defined as a `@ForeignKey`, enabling 1-1 relationships.
+  5. Any `ModelContainer` as a `@ForeignKey`
+  6. Composite `@ForeignKey`
+  7. Custom `TypeConverter` via `@Column(typeConverter = SomeTypeConverter.class)`
 
 **Restrictions & Limitations**:
-1. All `Model` **MUST HAVE** an accessible default constructor. We will use the default constructor when querying the database.
-2. Subclassing works as one would expect: the library gathers all inherited fields annotated with `@Column` and count those as rows in the current class's database.
-3. Column names default to the field name as a convenience, but if the name of your fields change you will need to specify the column name.
-4. All fields must be `public` or package private as the `_Adapter` class needs access to them. _NOTE:_ Package private fields need _not_ be in the same package as DBFlow will generate the necessary access methods to get to them.
-5. or private ONLY when you specify `get{Name}()` and `set{Name}(columnType)` methods for a column named `{name}`. This can be configured.
-6. All model class definitions have to be accessible. Inner model classes are supported as of 3.0.0-beta1+.
+  1. All `Model` **MUST HAVE** an accessible default constructor. We will use the default constructor when querying the database.
+  2. Subclassing works as one would expect: the library gathers all inherited fields annotated with `@Column` and count those as rows in the current class's database.
+  3. Column names default to the field name as a convenience, but if the name of your fields change you will need to specify the column name.
+  4. All fields must be `public` or package private as the `_Adapter` class needs access to them. _NOTE:_ Package private fields need _not_ be in the same package as DBFlow will generate the necessary access methods to get to them.
+  5. or private ONLY when you specify `get{Name}()` and `set{Name}(columnType)` methods for a column named `{name}`. This can be configured.
+  6. All model class definitions have to be accessible. Inner model classes are supported as of 3.0.0-beta1+.
 
 ### Sample Model
 This is an example of a `Model` class with a primary key (at least one is required) and another field.
@@ -180,10 +180,10 @@ In the `_Adapter`:
 ```
 
 We insert its value at runtime. This has some limitations:
-1. Constant, pure value strings
-2. No `Model`, `ModelContainer`, or primitive can use this.
-3. Must be of same type as column.
-4. `String` types need to be escaped via: `"\"something\""`
+  1. Constant, pure value strings
+  2. No `Model`, `ModelContainer`, or primitive can use this.
+  3. Must be of same type as column.
+  4. `String` types need to be escaped via: `"\"something\""`
 
 ### Unique Groups
 In Sqlite you can define any number of columns as having a "unique" relationship, meaning the combination of one or more rows must be unique across the whole table.

--- a/usage/DBStructure.md
+++ b/usage/DBStructure.md
@@ -54,21 +54,21 @@ be `public`, and point the `sqlHelperClass()` to the custom class in the `@Datab
 All standard tables must use the `@Table` annotation and implement `Model`. As a convenience, `BaseModel` provides a default implementation.
 
 **Models Support**:
-  1. Any default java class is supported such as the primitives, boxed primitives, and `String`.
-  2. A non-default object with a `TypeConverter` is also save-able. Objects with type-parameters are _not_ supported. Also `List`, `Map` or multi-value fields are not recommended. If you must, you have to leave out the type parameters.
-  3. Composite primary keys
-  4. Nested `Model` defined as a `@ForeignKey`, enabling 1-1 relationships.
-  5. Any `ModelContainer` as a `@ForeignKey`
-  6. Composite `@ForeignKey`
-  7. Custom `TypeConverter` via `@Column(typeConverter = SomeTypeConverter.class)`
+1. Any default java class is supported such as the primitives, boxed primitives, and `String`.
+2. A non-default object with a `TypeConverter` is also save-able. Objects with type-parameters are _not_ supported. Also `List`, `Map` or multi-value fields are not recommended. If you must, you have to leave out the type parameters.
+3. Composite primary keys
+4. Nested `Model` defined as a `@ForeignKey`, enabling 1-1 relationships.
+5. Any `ModelContainer` as a `@ForeignKey`
+6. Composite `@ForeignKey`
+7. Custom `TypeConverter` via `@Column(typeConverter = SomeTypeConverter.class)`
 
 **Restrictions & Limitations**:
-  1. All `Model` **MUST HAVE** an accessible default constructor. We will use the default constructor when querying the database.
-  2. Subclassing works as one would expect: the library gathers all inherited fields annotated with `@Column` and count those as rows in the current class's database.
-  3. Column names default to the field name as a convenience, but if the name of your fields change you will need to specify the column name.
-  4. All fields must be `public` or package private as the `_Adapter` class needs access to them. _NOTE:_ Package private fields need _not_ be in the same package as DBFlow will generate the necessary access methods to get to them.
-  5. or private ONLY when you specify `get{Name}()` and `set{Name}(columnType)` methods for a column named `{name}`. This can be configured.
-  6. All model class definitions have to be accessible. Inner model classes are supported as of 3.0.0-beta1+.
+1. All `Model` **MUST HAVE** an accessible default constructor. We will use the default constructor when querying the database.
+2. Subclassing works as one would expect: the library gathers all inherited fields annotated with `@Column` and count those as rows in the current class's database.
+3. Column names default to the field name as a convenience, but if the name of your fields change you will need to specify the column name.
+4. All fields must be `public` or package private as the `_Adapter` class needs access to them. _NOTE:_ Package private fields need _not_ be in the same package as DBFlow will generate the necessary access methods to get to them.
+5. or private ONLY when you specify `get{Name}()` and `set{Name}(columnType)` methods for a column named `{name}`. This can be configured.
+6. All model class definitions have to be accessible. Inner model classes are supported as of 3.0.0-beta1+.
 
 ### Sample Model
 This is an example of a `Model` class with a primary key (at least one is required) and another field.
@@ -149,6 +149,41 @@ public class PrivateModelTest extends BaseModel {
     //... etc
 }
 ```
+
+### Default values
+When a value of a field is missing or left out, you wish to provide a default "fallback" in the database. SQLite provides this as the `DEFAULT` command in a creation statement.
+
+However in DBFlow it is not so easy to respect this since we rely on precompiled `INSERT` statements with all primary keys in it. So as a compromise, these values are inserted as such:
+
+```java
+@Table(database = TestDatabase.class)
+public class DefaultModel extends TestModel1 {
+
+    @Column(defaultValue = "55")
+    Integer count;
+
+}
+```
+
+In the `_Adapter`:
+
+```java
+@Override
+  public final void bindToInsertValues(ContentValues values, DefaultModel model) {
+    if (model.count != null) {
+      values.put("`count`", model.count);
+    } else {
+      values.put("`count`", 55);
+    }
+    //...
+  }
+```
+
+We insert its value at runtime. This has some limitations:
+1. Constant, pure value strings
+2. No `Model`, `ModelContainer`, or primitive can use this.
+3. Must be of same type as column.
+4. `String` types need to be escaped via: `"\"something\""`
 
 ### Unique Groups
 In Sqlite you can define any number of columns as having a "unique" relationship, meaning the combination of one or more rows must be unique across the whole table.

--- a/usage/DBStructure.md
+++ b/usage/DBStructure.md
@@ -234,7 +234,8 @@ has become drastically easier in DBFlow 3.0+.
 
 To define a relationship,
 simply define the `@ManyToMany` annotation on a class pointing to another `Model` table:
-```java@Table(database = TestDatabase.class)
+```java
+@Table(database = TestDatabase.class)
 @ManyToMany(referencedTable = TestModel1.class)
 public class ManyToManyModel extends BaseModel {
 


### PR DESCRIPTION
1. Fixes issue where `ForeignKeyContainer` were actually loading their counterpart `Model` and then converting into `toModelContainer()`, which eliminated any performance gains from them.
2. Can manually pass in `DatabaseWrapper` to any query statement, this becomes extremely useful in `Migration` classes when recursive calls to `getWritableDatabase()` throws an exception.
3. `@Table(allFields = true)` now includes private fields. If you wish to ignore those, add `@ColumnIgnore` to your table.
4. Error messaging for private fields without proper getters and setters.
5. Fix a few bugs where `@PrimaryKey` and `@ForeignKey` are `Model` or `ModelContainer` objects.
6. added a `@ManyToMany` annotation to facilitate super-easy code-gen of association tables.
7. Default values of columns are respected for non-primitive, non-model types by insertion directly into their `ModelAdapter` methods when saving to the DB.
8. Many bug fixes and improvements
9. `@TableEndpoint` now looks for `contentProvider()` class instead of String name. Just point it to your class.
10. Added unsafe query checking in `ContentProvider`, since new safe checking is very limited.
11. Fixed issue where `InsertConflict` was ignored in `SQLiteStatement` for inserting.