### PR TITLE
Fix bug in ForeignKeyColumnDefinition

### DIFF
--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/column/ForeignKeyColumnDefinition.java
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/column/ForeignKeyColumnDefinition.java
@@ -412,7 +412,9 @@ public class ForeignKeyColumnDefinition extends ColumnDefinition {
 
     @Override
     public void appendPropertyComparisonAccessStatement(boolean isModelContainerAdapter, CodeBlock.Builder codeBuilder) {
-        if (!(columnAccess instanceof TypeConverterAccess)) {
+        if (nonModelColumn || columnAccess instanceof TypeConverterAccess) {
+            super.appendPropertyComparisonAccessStatement(isModelContainerAdapter, codeBuilder);
+        } else {
             String origStatement = getColumnAccessString(isModelContainerAdapter, false);
             if (isPrimaryKey) {
                 TableDefinition referenced = manager.getTableDefinition(tableDefinition.databaseDefinition.elementTypeName,
@@ -447,8 +449,6 @@ public class ForeignKeyColumnDefinition extends ColumnDefinition {
                 codeBuilder.add(elseBuilder.build());
                 codeBuilder.endControlFlow();
             }
-        } else {
-            super.appendPropertyComparisonAccessStatement(isModelContainerAdapter, codeBuilder);
         }
     }
 


### PR DESCRIPTION
If I had a `ForeignKey` defined like this:

    @ForeignKey(
      references = @ForeignKeyReference(columnName = "id", foreignColumnName = "foreignId", columnType = long.class),
      tableClass = ForignTable.class
    )
    long id;

I got the following error:

      if (containerid != null) {
                      ^
    first type:  long
    second type: <null>

Fix is to check `nonModelColumn` in `appendPropertyComparisonAccessStatement`.