### PR TITLE
Set saveForeignKeyModel = false for the generated ManyToMany table foreign keys.

### DIFF
--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/ManyToManyDefinition.java
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/ManyToManyDefinition.java
@@ -83,7 +83,8 @@ public class ManyToManyDefinition extends BaseDefinition {
         String fieldName = StringUtils.lower(referencedDefinition.elementName);
 
         FieldSpec.Builder fieldBuilder = FieldSpec.builder(referencedDefinition.elementClassName, fieldName)
-                .addAnnotation(AnnotationSpec.builder(ForeignKey.class).build());
+                .addAnnotation(AnnotationSpec.builder(ForeignKey.class)
+                                             .addMember("saveForeignKeyModel", "false").build());
         if (!generateAutoIncrement) {
             fieldBuilder.addAnnotation(AnnotationSpec.builder(PrimaryKey.class).build());
         }


### PR DESCRIPTION
The reason I set this flag to false is because I've overridden the `ModelA#save()` to persist all association objects and without this flag I get a circular dependency.