### PR TITLE
Throw exception if trying to create a Many to Many relationship for the same model class

### DIFF
--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/BaseDefinition.java
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/BaseDefinition.java
@@ -103,6 +103,9 @@ public abstract class BaseDefinition implements TypeDefinition {
         } else {
             outputName = elementClassName.simpleName();
         }
+        if(postfix.contains(outputName)) {
+            throw new UnsupportedOperationException("Many to many relationship for the same model type not supported");
+        }
         outputClassName = ClassName.get(packageName, outputName + postfix);
     }
 

--- a/usage/DatabaseModules.md
+++ b/usage/DatabaseModules.md
@@ -5,7 +5,7 @@ However, there are scenarios where an application has a library or subproject th
 
 To get around this problem, you must enable database module support for the module intended to be loaded by an application. Fortunately, this is a very easy process.
 
-To add databases to a module, first update your `build.gradle` of the library to define a custom `apt` argument that will place the `GeneratedDatabaseHolder` class-like definition in a different class file (in same package) so that the classes will not get duplicated.
+To add databases to a module, first update your `build.gradle` of the library to define a custom `apt` argument that will place the `GeneratedDatabaseHolder` class-like definition in a different class file (in same package) so that the classes will not get duplicated.  After you have called "apply plugin: 'com.neenbedankt.android-apt'" but before your depencies, add this:
 
 ```groovy
 apt {


### PR DESCRIPTION
Merged master -> develop (Surprisingly master was ahead)

#651 For now, in case of implementation mentioned in this issue, the DBFlow ends up generating code if there is a many to many relationship in the same model class. Because of this, setters and getters are created in the generated code twice with same names leading to compilation errors.

Until this is implemented, DBFlow could at least throw an UnsupportedOperationException. This pull request addresses the same.