### PR TITLE
Model Savers

### DIFF
--- a/dbflow-tests/src/test/java/com/raizlabs/android/dbflow/test/sql/FixPrimaryKeyMigrationTest.java
+++ b/dbflow-tests/src/test/java/com/raizlabs/android/dbflow/test/sql/FixPrimaryKeyMigrationTest.java
@@ -43,7 +43,7 @@ public class FixPrimaryKeyMigrationTest extends FlowTestCase {
 
     @Test
     public void test_validateTempCreationQuery() {
-        assertEquals("CREATE TABLE IF NOT EXISTS `Gl≠obalModel_temp`(`id` INTEGER,`name` TEXT, PRIMARY KEY(`id`)" + ");", fixPrimaryKeyMigration.getTempCreationQuery());
+        assertEquals("CREATE TABLE IF NOT EXISTS `GlobalModel_temp`(`id` INTEGER,`name` TEXT, PRIMARY KEY(`id`)" + ");", fixPrimaryKeyMigration.getTempCreationQuery());
     }
 
     @Test

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/SqlUtils.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/SqlUtils.java
@@ -87,13 +87,13 @@ public class SqlUtils {
      */
     @Deprecated
     public static <CacheableClass extends Model> List<CacheableClass> convertToCacheableList(
-            Class<CacheableClass> modelClass, Cursor cursor, ModelCache<CacheableClass, ?> modelCache) {
+        Class<CacheableClass> modelClass, Cursor cursor, ModelCache<CacheableClass, ?> modelCache) {
         final List<CacheableClass> entities = new ArrayList<>();
         ModelAdapter<CacheableClass> instanceAdapter = FlowManager.getModelAdapter(modelClass);
         if (instanceAdapter != null) {
             if (!instanceAdapter.cachingEnabled()) {
                 throw new IllegalArgumentException("You cannot call this method for a table that has no caching id. Either" +
-                        "use one Primary Key or call convertToList()");
+                    "use one Primary Key or call convertToList()");
             } else if (modelCache == null) {
                 throw new IllegalArgumentException("ModelCache specified in convertToCacheableList() must not be null.");
             }
@@ -131,7 +131,7 @@ public class SqlUtils {
      */
     @Deprecated
     public static <CacheableClass extends Model> List<CacheableClass> convertToCacheableList(
-            Class<CacheableClass> modelClass, Cursor cursor) {
+        Class<CacheableClass> modelClass, Cursor cursor) {
         return convertToCacheableList(modelClass, cursor, FlowManager.getModelAdapter(modelClass).getModelCache());
     }
 
@@ -235,7 +235,7 @@ public class SqlUtils {
     @SuppressWarnings("unchecked")
     @Deprecated
     public static <CacheableClass extends Model> CacheableClass convertToCacheableModel(
-            boolean dontMoveToFirst, Class<CacheableClass> table, Cursor cursor) {
+        boolean dontMoveToFirst, Class<CacheableClass> table, Cursor cursor) {
         CacheableClass model = null;
         if (dontMoveToFirst || cursor.moveToFirst()) {
             ModelAdapter<CacheableClass> modelAdapter = FlowManager.getModelAdapter(table);
@@ -243,7 +243,7 @@ public class SqlUtils {
             if (modelAdapter != null) {
                 ModelCache<CacheableClass, ?> modelCache = modelAdapter.getModelCache();
                 Object[] values = modelAdapter.getCachingColumnValuesFromCursor(
-                        new Object[modelAdapter.getCachingColumns().length], cursor);
+                    new Object[modelAdapter.getCachingColumns().length], cursor);
                 model = modelCache.get(modelAdapter.getCachingId(values));
                 if (model == null) {
                     model = modelAdapter.newInstance();
@@ -288,16 +288,7 @@ public class SqlUtils {
         return retModel;
     }
 
-    /**
-     * Checks whether the SQL query returns a {@link Cursor} with a count of at least 1. This
-     * means that the query was successful. It is commonly used when checking if a {@link Model} exists.
-     *
-     * @param table        The table to check
-     * @param sql          The SQL command to perform, must not be ; terminated.
-     * @param args         The optional string arguments when we use "?" in the sql
-     * @param <ModelClass> The class that implements {@link Model}
-     * @return
-     */
+    @Deprecated
     public static <ModelClass extends Model> boolean hasData(Class<ModelClass> table, String sql, String... args) {
         BaseDatabaseDefinition flowManager = FlowManager.getDatabaseForTable(table);
         Cursor cursor = flowManager.getWritableDatabase().rawQuery(sql, args);
@@ -350,10 +341,10 @@ public class SqlUtils {
         ContentValues contentValues = new ContentValues();
         adapter.bindToContentValues(contentValues, model);
         boolean successful = (SQLiteCompatibilityUtils.updateWithOnConflict(db, modelAdapter.getTableName(), contentValues,
-                adapter.getPrimaryConditionClause(model).getQuery(), null,
-                ConflictAction.getSQLiteDatabaseAlgorithmInt(
-                        modelAdapter.getUpdateOnConflictAction())) !=
-                0);
+            adapter.getPrimaryConditionClause(model).getQuery(), null,
+            ConflictAction.getSQLiteDatabaseAlgorithmInt(
+                modelAdapter.getUpdateOnConflictAction())) !=
+            0);
         if (successful) {
             notifyModelChanged(model, adapter, modelAdapter, Action.UPDATE);
         }
@@ -388,7 +379,7 @@ public class SqlUtils {
     public static <ModelClass extends Model, TableClass extends Model, AdapterClass extends RetrievalAdapter & InternalAdapter>
     void delete(final TableClass model, AdapterClass adapter, ModelAdapter<ModelClass> modelAdapter) {
         SQLite.delete((Class<TableClass>) adapter.getModelClass()).where(
-                adapter.getPrimaryConditionClause(model)).execute();
+            adapter.getPrimaryConditionClause(model)).execute();
         notifyModelChanged(model, adapter, modelAdapter, Action.DELETE);
         adapter.updateAutoIncrement(model, 0);
     }
@@ -420,7 +411,7 @@ public class SqlUtils {
     void notifyModelChanged(TableClass model, AdapterClass adapter, ModelAdapter<ModelClass> modelAdapter, Action action) {
         if (FlowContentObserver.shouldNotify()) {
             notifyModelChanged(modelAdapter.getModelClass(), action,
-                    adapter.getPrimaryConditionClause(model).getConditions());
+                adapter.getPrimaryConditionClause(model).getConditions());
         }
     }
 
@@ -434,7 +425,7 @@ public class SqlUtils {
      */
     public static Uri getNotificationUri(Class<? extends Model> modelClass, Action action, Iterable<SQLCondition> conditions) {
         Uri.Builder uriBuilder = new Uri.Builder().scheme("dbflow")
-                .authority(FlowManager.getTableName(modelClass));
+            .authority(FlowManager.getTableName(modelClass));
         if (action != null) {
             uriBuilder.fragment(action.name());
         }
@@ -457,7 +448,7 @@ public class SqlUtils {
      */
     public static Uri getNotificationUri(Class<? extends Model> modelClass, Action action, SQLCondition[] conditions) {
         Uri.Builder uriBuilder = new Uri.Builder().scheme("dbflow")
-                .authority(FlowManager.getTableName(modelClass));
+            .authority(FlowManager.getTableName(modelClass));
         if (action != null) {
             uriBuilder.fragment(action.name());
         }
@@ -508,7 +499,7 @@ public class SqlUtils {
      */
     public static <ModelClass extends Model> void dropTrigger(Class<ModelClass> mOnTable, String triggerName) {
         QueryBuilder queryBuilder = new QueryBuilder("DROP TRIGGER IF EXISTS ")
-                .append(triggerName);
+            .append(triggerName);
         FlowManager.getDatabaseForTable(mOnTable).getWritableDatabase().execSQL(queryBuilder.getQuery());
     }
 
@@ -521,7 +512,7 @@ public class SqlUtils {
      */
     public static <ModelClass extends Model> void dropIndex(Class<ModelClass> mOnTable, String indexName) {
         QueryBuilder queryBuilder = new QueryBuilder("DROP INDEX IF EXISTS ")
-                .append(QueryBuilder.quoteIfNeeded(indexName));
+            .append(QueryBuilder.quoteIfNeeded(indexName));
         FlowManager.getDatabaseForTable(mOnTable).getWritableDatabase().execSQL(queryBuilder.getQuery());
     }
 

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/SqlUtils.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/SqlUtils.java
@@ -313,6 +313,7 @@ public class SqlUtils {
      * @param modelAdapter The {@link ModelAdapter} to use
      */
     @SuppressWarnings("unchecked")
+    @Deprecated
     public static <ModelClass extends Model, TableClass extends Model, AdapterClass extends RetrievalAdapter & InternalAdapter>
     void save(TableClass model, AdapterClass adapter, ModelAdapter<ModelClass> modelAdapter) {
         if (model == null) {
@@ -341,6 +342,7 @@ public class SqlUtils {
      * @param modelAdapter The adapter to use
      * @return true if model updated successfully, false if not.
      */
+    @Deprecated
     @SuppressWarnings("unchecked")
     public static <ModelClass extends Model, TableClass extends Model, AdapterClass extends RetrievalAdapter & InternalAdapter>
     boolean update(TableClass model, AdapterClass adapter, ModelAdapter<ModelClass> modelAdapter) {
@@ -364,6 +366,7 @@ public class SqlUtils {
      * @param model        The model to insert.
      * @param modelAdapter The adapter to use.
      */
+    @Deprecated
     @SuppressWarnings("unchecked")
     public static <ModelClass extends Model, TableClass extends Model, AdapterClass extends RetrievalAdapter & InternalAdapter>
     void insert(TableClass model, AdapterClass adapter, ModelAdapter<ModelClass> modelAdapter) {
@@ -380,6 +383,7 @@ public class SqlUtils {
      *
      * @param model The model to delete
      */
+    @Deprecated
     @SuppressWarnings("unchecked")
     public static <ModelClass extends Model, TableClass extends Model, AdapterClass extends RetrievalAdapter & InternalAdapter>
     void delete(final TableClass model, AdapterClass adapter, ModelAdapter<ModelClass> modelAdapter) {
@@ -412,7 +416,7 @@ public class SqlUtils {
      * @param <AdapterClass> The class of the adapter, which is either a {@link ModelAdapter} or {@link ModelContainerAdapter}
      */
     @SuppressWarnings("unchecked")
-    private static <ModelClass extends Model, TableClass extends Model, AdapterClass extends RetrievalAdapter & InternalAdapter>
+    public static <ModelClass extends Model, TableClass extends Model, AdapterClass extends RetrievalAdapter & InternalAdapter>
     void notifyModelChanged(TableClass model, AdapterClass adapter, ModelAdapter<ModelClass> modelAdapter, Action action) {
         if (FlowContentObserver.shouldNotify()) {
             notifyModelChanged(modelAdapter.getModelClass(), action,

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/BaseModelQueriable.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/BaseModelQueriable.java
@@ -7,6 +7,7 @@ import com.raizlabs.android.dbflow.list.FlowCursorList;
 import com.raizlabs.android.dbflow.list.FlowQueryList;
 import com.raizlabs.android.dbflow.runtime.TransactionManager;
 import com.raizlabs.android.dbflow.sql.Query;
+import com.raizlabs.android.dbflow.sql.SqlUtils;
 import com.raizlabs.android.dbflow.sql.queriable.AsyncQuery;
 import com.raizlabs.android.dbflow.sql.queriable.ModelQueriable;
 import com.raizlabs.android.dbflow.structure.BaseQueryModel;
@@ -85,5 +86,4 @@ public abstract class BaseModelQueriable<ModelClass extends Model> extends BaseQ
     public <QueryClass extends BaseQueryModel> QueryClass queryCustomSingle(Class<QueryClass> queryModelClass) {
         return FlowManager.getQueryModelAdapter(queryModelClass).getSingleModelLoader().load(getQuery());
     }
-
 }

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/BaseQueriable.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/BaseQueriable.java
@@ -43,6 +43,16 @@ public abstract class BaseQueriable<ModelClass extends Model> implements Queriab
     }
 
     @Override
+    public boolean hasData() {
+        return count() > 0;
+    }
+
+    @Override
+    public boolean hasData(DatabaseWrapper databaseWrapper) {
+        return count(databaseWrapper) > 0;
+    }
+
+    @Override
     public Cursor query() {
         query(FlowManager.getDatabaseForTable(table).getWritableDatabase());
         return null;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/Where.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/Where.java
@@ -206,11 +206,6 @@ public class Where<ModelClass extends Model> extends BaseModelQueriable<ModelCla
     }
 
     @Override
-    public long count() {
-        return count(FlowManager.getDatabaseForTable(getTable()).getWritableDatabase());
-    }
-
-    @Override
     public String getQuery() {
         String fromQuery = whereBase.getQuery().trim();
         QueryBuilder queryBuilder = new QueryBuilder().append(fromQuery).appendSpace()
@@ -281,13 +276,4 @@ public class Where<ModelClass extends Model> extends BaseModelQueriable<ModelCla
         return super.querySingle();
     }
 
-    /**
-     * Returns whether the DB {@link android.database.Cursor} returns with a count of at least 1
-     *
-     * @return if {@link android.database.Cursor}.count &lt; 0
-     */
-    public boolean hasData() {
-        checkSelect("query");
-        return SqlUtils.hasData(whereBase.getTable(), getQuery());
-    }
 }

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/queriable/ModelQueriable.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/queriable/ModelQueriable.java
@@ -9,7 +9,6 @@ import com.raizlabs.android.dbflow.sql.language.Where;
 import com.raizlabs.android.dbflow.structure.BaseQueryModel;
 import com.raizlabs.android.dbflow.structure.Model;
 import com.raizlabs.android.dbflow.structure.container.ModelContainer;
-import com.raizlabs.android.dbflow.structure.database.DatabaseStatement;
 import com.raizlabs.android.dbflow.structure.database.DatabaseWrapper;
 
 import java.util.List;
@@ -92,4 +91,5 @@ public interface ModelQueriable<ModelClass extends Model> extends Queriable {
      * @return A single model from the query.
      */
     <QueryClass extends BaseQueryModel> QueryClass queryCustomSingle(Class<QueryClass> queryModelClass);
+
 }

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/queriable/Queriable.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/queriable/Queriable.java
@@ -54,6 +54,18 @@ public interface Queriable {
     long count(DatabaseWrapper databaseWrapper);
 
     /**
+     * @return True if this query has data. It will run a {@link #count()} greater than 0.
+     */
+    boolean hasData();
+
+    /**
+     * Allows you to pass in a {@link DatabaseWrapper} manually.
+     *
+     * @return True if this query has data. It will run a {@link #count()} greater than 0.
+     */
+    boolean hasData(DatabaseWrapper databaseWrapper);
+
+    /**
      * Will not return a result, rather simply will execute a SQL statement. Use this for non-SELECT statements or when
      * you're not interested in the result.
      */

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/saveable/ModelSaver.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/saveable/ModelSaver.java
@@ -1,0 +1,85 @@
+package com.raizlabs.android.dbflow.sql.saveable;
+
+import android.content.ContentValues;
+
+import com.raizlabs.android.dbflow.SQLiteCompatibilityUtils;
+import com.raizlabs.android.dbflow.annotation.ConflictAction;
+import com.raizlabs.android.dbflow.config.FlowManager;
+import com.raizlabs.android.dbflow.sql.SqlUtils;
+import com.raizlabs.android.dbflow.sql.language.Delete;
+import com.raizlabs.android.dbflow.sql.language.SQLite;
+import com.raizlabs.android.dbflow.structure.BaseModel;
+import com.raizlabs.android.dbflow.structure.InternalAdapter;
+import com.raizlabs.android.dbflow.structure.Model;
+import com.raizlabs.android.dbflow.structure.ModelAdapter;
+import com.raizlabs.android.dbflow.structure.RetrievalAdapter;
+import com.raizlabs.android.dbflow.structure.database.DatabaseStatement;
+import com.raizlabs.android.dbflow.structure.database.DatabaseWrapper;
+
+/**
+ * Description: Defines how models get saved into the DB. It will bind values to {@link android.content.ContentValues} for
+ * an update, execute a {@link DatabaseStatement}, or delete an object via the {@link Delete} wrapper.
+ */
+public class ModelSaver<ModelClass extends Model, TableClass extends Model, AdapterClass extends RetrievalAdapter & InternalAdapter> {
+
+    private final ModelAdapter<ModelClass> modelAdapter;
+    private final AdapterClass adapter;
+
+    public ModelSaver(ModelAdapter<ModelClass> modelAdapter, AdapterClass adapter) {
+        this.modelAdapter = modelAdapter;
+        this.adapter = adapter;
+    }
+
+    @SuppressWarnings("unchecked")
+    public void save(TableClass model) {
+        if (model == null) {
+            throw new IllegalArgumentException("Model from " + modelAdapter.getModelClass() + " was null");
+        }
+
+        boolean exists = adapter.exists(model);
+
+        if (exists) {
+            exists = update(model);
+        }
+
+        if (!exists) {
+            insert(model);
+        }
+
+        SqlUtils.notifyModelChanged(model, adapter, modelAdapter, BaseModel.Action.SAVE);
+    }
+
+    @SuppressWarnings("unchecked")
+    public boolean update(TableClass model) {
+        DatabaseWrapper db = FlowManager.getDatabaseForTable(modelAdapter.getModelClass()).getWritableDatabase();
+        ContentValues contentValues = new ContentValues();
+        adapter.bindToContentValues(contentValues, model);
+        boolean successful = (SQLiteCompatibilityUtils.updateWithOnConflict(db, modelAdapter.getTableName(), contentValues,
+            adapter.getPrimaryConditionClause(model).getQuery(), null,
+            ConflictAction.getSQLiteDatabaseAlgorithmInt(
+                modelAdapter.getUpdateOnConflictAction())) !=
+            0);
+        if (successful) {
+            SqlUtils.notifyModelChanged(model, adapter, modelAdapter, BaseModel.Action.UPDATE);
+        }
+        return successful;
+    }
+
+    @SuppressWarnings("unchecked")
+    public long insert(TableClass model) {
+        DatabaseStatement insertStatement = modelAdapter.getInsertStatement();
+        adapter.bindToInsertStatement(insertStatement, model);
+        long id = insertStatement.executeInsert();
+        adapter.updateAutoIncrement(model, id);
+        SqlUtils.notifyModelChanged(model, adapter, modelAdapter, BaseModel.Action.INSERT);
+        return id;
+    }
+
+    @SuppressWarnings("unchecked")
+    public void delete(TableClass model) {
+        SQLite.delete((Class<TableClass>) adapter.getModelClass()).where(
+            adapter.getPrimaryConditionClause(model)).execute();
+        SqlUtils.notifyModelChanged(model, adapter, modelAdapter, BaseModel.Action.DELETE);
+        adapter.updateAutoIncrement(model, 0);
+    }
+}

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/ModelAdapter.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/ModelAdapter.java
@@ -28,6 +28,7 @@ public abstract class ModelAdapter<ModelClass extends Model> extends InstanceAda
     private DatabaseStatement compiledStatement;
     private String[] cachingColumns;
     private ModelCache<ModelClass, ?> modelCache;
+    private
 
     /**
      * @return The precompiled insert statement for this table model adapter

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/ModelAdapter.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/ModelAdapter.java
@@ -11,6 +11,7 @@ import com.raizlabs.android.dbflow.config.FlowManager;
 import com.raizlabs.android.dbflow.sql.SqlUtils;
 import com.raizlabs.android.dbflow.sql.language.property.BaseProperty;
 import com.raizlabs.android.dbflow.sql.language.property.IProperty;
+import com.raizlabs.android.dbflow.sql.saveable.ModelSaver;
 import com.raizlabs.android.dbflow.structure.cache.IMultiKeyCacheConverter;
 import com.raizlabs.android.dbflow.structure.cache.ModelCache;
 import com.raizlabs.android.dbflow.structure.cache.SimpleMapCache;
@@ -28,7 +29,7 @@ public abstract class ModelAdapter<ModelClass extends Model> extends InstanceAda
     private DatabaseStatement compiledStatement;
     private String[] cachingColumns;
     private ModelCache<ModelClass, ?> modelCache;
-    private
+    private ModelSaver<ModelClass, ModelClass, ModelAdapter<ModelClass>> modelSaver;
 
     /**
      * @return The precompiled insert statement for this table model adapter
@@ -91,7 +92,7 @@ public abstract class ModelAdapter<ModelClass extends Model> extends InstanceAda
      */
     @Override
     public void save(ModelClass model) {
-        SqlUtils.save(model, this, this);
+        getModelSaver().save(model);
     }
 
     /**
@@ -101,7 +102,7 @@ public abstract class ModelAdapter<ModelClass extends Model> extends InstanceAda
      */
     @Override
     public void insert(ModelClass model) {
-        SqlUtils.insert(model, this, this);
+        getModelSaver().insert(model);
     }
 
     /**
@@ -111,7 +112,7 @@ public abstract class ModelAdapter<ModelClass extends Model> extends InstanceAda
      */
     @Override
     public void update(ModelClass model) {
-        SqlUtils.update(model, this, this);
+        getModelSaver().update(model);
     }
 
     /**
@@ -121,7 +122,7 @@ public abstract class ModelAdapter<ModelClass extends Model> extends InstanceAda
      */
     @Override
     public void delete(ModelClass model) {
-        SqlUtils.delete(model, this, this);
+        getModelSaver().delete(model);
     }
 
 
@@ -227,6 +228,22 @@ public abstract class ModelAdapter<ModelClass extends Model> extends InstanceAda
 
     public Object getCachingId(@NonNull ModelClass model) {
         return getCachingId(getCachingColumnValuesFromModel(new Object[getCachingColumns().length], model));
+    }
+
+    public ModelSaver<ModelClass, ModelClass, ModelAdapter<ModelClass>> getModelSaver() {
+        if (modelSaver == null) {
+            modelSaver = new ModelSaver<>(this, this);
+        }
+        return modelSaver;
+    }
+
+    /**
+     * Sets how this {@link ModelAdapter} saves its objects.
+     *
+     * @param modelSaver The saver to use.
+     */
+    public void setModelSaver(ModelSaver<ModelClass, ModelClass, ModelAdapter<ModelClass>> modelSaver) {
+        this.modelSaver = modelSaver;
     }
 
     /**

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/container/ModelContainerAdapter.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/container/ModelContainerAdapter.java
@@ -6,6 +6,7 @@ import android.support.annotation.NonNull;
 import com.raizlabs.android.dbflow.annotation.PrimaryKey;
 import com.raizlabs.android.dbflow.sql.SqlUtils;
 import com.raizlabs.android.dbflow.sql.queriable.ModelContainerLoader;
+import com.raizlabs.android.dbflow.sql.saveable.ModelSaver;
 import com.raizlabs.android.dbflow.structure.InternalAdapter;
 import com.raizlabs.android.dbflow.structure.Model;
 import com.raizlabs.android.dbflow.structure.RetrievalAdapter;
@@ -21,6 +22,7 @@ import java.util.Map;
 public abstract class ModelContainerAdapter<ModelClass extends Model> extends RetrievalAdapter<ModelContainer<ModelClass, ?>, ModelClass> implements InternalAdapter<ModelClass, ModelContainer<ModelClass, ?>> {
 
     private ModelContainerLoader<ModelClass> modelContainerLoader;
+    private ModelSaver<ModelClass, ModelClass, ModelContainerAdapter<ModelClass>> modelSaver;
 
     protected final Map<String, Class> columnMap = new HashMap<>();
 
@@ -60,6 +62,22 @@ public abstract class ModelContainerAdapter<ModelClass extends Model> extends Re
     @Override
     public void delete(ModelContainer<ModelClass, ?> modelContainer) {
         SqlUtils.delete(modelContainer, this, modelContainer.getModelAdapter());
+    }
+
+    public ModelSaver<ModelClass, ModelClass, ModelContainerAdapter<ModelClass>> getModelSaver() {
+        if (modelSaver == null) {
+            modelSaver = new ModelSaver<>(this, );
+        }
+        return modelSaver;
+    }
+
+    /**
+     * Sets how this {@link ModelAdapter} saves its objects.
+     *
+     * @param modelSaver The saver to use.
+     */
+    public void setModelSaver(ModelSaver<ModelClass, ModelClass, ModelContainerAdapter<ModelClass>> modelSaver) {
+        this.modelSaver = modelSaver;
     }
 
     /**

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/container/ModelContainerAdapter.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/container/ModelContainerAdapter.java
@@ -72,7 +72,7 @@ public abstract class ModelContainerAdapter<ModelClass extends Model> extends Re
     }
 
     /**
-     * Sets how this {@link ModelContainerAdapterg} saves its objects.
+     * Sets how this {@link ModelContainerAdapter} saves its objects.
      *
      * @param modelSaver The saver to use.
      */

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/container/ModelContainerAdapter.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/container/ModelContainerAdapter.java
@@ -4,7 +4,7 @@ import android.database.Cursor;
 import android.support.annotation.NonNull;
 
 import com.raizlabs.android.dbflow.annotation.PrimaryKey;
-import com.raizlabs.android.dbflow.sql.SqlUtils;
+import com.raizlabs.android.dbflow.config.FlowManager;
 import com.raizlabs.android.dbflow.sql.queriable.ModelContainerLoader;
 import com.raizlabs.android.dbflow.sql.saveable.ModelSaver;
 import com.raizlabs.android.dbflow.structure.InternalAdapter;
@@ -22,7 +22,7 @@ import java.util.Map;
 public abstract class ModelContainerAdapter<ModelClass extends Model> extends RetrievalAdapter<ModelContainer<ModelClass, ?>, ModelClass> implements InternalAdapter<ModelClass, ModelContainer<ModelClass, ?>> {
 
     private ModelContainerLoader<ModelClass> modelContainerLoader;
-    private ModelSaver<ModelClass, ModelClass, ModelContainerAdapter<ModelClass>> modelSaver;
+    private ModelSaver<ModelClass, ModelContainer<ModelClass, ?>, ModelContainerAdapter<ModelClass>> modelSaver;
 
     protected final Map<String, Class> columnMap = new HashMap<>();
 
@@ -33,7 +33,7 @@ public abstract class ModelContainerAdapter<ModelClass extends Model> extends Re
      */
     @Override
     public void save(ModelContainer<ModelClass, ?> modelContainer) {
-        SqlUtils.save(modelContainer, this, modelContainer.getModelAdapter());
+        getModelSaver().save(modelContainer);
     }
 
     /**
@@ -42,7 +42,7 @@ public abstract class ModelContainerAdapter<ModelClass extends Model> extends Re
      * @param modelContainer The model container to insert.
      */
     public void insert(ModelContainer<ModelClass, ?> modelContainer) {
-        SqlUtils.insert(modelContainer, this, modelContainer.getModelAdapter());
+        getModelSaver().insert(modelContainer);
     }
 
     /**
@@ -51,7 +51,7 @@ public abstract class ModelContainerAdapter<ModelClass extends Model> extends Re
      * @param modelContainer The model to update.
      */
     public void update(ModelContainer<ModelClass, ?> modelContainer) {
-        SqlUtils.update(modelContainer, this, modelContainer.getModelAdapter());
+        getModelSaver().update(modelContainer);
     }
 
     /**
@@ -61,22 +61,22 @@ public abstract class ModelContainerAdapter<ModelClass extends Model> extends Re
      */
     @Override
     public void delete(ModelContainer<ModelClass, ?> modelContainer) {
-        SqlUtils.delete(modelContainer, this, modelContainer.getModelAdapter());
+        getModelSaver().delete(modelContainer);
     }
 
-    public ModelSaver<ModelClass, ModelClass, ModelContainerAdapter<ModelClass>> getModelSaver() {
+    public ModelSaver<ModelClass, ModelContainer<ModelClass, ?>, ModelContainerAdapter<ModelClass>> getModelSaver() {
         if (modelSaver == null) {
-            modelSaver = new ModelSaver<>(this, );
+            modelSaver = new ModelSaver<>(FlowManager.getModelAdapter(getModelClass()), this);
         }
         return modelSaver;
     }
 
     /**
-     * Sets how this {@link ModelAdapter} saves its objects.
+     * Sets how this {@link ModelContainerAdapterg} saves its objects.
      *
      * @param modelSaver The saver to use.
      */
-    public void setModelSaver(ModelSaver<ModelClass, ModelClass, ModelContainerAdapter<ModelClass>> modelSaver) {
+    public void setModelSaver(ModelSaver<ModelClass, ModelContainer<ModelClass, ?>, ModelContainerAdapter<ModelClass>> modelSaver) {
         this.modelSaver = modelSaver;
     }
 


### PR DESCRIPTION
1. Allow you to override and specify your own `ModekSaver` for a specific table, if you want more flexibility. 
2. `hasData()` now uses `count()` as its basis for returning number of results