### PR TITLE
Create a custom database migration method.

### DIFF
--- a/dbflow-core/src/main/java/com/raizlabs/android/dbflow/annotation/Database.java
+++ b/dbflow-core/src/main/java/com/raizlabs/android/dbflow/annotation/Database.java
@@ -76,4 +76,18 @@ public @interface Database {
      * "TestTable" becomes "TestTable$Table" for a "$" separator.
      */
     String generatedClassSeparator() default "_";
+
+    /**
+     * @return Return the Migration script separator. This can to do be able to create a script to make a trigger
+     * or other db elements that may contain the default ";" separator.
+     */
+    String migrationScriptSeparator() default ";";
+
+    /**
+     * @return If return true the model automatic creation after database opening will be skipped
+     */
+    boolean skipAutomaticModelCreation() default false;
+
+
+
 }

--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/method/DatabaseDefinition.java
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/method/DatabaseDefinition.java
@@ -57,6 +57,10 @@ public class DatabaseDefinition extends BaseDefinition implements TypeDefinition
 
     public boolean isInMemory;
 
+    public String migrationScriptSeparator;
+
+    public boolean skipAutomaticModelCreation;
+
     TypeName sqliteOpenHelperClass;
 
     public Map<TypeName, TableDefinition> tableDefinitionMap = new HashMap<>();
@@ -105,6 +109,9 @@ public class DatabaseDefinition extends BaseDefinition implements TypeDefinition
             insertConflict = database.insertConflict();
             updateConflict = database.updateConflict();
             isInMemory = database.inMemory();
+
+            migrationScriptSeparator = database.migrationScriptSeparator();
+            skipAutomaticModelCreation = database.skipAutomaticModelCreation();
         }
     }
 
@@ -232,6 +239,18 @@ public class DatabaseDefinition extends BaseDefinition implements TypeDefinition
             .addAnnotation(Override.class)
             .addModifiers(DatabaseHandler.METHOD_MODIFIERS)
             .addStatement("return $S", databaseName)
+            .returns(ClassName.get(String.class)).build());
+
+        typeBuilder.addMethod(MethodSpec.methodBuilder("skipAutomaticModelCreation")
+            .addAnnotation(Override.class)
+            .addModifiers(DatabaseHandler.METHOD_MODIFIERS)
+            .addStatement("return $L", skipAutomaticModelCreation)
+            .returns(TypeName.BOOLEAN).build());
+
+        typeBuilder.addMethod(MethodSpec.methodBuilder("migrationScriptSeparator")
+            .addAnnotation(Override.class)
+            .addModifiers(DatabaseHandler.METHOD_MODIFIERS)
+            .addStatement("return $S", migrationScriptSeparator)
             .returns(ClassName.get(String.class)).build());
     }
 

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/config/BaseDatabaseDefinition.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/config/BaseDatabaseDefinition.java
@@ -196,6 +196,16 @@ public abstract class BaseDatabaseDefinition {
     public abstract boolean isInMemory();
 
     /**
+     * @return Return the default migration script separator
+     */
+    public abstract String migrationScriptSeparator();
+
+    /**
+     * @return True if need to skip the default model creation
+     */
+    public abstract boolean skipAutomaticModelCreation();
+
+    /**
      * @return The version of the database currently.
      */
     public abstract int getDatabaseVersion();

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/database/BaseDatabaseHelper.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/database/BaseDatabaseHelper.java
@@ -2,6 +2,7 @@ package com.raizlabs.android.dbflow.structure.database;
 
 import android.database.sqlite.SQLiteException;
 
+import com.raizlabs.android.dbflow.annotation.Database;
 import com.raizlabs.android.dbflow.config.BaseDatabaseDefinition;
 import com.raizlabs.android.dbflow.config.FlowLog;
 import com.raizlabs.android.dbflow.config.FlowManager;
@@ -44,13 +45,15 @@ public class BaseDatabaseHelper {
 
     public void onCreate(DatabaseWrapper db) {
         checkForeignKeySupport(db);
-        executeCreations(db);
+        if (!databaseDefinition.skipAutomaticModelCreation())
+            executeCreations(db);
         executeMigrations(db, -1, db.getVersion());
     }
 
     public void onUpgrade(DatabaseWrapper db, int oldVersion, int newVersion) {
         checkForeignKeySupport(db);
-        executeCreations(db);
+        if (!databaseDefinition.skipAutomaticModelCreation())
+            executeCreations(db);
         executeMigrations(db, oldVersion, newVersion);
     }
 
@@ -183,7 +186,7 @@ public class BaseDatabaseHelper {
             String line;
 
             // ends line with SQL
-            String querySuffix = ";";
+            String querySuffix = databaseDefinition.migrationScriptSeparator();
 
             // standard java comments
             String queryCommentPrefix = "\\";


### PR DESCRIPTION
This can be useful to make a manual database migration with two new annotation.
skipAutomaticModelCreation (boolean) = Is to be handle manually the model migrations by regular SQL script in Assets folder.
migrationScriptSeparator (String) = Added a specific migration script separator to work with script that create a trigger into database.