### PR TITLE
Version 3.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Image](https://github.com/agrosner/DBFlow/blob/develop/dbflow_banner.png?raw=true)
 
-[![JitPack.io](https://img.shields.io/badge/JitPack.io-3.0.0-red.svg?style=flat)](https://jitpack.io/#Raizlabs/DBFlow) [![Android Weekly](http://img.shields.io/badge/Android%20Weekly-%23129-2CB3E5.svg?style=flat)](http://androidweekly.net/issues/issue-129) [![Android Arsenal](https://img.shields.io/badge/Android%20Arsenal-DBFlow-brightgreen.svg?style=flat)](https://android-arsenal.com/details/1/1134)
+[![JitPack.io](https://img.shields.io/badge/JitPack.io-3.0.1-red.svg?style=flat)](https://jitpack.io/#Raizlabs/DBFlow) [![Android Weekly](http://img.shields.io/badge/Android%20Weekly-%23129-2CB3E5.svg?style=flat)](http://androidweekly.net/issues/issue-129) [![Android Arsenal](https://img.shields.io/badge/Android%20Arsenal-DBFlow-brightgreen.svg?style=flat)](https://android-arsenal.com/details/1/1134)
 
 A robust, powerful, and very simple ORM android database library with **annotation processing**.
 
@@ -57,7 +57,7 @@ Add the library to the project-level build.gradle, using the apt plugin to enabl
 
   apply plugin: 'com.neenbedankt.android-apt'
 
-  def dbflow_version = "3.0.0"
+  def dbflow_version = "3.0.1"
   // or dbflow_version = "develop-SNAPSHOT" for grabbing latest dependency in your project on the develop branch
   // or 10-digit short-hash of a specific commit. (Useful for bugs fixed in develop, but not in a release yet)
 

--- a/dbflow-processor/build.gradle
+++ b/dbflow-processor/build.gradle
@@ -9,7 +9,7 @@ sourceCompatibility = JavaVersion.VERSION_1_7
 
 dependencies {
     compile project("${dbflow_project_prefix}dbflow-core")
-    compile 'com.squareup:javapoet:1.6.1'
+    compile 'com.squareup:javapoet:1.7.0'
     compile 'com.google.auto.service:auto-service:1.0-rc2'
 }
 

--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/ClassNames.java
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/ClassNames.java
@@ -28,6 +28,7 @@ public class ClassNames {
     public static final String TRANSACTION = RUNTIME + ".transaction";
     public static final String DATABASE_TRANSACTION = DATABASE + ".transaction";
     public static final String PROCESS = TRANSACTION + ".process";
+    public static final String SAVEABLE = SQL + ".saveable";
 
     public static final ClassName DATABASE_HOLDER = ClassName.get(CONFIG, "DatabaseHolder");
     public static final ClassName FLOW_MANAGER = ClassName.get(CONFIG, "FlowManager");
@@ -107,4 +108,6 @@ public class ClassNames {
     public static final ClassName SQLITE = ClassName.get(LANGUAGE, "SQLite");
 
     public static final ClassName UNSAFE_STRING_CONDITION = ClassName.get(LANGUAGE, "UnSafeStringCondition");
+
+    public static final ClassName CACHEABLE_LIST_MODEL_SAVER = ClassName.get(SAVEABLE, "CacheableListModelSaver");
 }

--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/OneToManyDefinition.java
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/OneToManyDefinition.java
@@ -3,17 +3,21 @@ package com.raizlabs.android.dbflow.processor.definition;
 import com.google.common.collect.Lists;
 import com.raizlabs.android.dbflow.annotation.OneToMany;
 import com.raizlabs.android.dbflow.processor.ClassNames;
+import com.raizlabs.android.dbflow.processor.ProcessorUtils;
 import com.raizlabs.android.dbflow.processor.definition.column.BaseColumnAccess;
 import com.raizlabs.android.dbflow.processor.definition.column.PrivateColumnAccess;
 import com.raizlabs.android.dbflow.processor.definition.column.SimpleColumnAccess;
 import com.raizlabs.android.dbflow.processor.model.ProcessorManager;
 import com.raizlabs.android.dbflow.processor.utils.ModelUtils;
 import com.squareup.javapoet.CodeBlock;
+import com.squareup.javapoet.ParameterizedTypeName;
+import com.squareup.javapoet.TypeName;
 
 import java.util.Arrays;
 import java.util.List;
 
 import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.type.TypeMirror;
 
 /**
  * Description: Represents the {@link OneToMany} annotation.
@@ -27,6 +31,7 @@ public class OneToManyDefinition extends BaseDefinition {
     public List<OneToMany.Method> methods = Lists.newArrayList();
 
     private BaseColumnAccess columnAccess;
+    private boolean extendsBaseModel;
 
     public OneToManyDefinition(ExecutableElement typeElement,
                                ProcessorManager processorManager) {
@@ -46,6 +51,18 @@ public class OneToManyDefinition extends BaseDefinition {
             columnAccess = new PrivateColumnAccess(false);
         } else {
             columnAccess = new SimpleColumnAccess();
+        }
+
+        extendsBaseModel = false;
+        TypeMirror returnType = typeElement.getReturnType();
+        TypeName typeName = TypeName.get(returnType);
+        if (typeName instanceof ParameterizedTypeName) {
+            List<TypeName> typeArguments = ((ParameterizedTypeName) typeName).typeArguments;
+            if (typeArguments.size() == 1) {
+                TypeName returnTypeName = typeArguments.get(0);
+                extendsBaseModel = ProcessorUtils.isSubclass(manager.getProcessingEnvironment(),
+                        ClassNames.BASE_MODEL.toString(), manager.getElements().getTypeElement(returnTypeName.toString()));
+            }
         }
     }
 
@@ -79,40 +96,40 @@ public class OneToManyDefinition extends BaseDefinition {
      *
      * @param codeBuilder
      */
-    public void writeDelete(CodeBlock.Builder codeBuilder) {
+    public void writeDelete(CodeBlock.Builder codeBuilder, boolean useWrapper) {
         if (isDelete()) {
-            writeLoopWithMethod(codeBuilder, "delete");
+            writeLoopWithMethod(codeBuilder, "delete", useWrapper && extendsBaseModel);
 
             codeBuilder.addStatement(columnAccess.setColumnAccessString(null, variableName, variableName,
-                false, ModelUtils.getVariable(false), CodeBlock.of("null"), false));
+                    false, ModelUtils.getVariable(false), CodeBlock.of("null"), false));
         }
     }
 
-    public void writeSave(CodeBlock.Builder codeBuilder) {
+    public void writeSave(CodeBlock.Builder codeBuilder, boolean useWrapper) {
         if (isSave()) {
-            writeLoopWithMethod(codeBuilder, "save");
+            writeLoopWithMethod(codeBuilder, "save", useWrapper && extendsBaseModel);
         }
     }
 
-    public void writeUpdate(CodeBlock.Builder codeBuilder) {
+    public void writeUpdate(CodeBlock.Builder codeBuilder, boolean useWrapper) {
         if (isSave()) {
-            writeLoopWithMethod(codeBuilder, "update");
+            writeLoopWithMethod(codeBuilder, "update", useWrapper && extendsBaseModel);
         }
     }
 
-    public void writeInsert(CodeBlock.Builder codeBuilder) {
+    public void writeInsert(CodeBlock.Builder codeBuilder, boolean useWrapper) {
         if (isSave()) {
-            writeLoopWithMethod(codeBuilder, "insert");
+            writeLoopWithMethod(codeBuilder, "insert", useWrapper && extendsBaseModel);
         }
     }
 
-    private void writeLoopWithMethod(CodeBlock.Builder codeBuilder, String methodName) {
+    private void writeLoopWithMethod(CodeBlock.Builder codeBuilder, String methodName, boolean useWrapper) {
         codeBuilder
-            .beginControlFlow("if ($L != null) ", getMethodName())
-            .beginControlFlow("for ($T value: $L) ", ClassNames.MODEL, getMethodName())
-            .addStatement("value.$L()", methodName)
-            .endControlFlow()
-            .endControlFlow();
+                .beginControlFlow("if ($L != null) ", getMethodName())
+                .beginControlFlow("for ($T value: $L) ", extendsBaseModel ? ClassNames.BASE_MODEL : ClassNames.MODEL, getMethodName())
+                .addStatement("value.$L($L)", methodName, useWrapper ? ModelUtils.getWrapper() : "")
+                .endControlFlow()
+                .endControlFlow();
     }
 
     private String getMethodName() {

--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/TableDefinition.java
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/TableDefinition.java
@@ -199,10 +199,14 @@ public class TableDefinition extends BaseTableDefinition {
                         new LoadFromCursorMethod(this, false, implementsLoadFromCursorListener, false),
                         new ExistenceMethod(this, false),
                         new PrimaryConditionMethod(this, false),
-                        new OneToManyDeleteMethod(this, false),
-                        new OneToManySaveMethod(this, false, OneToManySaveMethod.METHOD_SAVE),
-                        new OneToManySaveMethod(this, false, OneToManySaveMethod.METHOD_INSERT),
-                        new OneToManySaveMethod(this, false, OneToManySaveMethod.METHOD_UPDATE)
+                        new OneToManyDeleteMethod(this, false, false),
+                        new OneToManyDeleteMethod(this, false, true),
+                        new OneToManySaveMethod(this, false, OneToManySaveMethod.METHOD_SAVE, false),
+                        new OneToManySaveMethod(this, false, OneToManySaveMethod.METHOD_INSERT, false),
+                        new OneToManySaveMethod(this, false, OneToManySaveMethod.METHOD_UPDATE, false),
+                        new OneToManySaveMethod(this, false, OneToManySaveMethod.METHOD_SAVE, true),
+                        new OneToManySaveMethod(this, false, OneToManySaveMethod.METHOD_INSERT, true),
+                        new OneToManySaveMethod(this, false, OneToManySaveMethod.METHOD_UPDATE, true)
                 };
     }
 

--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/TableDefinition.java
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/TableDefinition.java
@@ -543,6 +543,14 @@ public class TableDefinition extends BaseTableDefinition {
                     .addStatement("return new $T<>(getModelClass())", ClassNames.CACHEABLE_LIST_MODEL_LOADER)
                     .returns(ClassNames.LIST_MODEL_LOADER).build());
 
+            typeBuilder.addMethod(MethodSpec.methodBuilder("createListModelSaver")
+                    .addAnnotation(Override.class)
+                    .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
+                    .addStatement("return new $T<>(getModelSaver())", ClassNames.CACHEABLE_LIST_MODEL_SAVER)
+                    .returns(ParameterizedTypeName.get(ClassNames.CACHEABLE_LIST_MODEL_SAVER,
+                            elementClassName,
+                            ParameterizedTypeName.get(ClassNames.MODEL_ADAPTER, elementTypeName))).build());
+
             typeBuilder.addMethod(MethodSpec.methodBuilder("cachingEnabled")
                     .addAnnotation(Override.class)
                     .addModifiers(Modifier.PUBLIC, Modifier.FINAL)

--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/utils/ModelUtils.java
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/utils/ModelUtils.java
@@ -48,4 +48,8 @@ public class ModelUtils {
         return ParameterizedTypeName.get(ClassNames.MODEL_CONTAINER,
                 modelType, TypeName.get(manager.getTypeUtils().getWildcardType(null, null)));
     }
+
+    public static String getWrapper() {
+        return "wrapper";
+    }
 }

--- a/dbflow-tests/src/test/java/com/raizlabs/android/dbflow/test/transaction/TrCacheableModel.java
+++ b/dbflow-tests/src/test/java/com/raizlabs/android/dbflow/test/transaction/TrCacheableModel.java
@@ -1,0 +1,12 @@
+package com.raizlabs.android.dbflow.test.transaction;
+
+import com.raizlabs.android.dbflow.annotation.Table;
+import com.raizlabs.android.dbflow.test.TestDatabase;
+import com.raizlabs.android.dbflow.test.structure.TestModel1;
+
+/**
+ * Description:
+ */
+@Table(database = TestDatabase.class, cachingEnabled = true)
+public class TrCacheableModel extends TestModel1 {
+}

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/saveable/CacheableListModelSaver.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/saveable/CacheableListModelSaver.java
@@ -1,0 +1,78 @@
+package com.raizlabs.android.dbflow.sql.saveable;
+
+import android.content.ContentValues;
+import android.support.annotation.NonNull;
+
+import com.raizlabs.android.dbflow.structure.InternalAdapter;
+import com.raizlabs.android.dbflow.structure.Model;
+import com.raizlabs.android.dbflow.structure.RetrievalAdapter;
+import com.raizlabs.android.dbflow.structure.container.ModelContainer;
+import com.raizlabs.android.dbflow.structure.database.DatabaseStatement;
+import com.raizlabs.android.dbflow.structure.database.DatabaseWrapper;
+
+import java.util.Collection;
+
+/**
+ * Description: Used for model caching, enables caching models when saving in list. Does not work with {@link ModelContainer}.
+ */
+public class CacheableListModelSaver<TModel extends Model, TAdapter extends RetrievalAdapter & InternalAdapter>
+        extends ListModelSaver<TModel, TModel, TAdapter> {
+
+    public CacheableListModelSaver(ModelSaver<TModel, TModel, TAdapter> modelSaver) {
+        super(modelSaver);
+    }
+
+    @Override
+    public synchronized void saveAll(@NonNull Collection<TModel> tableCollection, DatabaseWrapper wrapper) {
+        // skip if empty.
+        if (tableCollection.isEmpty()) {
+            return;
+        }
+
+        DatabaseStatement statement = getModelSaver().getModelAdapter().getInsertStatement(wrapper);
+        ContentValues contentValues = new ContentValues();
+        try {
+            for (TModel model : tableCollection) {
+                if (getModelSaver().save(model, wrapper, statement, contentValues)) {
+                    getModelSaver().getModelAdapter().storeModelInCache(model);
+                }
+            }
+        } finally {
+            statement.close();
+        }
+    }
+
+    @Override
+    public synchronized void insertAll(@NonNull Collection<TModel> tableCollection, DatabaseWrapper wrapper) {
+        // skip if empty.
+        if (tableCollection.isEmpty()) {
+            return;
+        }
+
+        DatabaseStatement statement = getModelSaver().getModelAdapter().getInsertStatement(wrapper);
+        try {
+            for (TModel model : tableCollection) {
+                if (getModelSaver().insert(model, statement) > 0) {
+                    getModelSaver().getModelAdapter().storeModelInCache(model);
+                }
+            }
+        } finally {
+            statement.close();
+        }
+    }
+
+    @Override
+    public synchronized void updateAll(@NonNull Collection<TModel> tableCollection, DatabaseWrapper wrapper) {
+        // skip if empty.
+        if (tableCollection.isEmpty()) {
+            return;
+        }
+
+        ContentValues contentValues = new ContentValues();
+        for (TModel model : tableCollection) {
+            if (getModelSaver().update(model, wrapper, contentValues)) {
+                getModelSaver().getModelAdapter().storeModelInCache(model);
+            }
+        }
+    }
+}

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/saveable/ListModelSaver.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/saveable/ListModelSaver.java
@@ -70,14 +70,18 @@ public class ListModelSaver<TModel extends Model, TTable extends Model,
     }
 
     public synchronized void updateAll(@NonNull Collection<TTable> tableCollection, DatabaseWrapper wrapper) {
-        // skip if empty.
-        if (tableCollection.isEmpty()) {
-            return;
-        }
+            // skip if empty.
+            if (tableCollection.isEmpty()) {
+                return;
+            }
 
-        ContentValues contentValues = new ContentValues();
-        for (TTable model : tableCollection) {
-            modelSaver.update(model, wrapper, contentValues);
-        }
+            ContentValues contentValues = new ContentValues();
+            for (TTable model : tableCollection) {
+                modelSaver.update(model, wrapper, contentValues);
+            }
+    }
+
+    public ModelSaver<TModel, TTable, TAdapter> getModelSaver() {
+        return modelSaver;
     }
 }

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/saveable/ListModelSaver.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/saveable/ListModelSaver.java
@@ -70,15 +70,15 @@ public class ListModelSaver<TModel extends Model, TTable extends Model,
     }
 
     public synchronized void updateAll(@NonNull Collection<TTable> tableCollection, DatabaseWrapper wrapper) {
-            // skip if empty.
-            if (tableCollection.isEmpty()) {
-                return;
-            }
+        // skip if empty.
+        if (tableCollection.isEmpty()) {
+            return;
+        }
 
-            ContentValues contentValues = new ContentValues();
-            for (TTable model : tableCollection) {
-                modelSaver.update(model, wrapper, contentValues);
-            }
+        ContentValues contentValues = new ContentValues();
+        for (TTable model : tableCollection) {
+            modelSaver.update(model, wrapper, contentValues);
+        }
     }
 
     public ModelSaver<TModel, TTable, TAdapter> getModelSaver() {

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/saveable/ModelSaver.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/saveable/ModelSaver.java
@@ -36,17 +36,17 @@ public class ModelSaver<TModel extends Model, TTable extends Model,
         this.adapter = adapter;
     }
 
-    public synchronized void save(@NonNull TTable model) {
-        save(model, getWritableDatabase(), modelAdapter.getInsertStatement(), new ContentValues());
+    public synchronized boolean save(@NonNull TTable model) {
+        return save(model, getWritableDatabase(), modelAdapter.getInsertStatement(), new ContentValues());
     }
 
-    public synchronized void save(@NonNull TTable model, DatabaseWrapper wrapper) {
-        save(model, getWritableDatabase(), modelAdapter.getInsertStatement(wrapper), new ContentValues());
+    public synchronized boolean save(@NonNull TTable model, DatabaseWrapper wrapper) {
+        return save(model, getWritableDatabase(), modelAdapter.getInsertStatement(wrapper), new ContentValues());
     }
 
     @SuppressWarnings("unchecked")
-    public synchronized void save(@NonNull TTable model, DatabaseWrapper wrapper,
-                                  DatabaseStatement insertStatement, ContentValues contentValues) {
+    public synchronized boolean save(@NonNull TTable model, DatabaseWrapper wrapper,
+                                     DatabaseStatement insertStatement, ContentValues contentValues) {
         boolean exists = adapter.exists(model, wrapper);
 
         if (exists) {
@@ -60,6 +60,9 @@ public class ModelSaver<TModel extends Model, TTable extends Model,
         if (exists) {
             SqlUtils.notifyModelChanged(model, adapter, modelAdapter, BaseModel.Action.SAVE);
         }
+
+        // return successful store into db.
+        return exists;
     }
 
     public synchronized boolean update(@NonNull TTable model) {

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/AsyncModel.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/AsyncModel.java
@@ -54,7 +54,7 @@ public class AsyncModel<TModel extends Model> extends BaseAsyncObject<AsyncModel
                     public void processModel(TModel model) {
                         model.save();
                     }
-                }).build());
+                }).add(model).build());
     }
 
     @Override
@@ -65,7 +65,7 @@ public class AsyncModel<TModel extends Model> extends BaseAsyncObject<AsyncModel
                     public void processModel(TModel model) {
                         model.delete();
                     }
-                }).build());
+                }).add(model).build());
     }
 
     @Override
@@ -76,7 +76,7 @@ public class AsyncModel<TModel extends Model> extends BaseAsyncObject<AsyncModel
                     public void processModel(TModel model) {
                         model.update();
                     }
-                }).build());
+                }).add(model).build());
     }
 
     @Override
@@ -87,7 +87,7 @@ public class AsyncModel<TModel extends Model> extends BaseAsyncObject<AsyncModel
                     public void processModel(TModel model) {
                         model.insert();
                     }
-                }).build());
+                }).add(model).build());
     }
 
     @Override

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/ModelAdapter.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/ModelAdapter.java
@@ -121,12 +121,6 @@ public abstract class ModelAdapter<TModel extends Model> extends InstanceAdapter
     @Override
     public void saveAll(Collection<TModel> models, DatabaseWrapper databaseWrapper) {
         getListModelSaver().saveAll(models, databaseWrapper);
-
-        if (cachingEnabled()) {
-            for (TModel model : models) {
-                getModelCache().addModel(getCachingId(model), model);
-            }
-        }
     }
 
     @Override
@@ -142,23 +136,11 @@ public abstract class ModelAdapter<TModel extends Model> extends InstanceAdapter
     @Override
     public void insertAll(Collection<TModel> models) {
         getListModelSaver().insertAll(models);
-
-        if (cachingEnabled()) {
-            for (TModel model : models) {
-                getModelCache().addModel(getCachingId(model), model);
-            }
-        }
     }
 
     @Override
     public void insertAll(Collection<TModel> models, DatabaseWrapper databaseWrapper) {
         getListModelSaver().insertAll(models, databaseWrapper);
-
-        if (cachingEnabled()) {
-            for (TModel model : models) {
-                getModelCache().addModel(getCachingId(model), model);
-            }
-        }
     }
 
     @Override
@@ -174,23 +156,11 @@ public abstract class ModelAdapter<TModel extends Model> extends InstanceAdapter
     @Override
     public void updateAll(Collection<TModel> models) {
         getListModelSaver().updateAll(models);
-
-        if (cachingEnabled()) {
-            for (TModel model : models) {
-                getModelCache().addModel(getCachingId(model), model);
-            }
-        }
     }
 
     @Override
     public void updateAll(Collection<TModel> models, DatabaseWrapper databaseWrapper) {
         getListModelSaver().updateAll(models, databaseWrapper);
-
-        if (cachingEnabled()) {
-            for (TModel model : models) {
-                getModelCache().addModel(getCachingId(model), model);
-            }
-        }
     }
 
     @Override

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/ModelAdapter.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/ModelAdapter.java
@@ -110,11 +110,23 @@ public abstract class ModelAdapter<TModel extends Model> extends InstanceAdapter
     @Override
     public void saveAll(Collection<TModel> models) {
         getListModelSaver().saveAll(models);
+
+        if (cachingEnabled()) {
+            for (TModel model : models) {
+                getModelCache().addModel(getCachingId(model), model);
+            }
+        }
     }
 
     @Override
     public void saveAll(Collection<TModel> models, DatabaseWrapper databaseWrapper) {
         getListModelSaver().saveAll(models, databaseWrapper);
+
+        if (cachingEnabled()) {
+            for (TModel model : models) {
+                getModelCache().addModel(getCachingId(model), model);
+            }
+        }
     }
 
     @Override
@@ -130,11 +142,23 @@ public abstract class ModelAdapter<TModel extends Model> extends InstanceAdapter
     @Override
     public void insertAll(Collection<TModel> models) {
         getListModelSaver().insertAll(models);
+
+        if (cachingEnabled()) {
+            for (TModel model : models) {
+                getModelCache().addModel(getCachingId(model), model);
+            }
+        }
     }
 
     @Override
     public void insertAll(Collection<TModel> models, DatabaseWrapper databaseWrapper) {
         getListModelSaver().insertAll(models, databaseWrapper);
+
+        if (cachingEnabled()) {
+            for (TModel model : models) {
+                getModelCache().addModel(getCachingId(model), model);
+            }
+        }
     }
 
     @Override
@@ -150,11 +174,23 @@ public abstract class ModelAdapter<TModel extends Model> extends InstanceAdapter
     @Override
     public void updateAll(Collection<TModel> models) {
         getListModelSaver().updateAll(models);
+
+        if (cachingEnabled()) {
+            for (TModel model : models) {
+                getModelCache().addModel(getCachingId(model), model);
+            }
+        }
     }
 
     @Override
     public void updateAll(Collection<TModel> models, DatabaseWrapper databaseWrapper) {
         getListModelSaver().updateAll(models, databaseWrapper);
+
+        if (cachingEnabled()) {
+            for (TModel model : models) {
+                getModelCache().addModel(getCachingId(model), model);
+            }
+        }
     }
 
     @Override

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/ModelAdapter.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/ModelAdapter.java
@@ -238,7 +238,7 @@ public abstract class ModelAdapter<TModel extends Model> extends InstanceAdapter
      */
     public String getAutoIncrementingColumnName() {
         throw new InvalidDBConfiguration(
-                String.format("This method may have been called in error. The model class %1s must contain" +
+                String.format("This method may have been called in error. The model class %1s must contain " +
                                 "an autoincrementing or single int/long primary key (if used in a ModelCache, this method may be called)",
                         getModelClass()));
     }

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/ModelAdapter.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/ModelAdapter.java
@@ -287,6 +287,10 @@ public abstract class ModelAdapter<TModel extends Model> extends InstanceAdapter
         return null;
     }
 
+    public void storeModelInCache(@NonNull TModel model) {
+        getModelCache().addModel(getCachingId(model), model);
+    }
+
     public ModelCache<TModel, ?> getModelCache() {
         if (modelCache == null) {
             modelCache = createModelCache();
@@ -318,9 +322,13 @@ public abstract class ModelAdapter<TModel extends Model> extends InstanceAdapter
 
     public ListModelSaver<TModel, TModel, ModelAdapter<TModel>> getListModelSaver() {
         if (listModelSaver == null) {
-            listModelSaver = new ListModelSaver<>(getModelSaver());
+            listModelSaver = createListModelSaver();
         }
         return listModelSaver;
+    }
+
+    protected ListModelSaver<TModel, TModel, ModelAdapter<TModel>> createListModelSaver() {
+        return new ListModelSaver<>(getModelSaver());
     }
 
     /**

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=3.0.0
+version=3.0.1
 version_code=1
 group=com.raizlabs.android
 


### PR DESCRIPTION
1. Fixes issue where `AsyncModel` operations did not actually operate on its associated `Model`.
2. Fix code gen for overridden Update, Insert, delete ops where passing in `DatabaseWrapper` did not honor `@OneToMany` annotation.
3. Fix issue where `ListModelSaver` ignores caching rules. 