### PR TITLE
Add the ability to correctly process output of other APT tools

### DIFF
--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/model/ProcessorManager.java
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/model/ProcessorManager.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import javax.annotation.processing.FilerException;
 import javax.annotation.processing.Messager;
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.annotation.processing.RoundEnvironment;
@@ -324,9 +325,12 @@ public class ProcessorManager implements Handler {
 
                 databaseDefinition.getDatabaseDefinition().validateAndPrepareToWrite();
 
-                JavaFile.builder(databaseDefinition.getDatabaseDefinition().packageName,
-                        databaseDefinition.getDatabaseDefinition().getTypeSpec())
-                        .build().writeTo(processorManager.getProcessingEnvironment().getFiler());
+                if (roundEnvironment.processingOver())
+                {
+                    JavaFile.builder(databaseDefinition.getDatabaseDefinition().packageName,
+                                     databaseDefinition.getDatabaseDefinition().getTypeSpec())
+                            .build().writeTo(processorManager.getProcessingEnvironment().getFiler());
+                }
 
 
                 Collection<TableDefinition> tableDefinitions = databaseDefinition.tableDefinitionMap.values();
@@ -337,7 +341,11 @@ public class ProcessorManager implements Handler {
 
                 tableDefinitions = databaseDefinition.tableDefinitionMap.values();
                 for (TableDefinition tableDefinition : tableDefinitions) {
-                    tableDefinition.writeAdapter(processorManager.getProcessingEnvironment());
+                    try
+                    {
+                        tableDefinition.writeAdapter(processorManager.getProcessingEnvironment());
+                    }
+                    catch (FilerException e) { /*Ignored intentionally to allow multi-round table generation*/ }
                     if (tableDefinition.modelContainerDefinition != null) {
                         WriterUtils.writeBaseDefinition(tableDefinition.modelContainerDefinition, processorManager);
                     }
@@ -347,25 +355,45 @@ public class ProcessorManager implements Handler {
                 Collections.sort(modelViewDefinitions);
                 for (ModelViewDefinition modelViewDefinition : modelViewDefinitions) {
                     WriterUtils.writeBaseDefinition(modelViewDefinition, processorManager);
-                    modelViewDefinition.writeViewTable();
+                    try
+                    {
+                        modelViewDefinition.writeViewTable();
+                    }
+                    catch (FilerException e) { /*Ignored intentionally to allow multi-round table generation*/ }
                 }
 
                 Collection<QueryModelDefinition> queryModelDefinitions = databaseDefinition.queryModelDefinitionMap.values();
                 for (QueryModelDefinition queryModelDefinition : queryModelDefinitions) {
                     WriterUtils.writeBaseDefinition(queryModelDefinition, processorManager);
-                    queryModelDefinition.writeAdapter(processorManager.getProcessingEnvironment());
+                    try
+                    {
+                        queryModelDefinition.writeAdapter(processorManager.getProcessingEnvironment());
+                    }
+                    catch (FilerException e) { /*Ignored intentionally to allow multi-round table generation*/ }
                 }
 
                 for (TableDefinition tableDefinition : tableDefinitions) {
-                    tableDefinition.writePackageHelper(processorManager.getProcessingEnvironment());
+                    try
+                    {
+                        tableDefinition.writePackageHelper(processorManager.getProcessingEnvironment());
+                    }
+                    catch (FilerException e) { /*Ignored intentionally to allow multi-round table generation*/ }
                 }
 
                 for (ModelViewDefinition modelViewDefinition : modelViewDefinitions) {
-                    modelViewDefinition.writePackageHelper(processorManager.getProcessingEnvironment());
+                    try
+                    {
+                        modelViewDefinition.writePackageHelper(processorManager.getProcessingEnvironment());
+                    }
+                    catch (FilerException e) { /*Ignored intentionally to allow multi-round table generation*/ }
                 }
 
                 for (QueryModelDefinition queryModelDefinition : queryModelDefinitions) {
-                    queryModelDefinition.writePackageHelper(processorManager.getProcessingEnvironment());
+                    try
+                    {
+                        queryModelDefinition.writePackageHelper(processorManager.getProcessingEnvironment());
+                    }
+                    catch (FilerException e) { /*Ignored intentionally to allow multi-round table generation*/ }
                 }
             } catch (IOException e) {
             }

--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/model/ProcessorManager.java
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/model/ProcessorManager.java
@@ -399,11 +399,18 @@ public class ProcessorManager implements Handler {
             }
         }
 
-        try {
-            JavaFile.builder(ClassNames.FLOW_MANAGER_PACKAGE,
-                    new FlowManagerHolderDefinition(processorManager).getTypeSpec())
-                    .build().writeTo(processorManager.getProcessingEnvironment().getFiler());
-        } catch (IOException e) {
+        if (roundEnvironment.processingOver())
+        {
+            try
+            {
+                JavaFile.builder(ClassNames.FLOW_MANAGER_PACKAGE,
+                                 new FlowManagerHolderDefinition(processorManager).getTypeSpec())
+                        .build().writeTo(processorManager.getProcessingEnvironment().getFiler());
+            }
+            catch (IOException e)
+            {
+                logError(e.getMessage());
+            }
         }
     }
 }

--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/model/ProcessorManager.java
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/model/ProcessorManager.java
@@ -325,8 +325,7 @@ public class ProcessorManager implements Handler {
 
                 databaseDefinition.getDatabaseDefinition().validateAndPrepareToWrite();
 
-                if (roundEnvironment.processingOver())
-                {
+                if (roundEnvironment.processingOver()) {
                     JavaFile.builder(databaseDefinition.getDatabaseDefinition().packageName,
                                      databaseDefinition.getDatabaseDefinition().getTypeSpec())
                             .build().writeTo(processorManager.getProcessingEnvironment().getFiler());
@@ -341,8 +340,7 @@ public class ProcessorManager implements Handler {
 
                 tableDefinitions = databaseDefinition.tableDefinitionMap.values();
                 for (TableDefinition tableDefinition : tableDefinitions) {
-                    try
-                    {
+                    try {
                         tableDefinition.writeAdapter(processorManager.getProcessingEnvironment());
                     }
                     catch (FilerException e) { /*Ignored intentionally to allow multi-round table generation*/ }
@@ -355,8 +353,7 @@ public class ProcessorManager implements Handler {
                 Collections.sort(modelViewDefinitions);
                 for (ModelViewDefinition modelViewDefinition : modelViewDefinitions) {
                     WriterUtils.writeBaseDefinition(modelViewDefinition, processorManager);
-                    try
-                    {
+                    try {
                         modelViewDefinition.writeViewTable();
                     }
                     catch (FilerException e) { /*Ignored intentionally to allow multi-round table generation*/ }
@@ -365,32 +362,28 @@ public class ProcessorManager implements Handler {
                 Collection<QueryModelDefinition> queryModelDefinitions = databaseDefinition.queryModelDefinitionMap.values();
                 for (QueryModelDefinition queryModelDefinition : queryModelDefinitions) {
                     WriterUtils.writeBaseDefinition(queryModelDefinition, processorManager);
-                    try
-                    {
+                    try {
                         queryModelDefinition.writeAdapter(processorManager.getProcessingEnvironment());
                     }
                     catch (FilerException e) { /*Ignored intentionally to allow multi-round table generation*/ }
                 }
 
                 for (TableDefinition tableDefinition : tableDefinitions) {
-                    try
-                    {
+                    try {
                         tableDefinition.writePackageHelper(processorManager.getProcessingEnvironment());
                     }
                     catch (FilerException e) { /*Ignored intentionally to allow multi-round table generation*/ }
                 }
 
                 for (ModelViewDefinition modelViewDefinition : modelViewDefinitions) {
-                    try
-                    {
+                    try {
                         modelViewDefinition.writePackageHelper(processorManager.getProcessingEnvironment());
                     }
                     catch (FilerException e) { /*Ignored intentionally to allow multi-round table generation*/ }
                 }
 
                 for (QueryModelDefinition queryModelDefinition : queryModelDefinitions) {
-                    try
-                    {
+                    try {
                         queryModelDefinition.writePackageHelper(processorManager.getProcessingEnvironment());
                     }
                     catch (FilerException e) { /*Ignored intentionally to allow multi-round table generation*/ }
@@ -399,16 +392,13 @@ public class ProcessorManager implements Handler {
             }
         }
 
-        if (roundEnvironment.processingOver())
-        {
-            try
-            {
+        if (roundEnvironment.processingOver()) {
+            try {
                 JavaFile.builder(ClassNames.FLOW_MANAGER_PACKAGE,
                                  new FlowManagerHolderDefinition(processorManager).getTypeSpec())
                         .build().writeTo(processorManager.getProcessingEnvironment().getFiler());
             }
-            catch (IOException e)
-            {
+            catch (IOException e) {
                 logError(e.getMessage());
             }
         }


### PR DESCRIPTION
I've spent the last day writing a separate APT tool that generates multiple DBFlow tables based on an annotated interface. Once I was able to get a compiling output I discovered that the DBFlow processor was not generating the adapter or table classes for my generated `@Table` classes.

This commit causes the processor to defer the databaseDefinition until the last processing round and ignores Filer exceptions that interrupt the code flow causing the new files to not be written. Ultimately the exceptions were being caught and ignored anyway.