### PR TITLE
FlowCursorList + FlowQueryList Revamp/Enhancement

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.0'
+        classpath 'com.android.tools.build:gradle:2.1.2'
         classpath 'com.neenbedankt.gradle.plugins:android-apt:1.8'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.3'
     }

--- a/dbflow-tests/src/test/java/com/raizlabs/android/dbflow/test/list/FlowCursorListTest.java
+++ b/dbflow-tests/src/test/java/com/raizlabs/android/dbflow/test/list/FlowCursorListTest.java
@@ -18,7 +18,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -57,7 +56,7 @@ public class FlowCursorListTest extends FlowTestCase {
                 .build();
 
         assertEquals(TestQueryModel.class, cursorList.getTable());
-        assertFalse(cursorList.cachingEnabled());
+        assertTrue(cursorList.cachingEnabled());
         assertEquals(0, cursorList.cacheSize());
 
         cursorList.close();

--- a/dbflow-tests/src/test/java/com/raizlabs/android/dbflow/test/list/FlowCursorListTest.java
+++ b/dbflow-tests/src/test/java/com/raizlabs/android/dbflow/test/list/FlowCursorListTest.java
@@ -1,0 +1,78 @@
+package com.raizlabs.android.dbflow.test.list;
+
+import com.raizlabs.android.dbflow.list.FlowCursorList;
+import com.raizlabs.android.dbflow.sql.language.Delete;
+import com.raizlabs.android.dbflow.sql.language.SQLite;
+import com.raizlabs.android.dbflow.structure.cache.ModelLruCache;
+import com.raizlabs.android.dbflow.test.FlowTestCase;
+import com.raizlabs.android.dbflow.test.querymodel.TestQueryModel;
+import com.raizlabs.android.dbflow.test.structure.TestModel1;
+import com.raizlabs.android.dbflow.test.structure.TestModel1_Table;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Description:
+ */
+public class FlowCursorListTest extends FlowTestCase {
+
+
+    @Test
+    public void test_validateBuilderCacheable() {
+        FlowCursorList<TestModel1> cursorList =
+                new FlowCursorList.Builder<>(TestModel1.class)
+                        .cacheSize(50)
+                        .modelCache(ModelLruCache.<TestModel1>newInstance(50))
+                        .modelQueriable(SQLite.select().from(TestModel1.class))
+                        .build();
+
+        assertEquals(TestModel1.class, cursorList.getTable());
+        assertEquals(50, cursorList.cacheSize());
+        assertTrue(cursorList.modelCache() instanceof ModelLruCache);
+        assertEquals(true, cursorList.cachingEnabled());
+        assertNotNull(cursorList.getCursor());
+
+        cursorList.close();
+    }
+
+    @Test
+    public void test_validateBuilderCustomQuery() {
+        FlowCursorList<TestQueryModel> cursorList
+                = new FlowCursorList.Builder<>(TestQueryModel.class)
+                .cursor(SQLite
+                        .select(TestModel1_Table.name.as("newName"))
+                        .from(TestModel1.class).query())
+                .build();
+
+        assertEquals(TestQueryModel.class, cursorList.getTable());
+        assertFalse(cursorList.cachingEnabled());
+        assertEquals(0, cursorList.cacheSize());
+
+        cursorList.close();
+    }
+
+    @Test
+    public void test_ensureModelCache() {
+        Delete.table(TestModel1.class);
+
+        TestModel1 model = new TestModel1();
+        model.setName("Test");
+        model.save();
+
+        FlowCursorList<TestModel1> list = new FlowCursorList.Builder<>(TestModel1.class)
+                .cacheModels(true)
+                .modelQueriable(SQLite.select().from(TestModel1.class))
+                .build();
+        assertEquals(1, list.getCount());
+        assertEquals(model.getName(), list.getItem(0).getName());
+        assertEquals(list.getItem(0), list.getItem(0));
+
+        list.close();
+    }
+
+}

--- a/dbflow-tests/src/test/java/com/raizlabs/android/dbflow/test/list/FlowQueryListTest.java
+++ b/dbflow-tests/src/test/java/com/raizlabs/android/dbflow/test/list/FlowQueryListTest.java
@@ -1,13 +1,21 @@
 package com.raizlabs.android.dbflow.test.list;
 
+import com.raizlabs.android.dbflow.config.FlowManager;
 import com.raizlabs.android.dbflow.list.FlowQueryList;
+import com.raizlabs.android.dbflow.sql.language.SQLite;
+import com.raizlabs.android.dbflow.structure.database.transaction.FastStoreModelTransaction;
 import com.raizlabs.android.dbflow.structure.database.transaction.Transaction;
 import com.raizlabs.android.dbflow.test.FlowTestCase;
+import com.raizlabs.android.dbflow.test.TestDatabase;
 import com.raizlabs.android.dbflow.test.structure.TestModel1;
 
 import org.junit.Test;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -43,5 +51,30 @@ public class FlowQueryListTest extends FlowTestCase {
         assertEquals(50, queryList.cursorList().cacheSize());
         assertTrue(queryList.changeInTransaction());
 
+    }
+
+    @Test
+    public void test_canIterateQueryList() {
+        List<TestModel1> models = new ArrayList<>();
+        for (int i = 0; i < 50; i++) {
+            TestModel1 model = new TestModel1();
+            model.setName("" + i);
+            models.add(model);
+        }
+        FlowManager.getDatabase(TestDatabase.class)
+                .executeTransaction(FastStoreModelTransaction
+                        .insertBuilder(FlowManager.getModelAdapter(TestModel1.class))
+                        .addAll(models)
+                        .build());
+
+        List<TestModel1> queryList = SQLite.select()
+                .from(TestModel1.class).flowQueryList();
+        assertNotEquals(0, queryList.size());
+        assertEquals(50, queryList.size());
+        int count = 0;
+        for (TestModel1 model : queryList) {
+            assertEquals(count + "", model.getName());
+            count++;
+        }
     }
 }

--- a/dbflow-tests/src/test/java/com/raizlabs/android/dbflow/test/list/FlowQueryListTest.java
+++ b/dbflow-tests/src/test/java/com/raizlabs/android/dbflow/test/list/FlowQueryListTest.java
@@ -1,0 +1,47 @@
+package com.raizlabs.android.dbflow.test.list;
+
+import com.raizlabs.android.dbflow.list.FlowQueryList;
+import com.raizlabs.android.dbflow.structure.database.transaction.Transaction;
+import com.raizlabs.android.dbflow.test.FlowTestCase;
+import com.raizlabs.android.dbflow.test.structure.TestModel1;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Description:
+ */
+public class FlowQueryListTest extends FlowTestCase {
+
+
+    @Test
+    public void test_ensureValidateBuilder() {
+        Transaction.Success success = new Transaction.Success() {
+            @Override
+            public void onSuccess(Transaction transaction) {
+
+            }
+        };
+        Transaction.Error error = new Transaction.Error() {
+            @Override
+            public void onError(Transaction transaction, Throwable error) {
+
+            }
+        };
+        FlowQueryList<TestModel1> queryList
+                = new FlowQueryList.Builder<>(TestModel1.class)
+                .success(success)
+                .error(error)
+                .cacheSize(50)
+                .changeInTransaction(true)
+                .build();
+        assertEquals(success, queryList.success());
+        assertEquals(error, queryList.error());
+        assertEquals(true, queryList.cursorList().cachingEnabled());
+        assertEquals(50, queryList.cursorList().cacheSize());
+        assertTrue(queryList.changeInTransaction());
+
+    }
+}

--- a/dbflow-tests/src/test/java/com/raizlabs/android/dbflow/test/list/ListTest.java
+++ b/dbflow-tests/src/test/java/com/raizlabs/android/dbflow/test/list/ListTest.java
@@ -114,8 +114,17 @@ public class ListTest extends FlowTestCase {
     public void testCursorList() {
 
         final List<ListModel> testModel1s = GenerationUtils.generateRandomModels(ListModel.class, 50);
+        FlowManager.getDatabase(ListDatabase.class)
+                .executeTransaction(FastStoreModelTransaction
+                        .insertBuilder(FlowManager.getModelAdapter(ListModel.class))
+                        .addAll(testModel1s)
+                        .build());
 
-        FlowCursorList<ListModel> flowCursorList = new FlowCursorList<>(true, SQLite.select().from(ListModel.class));
+        FlowCursorList<ListModel> flowCursorList = new FlowCursorList.Builder<>(ListModel.class)
+                .cacheModels(true)
+                .modelQueriable(SQLite.select()
+                        .from(ListModel.class))
+                .build();
 
         TestModelAdapter modelAdapter = new TestModelAdapter(flowCursorList);
 

--- a/dbflow-tests/src/test/java/com/raizlabs/android/dbflow/test/querymodel/QueryModelTest.java
+++ b/dbflow-tests/src/test/java/com/raizlabs/android/dbflow/test/querymodel/QueryModelTest.java
@@ -1,12 +1,8 @@
 package com.raizlabs.android.dbflow.test.querymodel;
 
-import android.support.annotation.NonNull;
-
-import com.raizlabs.android.dbflow.sql.language.CursorResult;
 import com.raizlabs.android.dbflow.sql.language.Delete;
 import com.raizlabs.android.dbflow.sql.language.Select;
 import com.raizlabs.android.dbflow.sql.language.Where;
-import com.raizlabs.android.dbflow.structure.database.transaction.QueryTransaction;
 import com.raizlabs.android.dbflow.test.FlowTestCase;
 
 import org.junit.Test;

--- a/dbflow-tests/src/test/java/com/raizlabs/android/dbflow/test/sql/PropertyFactoryTest.java
+++ b/dbflow-tests/src/test/java/com/raizlabs/android/dbflow/test/sql/PropertyFactoryTest.java
@@ -26,57 +26,75 @@ import static org.junit.Assert.assertEquals;
 public class PropertyFactoryTest extends FlowTestCase {
 
     @Test
-    public void testPropertyFactory() {
-
+    public void test_delete() {
         long time = System.currentTimeMillis();
 
         Where<TestModel2> delete = SQLite.delete(TestModel2.class)
                 .where(TestModel2_Table.model_order.plus(PropertyFactory.from(5)).lessThan((int) time));
         assertEquals("DELETE FROM `TestModel2` WHERE `model_order` + 5<" + (int) time, delete.getQuery().trim());
+    }
 
+    @Test
+    public void test_charProperty() {
         CharProperty charProperty = PropertyFactory.from('c');
         assertEquals("'c'", charProperty.getQuery());
         QueryBuilder queryBuilder = new QueryBuilder();
         charProperty.between('d').and('e').appendConditionToQuery(queryBuilder);
         assertEquals("'c' BETWEEN 'd' AND 'e'", queryBuilder.getQuery().trim());
-
-        Property<String> stringProperty = PropertyFactory.from("MyGirl");
-        assertEquals("'MyGirl'", stringProperty.getQuery());
-        queryBuilder = new QueryBuilder();
-        stringProperty.concatenate("Talkin' About").appendConditionToQuery(queryBuilder);
-        assertEquals("'MyGirl'='MyGirl' || 'Talkin'' About'", queryBuilder.getQuery().trim());
-
-        ByteProperty byteProperty = PropertyFactory.from((byte) 5);
-        assertEquals("5", byteProperty.getQuery());
-        queryBuilder = new QueryBuilder();
-        byteProperty.in((byte) 6, (byte) 7, (byte) 8, (byte) 9).appendConditionToQuery(queryBuilder);
-        assertEquals("5 IN (6,7,8,9)", queryBuilder.getQuery().trim());
-
-        IntProperty intProperty = PropertyFactory.from(5);
-        assertEquals("5", intProperty.getQuery());
-        queryBuilder = new QueryBuilder();
-        intProperty.greaterThan(TestModel2_Table.model_order).appendConditionToQuery(queryBuilder);
-        assertEquals("5>`model_order`", queryBuilder.getQuery().trim());
-
-        DoubleProperty doubleProperty = PropertyFactory.from(10d);
-        assertEquals("10.0", doubleProperty.getQuery());
-        queryBuilder = new QueryBuilder();
-        doubleProperty.plus(ConditionModel_Table.fraction).lessThan(ConditionModel_Table.fraction).appendConditionToQuery(queryBuilder);
-        assertEquals("10.0 + `fraction`<`fraction`", queryBuilder.getQuery().trim());
-
-        FloatProperty floatProperty = PropertyFactory.from(20f);
-        assertEquals("20.0", floatProperty.getQuery());
-        queryBuilder = new QueryBuilder();
-        floatProperty.minus(ConditionModel_Table.floatie).minus(ConditionModel_Table.floatie).eq(5f).appendConditionToQuery(queryBuilder);
-
-        Property<TestModel1> model1Property = PropertyFactory.from(
-                SQLite.select().from(TestModel1.class).where(TestModel1_Table.name.eq("Test"))).as("Cool");
-        assertEquals("(SELECT * FROM `TestModel1` WHERE `name`='Test' ) AS `Cool`", model1Property.getDefinition());
-        queryBuilder = new QueryBuilder();
-        model1Property.minus(ConditionModel_Table.fraction).plus(TestModel1_Table.name.withTable()).like("%somethingnotvalid%").appendConditionToQuery(queryBuilder);
-        assertEquals("(SELECT * FROM `TestModel1` WHERE `name`='Test' ) - `fraction` + `TestModel1`.`name` LIKE '%somethingnotvalid%'", queryBuilder.getQuery().trim());
-
     }
 
+    @Test
+    public void test_stringProperty() {
+        Property<String> stringProperty = PropertyFactory.from("MyGirl");
+        assertEquals("'MyGirl'", stringProperty.getQuery());
+        QueryBuilder queryBuilder = new QueryBuilder();
+        stringProperty.concatenate("Talkin' About").appendConditionToQuery(queryBuilder);
+        assertEquals("'MyGirl'='MyGirl' || 'Talkin'' About'", queryBuilder.getQuery().trim());
+    }
 
+    @Test
+    public void test_byteProperty() {
+        ByteProperty byteProperty = PropertyFactory.from((byte) 5);
+        assertEquals("5", byteProperty.getQuery());
+        QueryBuilder queryBuilder = new QueryBuilder();
+        byteProperty.in((byte) 6, (byte) 7, (byte) 8, (byte) 9).appendConditionToQuery(queryBuilder);
+        assertEquals("5 IN (6,7,8,9)", queryBuilder.getQuery().trim());
+    }
+
+    @Test
+    public void test_intProperty() {
+        IntProperty intProperty = PropertyFactory.from(5);
+        assertEquals("5", intProperty.getQuery());
+        QueryBuilder queryBuilder = new QueryBuilder();
+        intProperty.greaterThan(TestModel2_Table.model_order).appendConditionToQuery(queryBuilder);
+        assertEquals("5>`model_order`", queryBuilder.getQuery().trim());
+    }
+
+    @Test
+    public void test_doubleProperty() {
+        DoubleProperty doubleProperty = PropertyFactory.from(10d);
+        assertEquals("10.0", doubleProperty.getQuery());
+        QueryBuilder queryBuilder = new QueryBuilder();
+        doubleProperty.plus(ConditionModel_Table.fraction).lessThan(ConditionModel_Table.fraction).appendConditionToQuery(queryBuilder);
+        assertEquals("10.0 + `fraction`<`fraction`", queryBuilder.getQuery().trim());
+    }
+
+    @Test
+    public void test_floatProperty() {
+        FloatProperty floatProperty = PropertyFactory.from(20f);
+        assertEquals("20.0", floatProperty.getQuery());
+        QueryBuilder queryBuilder = new QueryBuilder();
+        floatProperty.minus(ConditionModel_Table.floatie).minus(ConditionModel_Table.floatie).eq(5f).appendConditionToQuery(queryBuilder);
+    }
+
+    @Test
+    public void test_queryProperty() {
+        Property<TestModel1> model1Property = PropertyFactory.from(
+                SQLite.select().from(TestModel1.class).where(TestModel1_Table.name.eq("Test"))).as("Cool");
+        assertEquals("(SELECT * FROM `TestModel1` WHERE `name`='Test') AS `Cool`", model1Property.getDefinition());
+        QueryBuilder queryBuilder = new QueryBuilder();
+        model1Property.minus(ConditionModel_Table.fraction).plus(TestModel1_Table.name.withTable()).like("%somethingnotvalid%").appendConditionToQuery(queryBuilder);
+        assertEquals("(SELECT * FROM `TestModel1` WHERE `name`='Test') - `fraction` + `TestModel1`.`name` LIKE '%somethingnotvalid%'", queryBuilder.getQuery().trim());
+
+    }
 }

--- a/dbflow-tests/src/test/java/com/raizlabs/android/dbflow/test/sql/SelectTest.java
+++ b/dbflow-tests/src/test/java/com/raizlabs/android/dbflow/test/sql/SelectTest.java
@@ -6,6 +6,7 @@ import com.raizlabs.android.dbflow.sql.language.Method;
 import com.raizlabs.android.dbflow.sql.language.SQLite;
 import com.raizlabs.android.dbflow.sql.language.Select;
 import com.raizlabs.android.dbflow.sql.language.Where;
+import com.raizlabs.android.dbflow.sql.language.property.PropertyFactory;
 import com.raizlabs.android.dbflow.test.FlowTestCase;
 import com.raizlabs.android.dbflow.test.structure.TestModel1;
 import com.raizlabs.android.dbflow.test.structure.TestModel1_Table;
@@ -24,20 +25,23 @@ import static org.junit.Assert.assertTrue;
 public class SelectTest extends FlowTestCase {
 
     @Test
-    public void testSimpleSelectStatement() {
+    public void test_simpleSelectStatement() {
         Where<TestModel1> where = new Select(name).from(TestModel1.class)
                 .where(name.is("test"));
 
         assertEquals("SELECT `name` FROM `TestModel1` WHERE `name`='test'", where.getQuery().trim());
         where.query();
 
+    }
+
+    @Test
+    public void test_simpleSelectStatement2() {
         Where<TestModel3> where4 = new Select().from(TestModel3.class)
                 .where(name.eq("test"))
                 .and(type.is("test"));
 
-        assertEquals("SELECT * FROM `TestModel32` WHERE `name`='test' AND `type`='test'", where4.getQuery().trim());
-
-
+        assertEquals("SELECT * FROM `TestModel32` WHERE `name`='test' AND `type`='test'",
+                where4.getQuery().trim());
     }
 
     @Test
@@ -108,7 +112,7 @@ public class SelectTest extends FlowTestCase {
     }
 
     @Test
-    public void testJoins() {
+    public void test_joins() {
 
         TestModel1 testModel1 = new TestModel1();
         testModel1.setName("Test");
@@ -133,11 +137,26 @@ public class SelectTest extends FlowTestCase {
     }
 
     @Test
-    public void testNulls() {
+    public void test_nulls() {
 
         String nullable = null;
         String query = SQLite.select().from(TestModel1.class).where(TestModel1_Table.name.eq(nullable)).getQuery();
         assertEquals("SELECT * FROM `TestModel1` WHERE `name`=NULL", query.trim());
     }
 
+
+    @Test
+    public void test_selectProjectionQuery() {
+        Where<TestModel1> where = SQLite.select(TestModel1_Table.name)
+                .from(TestModel1.class).as("TableName")
+                .where(TestModel1_Table.name.eq("Test"));
+
+        String query = SQLite.select(PropertyFactory.from(where), TestModel1_Table.name)
+                .from(TestModel1.class).getQuery();
+
+        assertEquals("SELECT (SELECT `name` FROM `TestModel1` AS `TableName`" +
+                " WHERE `name`='Test'),`name` FROM `TestModel1`", query.trim());
+
+
+    }
 }

--- a/dbflow-tests/src/test/java/com/raizlabs/android/dbflow/test/structure/join/JoinTest.java
+++ b/dbflow-tests/src/test/java/com/raizlabs/android/dbflow/test/structure/join/JoinTest.java
@@ -155,7 +155,7 @@ public class JoinTest extends FlowTestCase {
         assertEquals("SELECT * FROM `TestModel1`" +
                         " INNER JOIN (SELECT `count`,MAX(`name`) AS `MaxName`" +
                         " FROM `DefaultModel`" +
-                        " GROUP BY `date` ) AS `topmsg`" +
+                        " GROUP BY `date`) AS `topmsg`" +
                         " ON `TestModel1`.`name`=`topmsg`.`MaxName`",
                 query.trim());
     }

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/list/CursorIterator.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/list/CursorIterator.java
@@ -1,0 +1,42 @@
+package com.raizlabs.android.dbflow.list;
+
+import android.database.Cursor;
+
+import com.raizlabs.android.dbflow.structure.Model;
+
+import java.util.Iterator;
+
+/**
+ * Description:
+ */
+public class CursorIterator<TModel extends Model> implements Iterator<TModel> {
+
+    private final FlowCursorList<TModel> cursorList;
+    private int count;
+
+    public CursorIterator(FlowCursorList<TModel> cursorList) {
+        this.cursorList = cursorList;
+        Cursor cursor = cursorList.cursor();
+        if (cursor != null) {
+            cursor.moveToPosition(-1);
+            count = cursor.getCount();
+        }
+    }
+
+    @Override
+    public boolean hasNext() {
+        return count > 0;
+    }
+
+    @Override
+    public TModel next() {
+        TModel item = cursorList.getItem(cursorList.getCount() - count);
+        count--;
+        return item;
+    }
+
+    @Override
+    public void remove() {
+        throw new UnsupportedOperationException("Cursor Iterator: cannot remove from an active Iterator ");
+    }
+}

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/list/FlowCursorIterator.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/list/FlowCursorIterator.java
@@ -10,17 +10,17 @@ import java.util.ListIterator;
 /**
  * Description: Provides iteration capabilitie to a {@link FlowCursorList}.
  */
-public class CursorIterator<TModel extends Model> implements ListIterator<TModel> {
+public class FlowCursorIterator<TModel extends Model> implements ListIterator<TModel> {
 
-    private final FlowCursorList<TModel> cursorList;
+    private final IFlowCursorIterator<TModel> cursorList;
     private int reverseIndex;
     private int startingCount;
 
-    public CursorIterator(FlowCursorList<TModel> cursorList) {
+    public FlowCursorIterator(IFlowCursorIterator<TModel> cursorList) {
         this(cursorList, 0);
     }
 
-    public CursorIterator(FlowCursorList<TModel> cursorList, int startingLocation) {
+    public FlowCursorIterator(IFlowCursorIterator<TModel> cursorList, int startingLocation) {
         this.cursorList = cursorList;
         Cursor cursor = cursorList.cursor();
         if (cursor != null) {

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/list/FlowCursorList.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/list/FlowCursorList.java
@@ -15,12 +15,13 @@ import com.raizlabs.android.dbflow.structure.cache.ModelLruCache;
 
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 
 /**
  * Description: A non-modifiable, cursor-backed list that you can use in {@link ListView} or other data sources.
  */
-public class FlowCursorList<TModel extends Model> {
+public class FlowCursorList<TModel extends Model> implements Iterable<TModel> {
 
     /**
      * Interface for callbacks when cursor gets refreshed.
@@ -119,6 +120,11 @@ public class FlowCursorList<TModel extends Model> {
         modelAdapter = FlowManager.getInstanceAdapter(table);
         this.cacheModels = cacheModels;
         setCacheModels(cacheModels);
+    }
+
+    @Override
+    public Iterator<TModel> iterator() {
+        return new CursorIterator<>(this);
     }
 
     /**

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/list/FlowCursorList.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/list/FlowCursorList.java
@@ -13,6 +13,7 @@ import com.raizlabs.android.dbflow.structure.Model;
 import com.raizlabs.android.dbflow.structure.cache.ModelCache;
 import com.raizlabs.android.dbflow.structure.cache.ModelLruCache;
 
+import java.io.Closeable;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -21,7 +22,7 @@ import java.util.List;
 /**
  * Description: A non-modifiable, cursor-backed list that you can use in {@link ListView} or other data sources.
  */
-public class FlowCursorList<TModel extends Model> implements Iterable<TModel> {
+public class FlowCursorList<TModel extends Model> implements Iterable<TModel>, Closeable {
 
     /**
      * Interface for callbacks when cursor gets refreshed.
@@ -298,6 +299,7 @@ public class FlowCursorList<TModel extends Model> implements Iterable<TModel> {
     /**
      * Closes the cursor backed by this list
      */
+    @Override
     public void close() {
         warnEmptyCursor();
         if (cursor != null) {

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/list/FlowCursorList.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/list/FlowCursorList.java
@@ -343,6 +343,19 @@ public class FlowCursorList<TModel extends Model> {
     }
 
     /**
+     * @return A new {@link Builder} that contains the same cache, query statement, and other
+     * underlying data, but allows for modification.
+     */
+    public Builder<TModel> newBuilder() {
+        return new Builder<>(table)
+                .modelQueriable(modelQueriable)
+                .cursor(cursor)
+                .cacheSize(cacheSize)
+                .cacheModels(cacheModels)
+                .modelCache(modelCache);
+    }
+
+    /**
      * Provides easy way to construct a {@link FlowCursorList}.
      *
      * @param <TModel>

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/list/FlowCursorList.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/list/FlowCursorList.java
@@ -22,7 +22,8 @@ import java.util.List;
 /**
  * Description: A non-modifiable, cursor-backed list that you can use in {@link ListView} or other data sources.
  */
-public class FlowCursorList<TModel extends Model> implements Iterable<TModel>, Closeable {
+public class FlowCursorList<TModel extends Model> implements
+        Iterable<TModel>, Closeable, IFlowCursorIterator<TModel> {
 
     /**
      * Interface for callbacks when cursor gets refreshed.
@@ -125,7 +126,7 @@ public class FlowCursorList<TModel extends Model> implements Iterable<TModel>, C
 
     @Override
     public Iterator<TModel> iterator() {
-        return new CursorIterator<>(this);
+        return new FlowCursorIterator<>(this);
     }
 
     /**
@@ -238,6 +239,7 @@ public class FlowCursorList<TModel extends Model> implements Iterable<TModel>, C
      * @param position The row number in the {@link android.database.Cursor} to look at
      * @return The {@link TModel} converted from the cursor
      */
+    @Override
     public TModel getItem(long position) {
         throwIfCursorClosed();
         warnEmptyCursor();
@@ -278,6 +280,7 @@ public class FlowCursorList<TModel extends Model> implements Iterable<TModel>, C
     /**
      * @return the count of the rows in the {@link android.database.Cursor} backed by this list.
      */
+    @Override
     public int getCount() {
         throwIfCursorClosed();
         warnEmptyCursor();
@@ -308,6 +311,7 @@ public class FlowCursorList<TModel extends Model> implements Iterable<TModel>, C
         cursor = null;
     }
 
+    @Override
     @Nullable
     public Cursor cursor() {
         throwIfCursorClosed();
@@ -373,7 +377,7 @@ public class FlowCursorList<TModel extends Model> implements Iterable<TModel>, C
         private final Class<TModel> modelClass;
         private Cursor cursor;
         private ModelQueriable<TModel> modelQueriable;
-        private boolean cacheModels;
+        private boolean cacheModels = true;
         private int cacheSize;
         private ModelCache<TModel, ?> modelCache;
 

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/list/FlowQueryList.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/list/FlowQueryList.java
@@ -248,6 +248,18 @@ public class FlowQueryList<TModel extends Model> extends FlowContentObserver imp
     }
 
     /**
+     * @return Constructs a new {@link Builder} that reuses the underlying {@link Cursor}, cache,
+     * callbacks, and other properties.
+     */
+    public Builder<TModel> newBuilder() {
+        return new Builder<>(internalCursorList)
+                .success(successCallback)
+                .error(errorCallback)
+                .changeInTransaction(changeInTransaction)
+                .transact(transact);
+    }
+
+    /**
      * Refreshes the content backing this list.
      */
     public void refresh() {
@@ -729,6 +741,15 @@ public class FlowQueryList<TModel extends Model> extends FlowContentObserver imp
 
         private Transaction.Success success;
         private Transaction.Error error;
+
+        private Builder(FlowCursorList<TModel> cursorList) {
+            table = cursorList.table();
+            cursor = cursorList.cursor();
+            cacheModels = cursorList.cachingEnabled();
+            cacheSize = cursorList.cacheSize();
+            modelQueriable = cursorList.modelQueriable();
+            modelCache = cursorList.modelCache();
+        }
 
         public Builder(Class<TModel> table) {
             this.table = table;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/list/FlowQueryList.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/list/FlowQueryList.java
@@ -37,7 +37,7 @@ import java.util.ListIterator;
  * on the underlying table.
  */
 public class FlowQueryList<TModel extends Model> extends FlowContentObserver
-        implements List<TModel>, Closeable {
+        implements List<TModel>, Closeable, IFlowCursorIterator<TModel> {
 
     private static final Handler REFRESH_HANDLER = new Handler(Looper.myLooper());
 
@@ -435,6 +435,21 @@ public class FlowQueryList<TModel extends Model> extends FlowContentObserver
         return contains;
     }
 
+    @Override
+    public int getCount() {
+        return internalCursorList.getCount();
+    }
+
+    @Override
+    public TModel getItem(long position) {
+        return internalCursorList.getItem(position);
+    }
+
+    @Override
+    public Cursor cursor() {
+        return internalCursorList.cursor();
+    }
+
     /**
      * Returns the item from the backing {@link FlowCursorList}. First call
      * will load the model from the cursor, while subsequent calls will use the cache.
@@ -466,7 +481,7 @@ public class FlowQueryList<TModel extends Model> extends FlowContentObserver
     @NonNull
     @Override
     public Iterator<TModel> iterator() {
-        return new CursorIterator<>(internalCursorList);
+        return new FlowCursorIterator<>(this);
     }
 
     @Override
@@ -482,7 +497,7 @@ public class FlowQueryList<TModel extends Model> extends FlowContentObserver
     @NonNull
     @Override
     public ListIterator<TModel> listIterator() {
-        return new CursorIterator<>(internalCursorList);
+        return new FlowCursorIterator<>(this);
     }
 
     /**
@@ -493,7 +508,7 @@ public class FlowQueryList<TModel extends Model> extends FlowContentObserver
     @NonNull
     @Override
     public ListIterator<TModel> listIterator(int location) {
-        return new CursorIterator<TModel>(internalCursorList, location);
+        return new FlowCursorIterator<>(this, location);
     }
 
     /**
@@ -739,7 +754,7 @@ public class FlowQueryList<TModel extends Model> extends FlowContentObserver
         private boolean transact;
         private boolean changeInTransaction;
         private Cursor cursor;
-        private boolean cacheModels;
+        private boolean cacheModels = true;
         private int cacheSize;
         private ModelQueriable<TModel> modelQueriable;
         private ModelCache<TModel, ?> modelCache;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/list/FlowQueryList.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/list/FlowQueryList.java
@@ -22,6 +22,8 @@ import com.raizlabs.android.dbflow.structure.database.transaction.ProcessModelTr
 import com.raizlabs.android.dbflow.structure.database.transaction.QueryTransaction;
 import com.raizlabs.android.dbflow.structure.database.transaction.Transaction;
 
+import java.io.Closeable;
+import java.io.IOException;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
@@ -34,7 +36,8 @@ import java.util.ListIterator;
  * on this list to know when the results complete. NOTE: any modifications to this list will be reflected
  * on the underlying table.
  */
-public class FlowQueryList<TModel extends Model> extends FlowContentObserver implements List<TModel> {
+public class FlowQueryList<TModel extends Model> extends FlowContentObserver
+        implements List<TModel>, Closeable {
 
     private static final Handler REFRESH_HANDLER = new Handler(Looper.myLooper());
 
@@ -663,6 +666,11 @@ public class FlowQueryList<TModel extends Model> extends FlowContentObserver imp
     public <T> T[] toArray(T[] array) {
         List<TModel> tableList = internalCursorList.getAll();
         return tableList.toArray(array);
+    }
+
+    @Override
+    public void close() throws IOException {
+        internalCursorList.close();
     }
 
     private final ProcessModelTransaction.ProcessModel<TModel> saveModel =

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/list/FlowQueryList.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/list/FlowQueryList.java
@@ -463,8 +463,7 @@ public class FlowQueryList<TModel extends Model> extends FlowContentObserver imp
     @NonNull
     @Override
     public Iterator<TModel> iterator() {
-        List<TModel> tableList = internalCursorList.getAll();
-        return tableList.iterator();
+        return new CursorIterator<>(internalCursorList);
     }
 
     @Override
@@ -480,8 +479,7 @@ public class FlowQueryList<TModel extends Model> extends FlowContentObserver imp
     @NonNull
     @Override
     public ListIterator<TModel> listIterator() {
-        List<TModel> tableList = internalCursorList.getAll();
-        return tableList.listIterator();
+        return new CursorIterator<>(internalCursorList);
     }
 
     /**
@@ -492,8 +490,7 @@ public class FlowQueryList<TModel extends Model> extends FlowContentObserver imp
     @NonNull
     @Override
     public ListIterator<TModel> listIterator(int location) {
-        List<TModel> tableList = internalCursorList.getAll();
-        return tableList.listIterator(location);
+        return new CursorIterator<TModel>(internalCursorList, location);
     }
 
     /**

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/list/FlowQueryList.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/list/FlowQueryList.java
@@ -52,9 +52,6 @@ public class FlowQueryList<TModel extends Model> extends FlowContentObserver imp
      */
     private boolean transact = false;
 
-    /**
-     * If true, an operation occurred that when we call endTransactionAndNotify, we refresh content.
-     */
     private boolean changeInTransaction = false;
 
     private boolean pendingRefresh = false;
@@ -78,7 +75,7 @@ public class FlowQueryList<TModel extends Model> extends FlowContentObserver imp
      * Constructs an instance of this list with the specfied {@link ModelQueriable} object.
      *
      * @param modelQueriable The object that can query from a database.
-     * @deprecated use {@link Builder}
+     * @deprecated use {@link Builder#modelQueriable(ModelQueriable)}
      */
     @Deprecated
     public FlowQueryList(ModelQueriable<TModel> modelQueriable) {
@@ -89,7 +86,7 @@ public class FlowQueryList<TModel extends Model> extends FlowContentObserver imp
      * Constructs an instance of this list with the specfied {@link ModelQueriable} object.
      *
      * @param modelQueriable The object that can query from a database.
-     * @deprecated use {@link Builder}
+     * @deprecated use {@link Builder#modelQueriable(ModelQueriable)}, {@link Builder#cacheModels(boolean)}
      */
     @Deprecated
     public FlowQueryList(boolean cacheModels, ModelQueriable<TModel> modelQueriable) {
@@ -97,6 +94,7 @@ public class FlowQueryList<TModel extends Model> extends FlowContentObserver imp
         internalCursorList = new FlowCursorList.Builder<>(modelQueriable.getTable())
                 .modelQueriable(modelQueriable)
                 .cacheModels(cacheModels)
+                .cacheSize(getCacheSize())
                 .modelCache(getBackingCache(getCacheSize()))
                 .build();
     }
@@ -105,6 +103,7 @@ public class FlowQueryList<TModel extends Model> extends FlowContentObserver imp
     /**
      * @deprecated use {@link Builder#cacheModels(boolean)}, {@link Builder#cacheSize(int)}
      */
+    @Deprecated
     public void setCacheModels(boolean cacheModels, int cacheSize) {
         internalCursorList.setCacheModels(cacheModels, cacheSize);
     }
@@ -221,9 +220,31 @@ public class FlowQueryList<TModel extends Model> extends FlowContentObserver imp
 
     /**
      * @return The {@link FlowCursorList} that backs this table list.
+     * @deprecated use {@link #cursorList()}
      */
+    @Deprecated
     public FlowCursorList<TModel> getCursorList() {
         return internalCursorList;
+    }
+
+    public FlowCursorList<TModel> cursorList() {
+        return internalCursorList;
+    }
+
+    public Transaction.Error error() {
+        return errorCallback;
+    }
+
+    public Transaction.Success success() {
+        return successCallback;
+    }
+
+    public boolean changeInTransaction() {
+        return changeInTransaction;
+    }
+
+    public boolean transact() {
+        return transact;
     }
 
     /**
@@ -259,7 +280,6 @@ public class FlowQueryList<TModel extends Model> extends FlowContentObserver imp
     public void enableSelfRefreshes(Context context) {
         registerForContentChanges(context);
     }
-
 
     @Override
     public void endTransactionAndNotify() {
@@ -465,8 +485,9 @@ public class FlowQueryList<TModel extends Model> extends FlowContentObserver imp
     }
 
     /**
-     * Removes the {@link TModel} from its table on the {@link DefaultTransactionQueue} .
-     * If {@link #transact} is true, the delete does not happen immediately.
+     * Deletes a {@link TModel} at a specific position within the stored {@link Cursor}.
+     * If {@link #transact} is true, the delete does not happen immediately. Avoid using this operation
+     * many times. If you need to remove multiple, use {@link #removeAll(Collection)}
      *
      * @param location The location within the table to remove the item from
      * @return The removed item.
@@ -733,6 +754,9 @@ public class FlowQueryList<TModel extends Model> extends FlowContentObserver imp
             return this;
         }
 
+        /**
+         * If true, when an operation occurs when we call endTransactionAndNotify, we refresh content.
+         */
         public Builder<TModel> changeInTransaction(boolean changeInTransaction) {
             this.changeInTransaction = changeInTransaction;
             return this;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/list/IFlowCursorIterator.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/list/IFlowCursorIterator.java
@@ -1,0 +1,26 @@
+package com.raizlabs.android.dbflow.list;
+
+import android.database.Cursor;
+
+import com.raizlabs.android.dbflow.structure.Model;
+
+/**
+ * Description: Simple interface that allows you to iterate a {@link Cursor}.
+ */
+public interface IFlowCursorIterator<TModel extends Model> {
+
+    /**
+     * @return Count of the {@link Cursor}.
+     */
+    int getCount();
+
+    /**
+     * @param position The position within the {@link Cursor} to retrieve and convert into a {@link TModel}
+     */
+    TModel getItem(long position);
+
+    /**
+     * @return The cursor.
+     */
+    Cursor cursor();
+}

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/BaseModelQueriable.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/BaseModelQueriable.java
@@ -83,12 +83,15 @@ public abstract class BaseModelQueriable<TModel extends Model> extends BaseQueri
 
     @Override
     public FlowCursorList<TModel> cursorList() {
-        return new FlowCursorList<>(false, this);
+        return new FlowCursorList.Builder<>(getTable())
+                .modelQueriable(this).build();
     }
 
     @Override
     public FlowQueryList<TModel> flowQueryList() {
-        return new FlowQueryList<>(this);
+        return new FlowQueryList.Builder<>(getTable())
+                .modelQueriable(this)
+                .build();
     }
 
     @Override

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/property/PropertyFactory.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/property/PropertyFactory.java
@@ -115,7 +115,7 @@ public class PropertyFactory {
      * @return A new property that is a query.
      */
     public static <TModel extends Model> Property<TModel> from(@NonNull ModelQueriable<TModel> queriable) {
-        return from(queriable.getTable(), "(" + queriable.getQuery() + ")");
+        return from(queriable.getTable(), "(" + String.valueOf(queriable.getQuery()).trim() + ")");
     }
 
     /**


### PR DESCRIPTION
1. New API for both classes via `Builder` API
2. Deprecate setters + old constructors
3. Iteration is way more efficient. Previously we would iterate after loading _all_ rows in the list first. Now we use a `FlowCursorIterator` that does hyper-efficient iteration. 