### PR TITLE
Update SQLCipher to 3.5.0

### DIFF
--- a/dbflow-sqlcipher/build.gradle
+++ b/dbflow-sqlcipher/build.gradle
@@ -25,7 +25,7 @@ android {
 }
 
 dependencies {
-    compile "net.zetetic:android-database-sqlcipher:3.4.0"
+    compile "net.zetetic:android-database-sqlcipher:3.5.0@aar"
     compile project("${dbflow_project_prefix}dbflow")
 }
 


### PR DESCRIPTION
This update to SQLCipher enables Android N compatibility.  Full details [here](http://discuss.zetetic.net/t/sqlcipher-for-android-release-android-n-support/1465)