### PR TITLE
Initialize content provider uri matcher in onCreate

### DIFF
--- a/dbflow-tests/src/test/java/com/raizlabs/android/dbflow/test/provider/ContentProviderTest.java
+++ b/dbflow-tests/src/test/java/com/raizlabs/android/dbflow/test/provider/ContentProviderTest.java
@@ -29,7 +29,10 @@ public class ContentProviderTest extends FlowTestCase {
 
     @Before
     public void setUp() {
-        ShadowContentResolver.registerProvider(TestContentProvider.AUTHORITY, new TestContentProvider_Provider());
+        TestContentProvider_Provider provider = new TestContentProvider_Provider();
+        provider.onCreate();
+
+        ShadowContentResolver.registerProvider(TestContentProvider.AUTHORITY, provider);
     }
 
     @Test


### PR DESCRIPTION
In my current project work flow I have a library project we shall call `SDK` and two Applications, `appA` and `appB`.

`appA` and `appB` both depend on `SDK`.

Because the content provider defined in the SDK has (had) a compile time constant authority set, an authority conflict will occur when attempting to install the applications side by side. 

By checking if the authority constant contains "R.string." we can modify the code generation logic path to use a string resource lookup to get the authority string and thus build the URI's based on a run time determined value.

Consuming applications can then define an overriding string to change the authority as appropriate.

This also serves as a fix where multiple flavors of the same application would have a provider authority conflict. 

I opted to make everything based on the instance because the android system initializes content providers BEFORE the application `onCreate` is called. By moving all of this to instance fields / `onCreate`. I am able to do `getContext().getString(fqcn.R.string)` and disregard differences in `onCreate` dispatch ordering. It is important to note that if content provider is generated in a package other than the one is which `R` resides you must supply a fully qualified class name. This is the only part of this that I don't love but gets us to a minimum viable product quickly.

Alternatively we could add an integer field (default 0) on the annotation and give the current authority field a default empty string then perform a compile time check to ensure that one and only one is set.  Let me know if you would more prefer something along these lines and I will get to work adjusting.

When creating the URI in a model class if can be done using the `FlowManager.getContext()` method as the `Application.onCreate()` and subsequent call to `FlowManager.init(...)` would have occurred early enough that the first references to your model class will always follow. The static field initialization should then be able to safely get a context instance for string lookup.

One example of this being:
```java
@ContentUri(path = "CodeSample_Model", type = ContentUri.ContentType.VND_MULTIPLE + "CodeSample_Model")
public static final Uri CONTENT_URI = ContentUtils.buildUriWithAuthority(FlowManager.getContext().getString(R.string.sdk_db_authority) , "CodeSample_Model");
``` 