### PR TITLE
Fix TransactionQueue leak when destroying FlowManager

### DIFF
--- a/dbflow-tests/src/test/java/com/raizlabs/android/dbflow/test/DBFlowTestRule.java
+++ b/dbflow-tests/src/test/java/com/raizlabs/android/dbflow/test/DBFlowTestRule.java
@@ -30,7 +30,6 @@ public class DBFlowTestRule implements TestRule {
                 try {
                     base.evaluate();
                 } finally {
-                    FlowManager.reset();
                     FlowManager.destroy();
                 }
             }

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/config/FlowManager.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/config/FlowManager.java
@@ -278,6 +278,12 @@ public class FlowManager {
      * Release reference to context and {@link FlowConfig}
      */
     public static synchronized void destroy() {
+        Set<Map.Entry<Class<?>, DatabaseDefinition>> entrySet = globalDatabaseHolder.databaseClassLookupMap.entrySet();
+        for (Map.Entry<Class<?>, DatabaseDefinition> value : entrySet) {
+            value.getValue().getTransactionManager().stopQueue();
+            value.getValue().getHelper().closeDB();
+        }
+
         config = null;
 
         // Reset the global database holder.


### PR DESCRIPTION
I've tried to upgrade DBFlow to 3+ on a ~1k unit tests project but I couldn't since I would get an `OutOfMemory` error when running my tests. I was calling `FlowManager.destroy()` as suggested and also tried `FlowManager.reset()` on each `@After` without success.

The thing is `FlowManager.destroy()` was clearing the global `DatabaseHolder` without stopping the  `TransactionQueues/Threads` inside of it. This would cause the creation of more than 2.5+ threads and the tests would just break. This behaviour can be reproduced on DBFlow's owns tests at the moment, but the threads number go up to 1.7k+ and the tests end before everything shuts down.

The fix was to stop all transaction queues before clearing up the global DatabaseHolder.
The threads will go up to ~200 now (it could be less but there's #1041).

Another simple way to reproduce is with this test:

```
    @Test
    public void test_A() {
        for (int i = 0; i < 1000; i++) {
            FlowManager.init(new FlowConfig.Builder(RuntimeEnvironment.application).build());
            FlowManager.destroy();
        }
    }
```
## 

I also removed `FlowManager.reset()` from the `DBFlowTestRule` since It was not needed when using Robolectric afaik.

Btw, I think there's a major flaw on the `FlowManager.reset()` because it delete all databases, stops all transaction queues just to right after create another `TransactionManager` and then it clears the global DatabaseHolder maps, without giving me the possibility to access them again in the future just to destroy.

I don't know if I chose the best approach to solve this, hope it helps!
