### PR TITLE
Introduce BigDecimalConverter

### DIFF
--- a/dbflow-core/src/main/java/com/raizlabs/android/dbflow/converter/BigDecimalConverter.java
+++ b/dbflow-core/src/main/java/com/raizlabs/android/dbflow/converter/BigDecimalConverter.java
@@ -1,0 +1,18 @@
+package com.raizlabs.android.dbflow.converter;
+
+import java.math.BigDecimal;
+
+/**
+ * Description: Defines how we store and retrieve a {@link java.math.BigDecimal}
+ */
+public class BigDecimalConverter extends TypeConverter<String, BigDecimal> {
+    @Override
+    public String getDBValue(BigDecimal model) {
+        return model == null ? null : model.toString();
+    }
+
+    @Override
+    public BigDecimal getModelValue(String data) {
+        return data == null ? null : new BigDecimal(data);
+    }
+}

--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/Handlers.kt
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/Handlers.kt
@@ -159,7 +159,8 @@ class TypeConverterHandler : BaseContainerHandler<TypeConverter>() {
         private val VALIDATOR = TypeConverterValidator()
         private val DEFAULT_TYPE_CONVERTERS = arrayOf<Class<*>>(CalendarConverter::class.java,
                 DateConverter::class.java, SqlDateConverter::class.java,
-                BooleanConverter::class.java, UUIDConverter::class.java)
+                BooleanConverter::class.java, UUIDConverter::class.java,
+                BigDecimalConverter::class.java)
     }
 }
 


### PR DESCRIPTION
Apps dealing with monetary values use BigDecimal for exact value
storage. A default converter simplifies BigDecimal usage.
