### PR TITLE
Fix broken IndexMigration

### DIFF
--- a/dbflow-tests/src/test/java/com/raizlabs/android/dbflow/test/sql/MigrationTest.java
+++ b/dbflow-tests/src/test/java/com/raizlabs/android/dbflow/test/sql/MigrationTest.java
@@ -95,6 +95,7 @@ public class MigrationTest extends FlowTestCase {
         // broken with junit tests
     }
 
+    @Test
     public void testIndexMigration() {
         IndexMigration<TestModel3> indexMigration
                 = new IndexMigration<TestModel3>(TestModel3.class) {

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/migration/IndexMigration.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/migration/IndexMigration.java
@@ -5,7 +5,6 @@ import android.support.annotation.NonNull;
 
 import com.raizlabs.android.dbflow.sql.language.Index;
 import com.raizlabs.android.dbflow.sql.language.property.IProperty;
-import com.raizlabs.android.dbflow.structure.Model;
 import com.raizlabs.android.dbflow.structure.database.DatabaseWrapper;
 
 /**
@@ -17,11 +16,6 @@ public abstract class IndexMigration<TModel> extends BaseMigration {
      * The table to index on
      */
     private Class<TModel> onTable;
-
-    /**
-     * The name of this index
-     */
-    private String name;
 
     /**
      * The underlying index object.
@@ -50,7 +44,6 @@ public abstract class IndexMigration<TModel> extends BaseMigration {
     @Override
     public void onPostMigrate() {
         onTable = null;
-        name = null;
         index = null;
     }
 
@@ -80,7 +73,7 @@ public abstract class IndexMigration<TModel> extends BaseMigration {
      */
     public Index<TModel> getIndex() {
         if (index == null) {
-            index = new Index<TModel>(name).on(onTable);
+            index = new Index<TModel>(getName()).on(onTable);
         }
         return index;
     }
@@ -91,5 +84,4 @@ public abstract class IndexMigration<TModel> extends BaseMigration {
     public String getIndexQuery() {
         return getIndex().getQuery();
     }
-
 }


### PR DESCRIPTION
Properly use the getName() method that subclasses have the implement.
No need to keep a 'name' member around for this purpose. Re-enable
previously broken test.