### PR TITLE
Reset Single DB: close insert statements

### DIFF
--- a/dbflow-tests/src/test/java/com/raizlabs/android/dbflow/test/config/ResetModel.kt
+++ b/dbflow-tests/src/test/java/com/raizlabs/android/dbflow/test/config/ResetModel.kt
@@ -1,0 +1,24 @@
+package com.raizlabs.android.dbflow.test.sql.unique
+
+import com.raizlabs.android.dbflow.annotation.Column
+import com.raizlabs.android.dbflow.annotation.ConflictAction
+import com.raizlabs.android.dbflow.annotation.PrimaryKey
+import com.raizlabs.android.dbflow.annotation.Table
+import com.raizlabs.android.dbflow.annotation.Unique
+import com.raizlabs.android.dbflow.annotation.UniqueGroup
+import com.raizlabs.android.dbflow.structure.BaseModel
+import com.raizlabs.android.dbflow.test.TestDatabase
+
+/**
+ * Description:
+ */
+@Table(database = TestDatabase::class)
+class ResetModel : BaseModel() {
+
+    @Column
+    @PrimaryKey(autoincrement = true)
+    var id: Long = 0
+
+    @Column
+    var name: String? = null
+}

--- a/dbflow-tests/src/test/java/com/raizlabs/android/dbflow/test/config/ResetTest.kt
+++ b/dbflow-tests/src/test/java/com/raizlabs/android/dbflow/test/config/ResetTest.kt
@@ -1,0 +1,31 @@
+package com.raizlabs.android.dbflow.test.config
+
+import com.raizlabs.android.dbflow.config.FlowManager
+import com.raizlabs.android.dbflow.sql.language.SQLite
+import com.raizlabs.android.dbflow.test.FlowTestCase
+import com.raizlabs.android.dbflow.test.TestDatabase
+import com.raizlabs.android.dbflow.test.sql.unique.ResetModel
+import junit.framework.Assert.assertEquals
+import org.junit.Test
+
+class ResetTest : FlowTestCase() {
+
+    @Test
+    fun test_resetSingleDatabase() {
+
+        var aModel = ResetModel()
+        aModel.name = "bob"
+        aModel.insert()
+        assertEquals(1, SQLite.select().from(ResetModel::class.java).count())
+
+
+        FlowManager.getDatabase(TestDatabase::class.java).reset(context)
+        assertEquals(0, SQLite.select().from(ResetModel::class.java).count())
+
+        aModel = ResetModel()
+        aModel.name = "fred"
+        aModel.insert()
+        assertEquals(1, SQLite.select().from(ResetModel::class.java).count())
+
+    }
+}

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/config/DatabaseDefinition.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/config/DatabaseDefinition.java
@@ -274,6 +274,9 @@ public abstract class DatabaseDefinition {
             isResetting = true;
             getTransactionManager().stopQueue();
             getHelper().closeDB();
+            for (ModelAdapter modelAdapter : modelAdapters.values()) {
+                modelAdapter.closeInsertStatement();
+            }
             context.deleteDatabase(getDatabaseFileName());
 
             // recreate queue after interrupting it.

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/config/DatabaseDefinition.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/config/DatabaseDefinition.java
@@ -276,6 +276,7 @@ public abstract class DatabaseDefinition {
             getHelper().closeDB();
             for (ModelAdapter modelAdapter : modelAdapters.values()) {
                 modelAdapter.closeInsertStatement();
+                modelAdapter.closeCompiledStatement();
             }
             context.deleteDatabase(getDatabaseFileName());
 

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/ModelAdapter.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/ModelAdapter.java
@@ -55,6 +55,14 @@ public abstract class ModelAdapter<TModel> extends InstanceAdapter<TModel>
         return insertStatement;
     }
 
+    public void closeInsertStatement() {
+        if (insertStatement == null) {
+            return;
+        }
+        insertStatement.close();
+        insertStatement = null;
+    }
+
     /**
      * @param databaseWrapper The database used to do an insert statement.
      * @return a new compiled {@link DatabaseStatement} representing insert. Not cached, always generated.

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/ModelAdapter.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/ModelAdapter.java
@@ -84,6 +84,14 @@ public abstract class ModelAdapter<TModel> extends InstanceAdapter<TModel>
         return compiledStatement;
     }
 
+    public void closeCompiledStatement() {
+        if (compiledStatement == null) {
+            return;
+        }
+        compiledStatement.close();
+        compiledStatement = null;
+    }
+
     /**
      * @param databaseWrapper The database used to do an insert statement.
      * @return a new compiled {@link DatabaseStatement} representing insert.


### PR DESCRIPTION
In our app, I wanted to wipe out all data in the database and then start again right away without having to add each Model class to a Delete (so that as we add models, we don't have to remember to add them there). When trying to reset the database and then use it again, I got errors saying the database was closed. I was able to reproduce this with the test I added in this PR. The database objects weren't fully released since the ModelAdapter was still holding a reference to the InsertStatement. So, as part of reset, we close the statement (our impl of SQLite's finalizers don't like the statement to not be closed) and set it to null.