### PR TITLE
Database filename getter

### DIFF
--- a/dbflow-core/src/main/java/com/raizlabs/android/dbflow/annotation/Database.java
+++ b/dbflow-core/src/main/java/com/raizlabs/android/dbflow/annotation/Database.java
@@ -36,6 +36,11 @@ public @interface Database {
     String databaseExtension() default "";
 
     /**
+     * @return The filename of the DB. If not specified it assume the default value.
+     */
+    String fileName() default "";
+
+    /**
      * @return If true, SQLite will throw exceptions when {@link ForeignKey} constraints are not respected.
      * Default is false and will not throw exceptions.
      */


### PR DESCRIPTION
Added ability to annotate a custom method to specify the database filename getter.

With this you can add a custom database annotation with a static application method for example: "MyApplication.instance.getCustomDatabaseFileName()"
and add this annotation to database class as string.

After that I've added a custom DatabaseDefinition method that can enable a soft database closure, thanks to you can have ability to switch from a database to other simply closing it and reinit DBFlow.