### PR TITLE
Ability to annotate a custom method to specify the database filename

### DIFF
--- a/dbflow-core/src/main/java/com/raizlabs/android/dbflow/annotation/Database.java
+++ b/dbflow-core/src/main/java/com/raizlabs/android/dbflow/annotation/Database.java
@@ -36,6 +36,11 @@ public @interface Database {
     String databaseExtension() default "";
 
     /**
+     * @return The filename of the DB. If not specified it assume the default value.
+     */
+    String fileName() default "";
+
+    /**
      * @return If true, SQLite will throw exceptions when {@link ForeignKey} constraints are not respected.
      * Default is false and will not throw exceptions.
      */

--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/DatabaseDefinition.kt
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/DatabaseDefinition.kt
@@ -50,6 +50,8 @@ class DatabaseDefinition(manager: ProcessorManager, element: Element) : BaseDefi
 
     var databaseExtensionName = ""
 
+    var databaseFileName = ""
+
     init {
         packageName = ClassNames.FLOW_MANAGER_PACKAGE
 
@@ -232,6 +234,14 @@ class DatabaseDefinition(manager: ProcessorManager, element: Element) : BaseDefi
                     .addStatement("return \$S", databaseExtensionName)
                     .returns(String::class.java)
                     .build())
+        }
+
+        if (databaseFileName.isNullOrBlank().not()) {
+            typeBuilder.addMethod(MethodSpec.methodBuilder("getDatabaseFileName")
+                .addAnnotation(Override::class.java).addModifiers(DatabaseHandler.METHOD_MODIFIERS)
+                .addStatement("return " + databaseFileName)
+                .returns(String::class.java)
+                .build())
         }
     }
 

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/config/DatabaseDefinition.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/config/DatabaseDefinition.java
@@ -313,6 +313,18 @@ public abstract class DatabaseDefinition {
     }
 
     /**
+     * Performs Only database closing without reopen it.
+     *
+     */
+    public void close() {
+        getTransactionManager().stopQueue();
+        getHelper().closeDB();
+
+        openHelper = null;
+        isResetting = false;
+    }
+
+    /**
      * @return True if the database is ok. If backups are enabled, we restore from backup and will
      * override the return value if it replaces the main DB.
      */


### PR DESCRIPTION
With this you can add a custom database annotation with a static application method for example: "MyApplication.instance.getCustomDatabaseFileName()"
and add this annotation to database class as string.

After that I've added a custom DatabaseDefinition method that can enable a soft database closure, thanks to you can have ability to switch from a database to other simply closing it and reinit DBFlow.