### PR TITLE
Add option to defer foreign key constraints

### DIFF
--- a/dbflow-core/src/main/java/com/raizlabs/android/dbflow/annotation/ForeignKey.java
+++ b/dbflow-core/src/main/java/com/raizlabs/android/dbflow/annotation/ForeignKey.java
@@ -30,7 +30,7 @@ public @interface ForeignKey {
 
     /**
      * @return Default false. When this column is a {@link ForeignKey} and table object,
-     * returning true will delte the model before deleting its enclosing child class.
+     * returning true will delete the model before deleting its enclosing child class.
      * If false, we expect the field to not change and must delete the model manually outside
      * of the ModelAdapter before saving the child class.
      */
@@ -66,4 +66,11 @@ public @interface ForeignKey {
      * @return {@link ForeignKeyAction}
      */
     ForeignKeyAction onUpdate() default ForeignKeyAction.NO_ACTION;
+
+    /**
+     * @return Default false. Only takes effect when foreignKeyConstraintsEnforced = true for the
+     * enclosing database. When true, foreign key constraints are enforced when transactions are
+     * committed. When false, foreign key constraints are enforced immediately.
+     */
+    boolean deferrable() default false;
 }

--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/Methods.kt
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/Methods.kt
@@ -220,6 +220,10 @@ class CreationQueryMethod(private val tableDefinition: TableDefinition) : Method
                 }
                 referenceBuilder.add(") ON UPDATE \$L ON DELETE \$L", foreignKeyColumnDefinition.onUpdate.name.replace("_", " "),
                     foreignKeyColumnDefinition.onDelete.name.replace("_", " "))
+
+                if (foreignKeyColumnDefinition.deferrable) {
+                    referenceBuilder.add(" DEFERRABLE INITIALLY DEFERRED")
+                }
                 referenceKeyBlocks.add(referenceBuilder.build())
             }
 

--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/column/ForeignKeyColumnDefinition.kt
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/column/ForeignKeyColumnDefinition.kt
@@ -46,6 +46,8 @@ class ForeignKeyColumnDefinition(manager: ProcessorManager, tableDefinition: Tab
     var saveForeignKeyModel: Boolean = false
     var deleteForeignKeyModel: Boolean = false
 
+    var deferrable: Boolean = false
+
     var needsReferences = true
 
     override val typeConverterElementNames: List<TypeName?>
@@ -56,6 +58,7 @@ class ForeignKeyColumnDefinition(manager: ProcessorManager, tableDefinition: Tab
         val foreignKey = element.getAnnotation(ForeignKey::class.java)
         onUpdate = foreignKey.onUpdate
         onDelete = foreignKey.onDelete
+        deferrable = foreignKey.deferrable
 
         isStubbedRelationship = foreignKey.stubbedRelationship
 


### PR DESCRIPTION
Adds option to `@ForeignKey` annotation to allow `DEFERRABLE` enforcement of constraints. [SQLite docs](https://sqlite.org/foreignkeys.html#fk_deferred)