### PR TITLE
Rx2 extension: Fixed issue with incorrect emitting data in the RXSQLi…

### DIFF
--- a/dbflow-rx2/src/main/java/com/raizlabs/android/dbflow/rx2/language/RXModelQueriable.java
+++ b/dbflow-rx2/src/main/java/com/raizlabs/android/dbflow/rx2/language/RXModelQueriable.java
@@ -100,6 +100,8 @@ public interface RXModelQueriable<TModel> extends RXQueriable {
 
     /**
      * @return A new {@link Observable} that observes when the {@link TModel} table changes.
+     * Result Flowable may emmit the data in the thread another then current thread or subscribeOn(), because
+     * notification from ContentResolver about data changes comes from Binder thread.
      * This can also be multiple tables, given if it results from a {@link Join} (one for each join table).
      */
     @NonNull

--- a/dbflow-rx2/src/main/java/com/raizlabs/android/dbflow/rx2/language/RXModelQueriableImpl.java
+++ b/dbflow-rx2/src/main/java/com/raizlabs/android/dbflow/rx2/language/RXModelQueriableImpl.java
@@ -2,6 +2,8 @@ package com.raizlabs.android.dbflow.rx2.language;
 
 import android.support.annotation.NonNull;
 
+import com.raizlabs.android.dbflow.config.FlowLog;
+import com.raizlabs.android.dbflow.list.FlowCursorIterator;
 import com.raizlabs.android.dbflow.list.FlowCursorList;
 import com.raizlabs.android.dbflow.list.FlowQueryList;
 import com.raizlabs.android.dbflow.sql.language.BaseModelQueriable;
@@ -14,6 +16,8 @@ import java.util.concurrent.Callable;
 
 import io.reactivex.BackpressureStrategy;
 import io.reactivex.Flowable;
+import io.reactivex.FlowableEmitter;
+import io.reactivex.FlowableOnSubscribe;
 import io.reactivex.Single;
 
 import static io.reactivex.Single.fromCallable;

--- a/dbflow-rx2/src/main/java/com/raizlabs/android/dbflow/rx2/language/RXModelQueriableImpl.java
+++ b/dbflow-rx2/src/main/java/com/raizlabs/android/dbflow/rx2/language/RXModelQueriableImpl.java
@@ -25,7 +25,7 @@ import static io.reactivex.Single.fromCallable;
 /**
  * Description: Represents {@link BaseModelQueriable} in RX form.
  */
-public class RXModelQueriableImpl<T> extends RXQueriableImpl<T>
+public class RXModelQueriableImpl<T> extends RXQueriableImpl
         implements RXModelQueriable<T> {
 
     private final ModelQueriable<T> modelQueriable;

--- a/dbflow-rx2/src/main/java/com/raizlabs/android/dbflow/rx2/language/RXQueriableImpl.java
+++ b/dbflow-rx2/src/main/java/com/raizlabs/android/dbflow/rx2/language/RXQueriableImpl.java
@@ -18,12 +18,12 @@ import static io.reactivex.Single.fromCallable;
 /**
  * Description: Represents {@link BaseQueriable} with RX constructs.
  */
-public class RXQueriableImpl<T> implements RXQueriable {
+public class RXQueriableImpl implements RXQueriable {
 
-    private final Class<T> table;
+    private final Class<?> table;
     private final Queriable queriable;
 
-    public RXQueriableImpl(Class<T> table, Queriable queriable) {
+    public RXQueriableImpl(Class<?> table, Queriable queriable) {
         this.table = table;
         this.queriable = queriable;
     }

--- a/dbflow-rx2/src/main/java/com/raizlabs/android/dbflow/rx2/language/RXSQLite.java
+++ b/dbflow-rx2/src/main/java/com/raizlabs/android/dbflow/rx2/language/RXSQLite.java
@@ -11,15 +11,13 @@ import com.raizlabs.android.dbflow.sql.queriable.Queriable;
  * with {@link SQLite}.
  */
 public class RXSQLite {
-
     @NonNull
     public static <T> RXModelQueriableImpl<T> rx(ModelQueriable<T> modelQueriable) {
         return new RXModelQueriableImpl<>(modelQueriable);
     }
 
     @NonNull
-    public static <T> RXQueriableImpl<T> rx(Class<T> table, Queriable queriable) {
-        return new RXQueriableImpl<>(table, queriable);
+    public static RXQueriableImpl rx(Class<?> table, Queriable queriable) {
+        return new RXQueriableImpl(table, queriable);
     }
-
 }

--- a/dbflow-rx2/src/main/java/com/raizlabs/android/dbflow/rx2/language/TableChangeOnSubscribe.java
+++ b/dbflow-rx2/src/main/java/com/raizlabs/android/dbflow/rx2/language/TableChangeOnSubscribe.java
@@ -31,7 +31,7 @@ public class TableChangeOnSubscribe<TModel> implements FlowableOnSubscribe<Model
 
     @Override
     public void subscribe(FlowableEmitter<ModelQueriable<TModel>> e) throws Exception {
-        flowableEmitter = e;
+        flowableEmitter = e.serialize();
         flowableEmitter.setDisposable(Disposables.fromRunnable(new Runnable() {
             @Override
             public void run() {

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/runtime/FlowContentObserver.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/runtime/FlowContentObserver.java
@@ -71,7 +71,7 @@ public class FlowContentObserver extends ContentObserver {
 
         /**
          * Notifies that the state of a {@link Model}
-         * has changed for the table this is registered for.
+         * has changed for the table this is registered for. This method can be called from the thread another then main thread.
          *
          * @param table            The table that this change occurred on. This is ONLY available on {@link VERSION_CODES#JELLY_BEAN}
          *                         and up.
@@ -89,7 +89,7 @@ public class FlowContentObserver extends ContentObserver {
     public interface OnTableChangedListener {
 
         /**
-         * Called when table changes.
+         * Called when table changes. This method can be called from the thread another then main thread.
          *
          * @param tableChanged The table that has changed. NULL unless version of app is {@link VERSION_CODES#JELLY_BEAN}
          *                     or higher.


### PR DESCRIPTION
…te.rx(...) -> RXModelQueriableImpl.queryResults()

The calling CursorResultFlowable.CursorResultObserver.disposable.isDisposed() returns true all the time.

Explanation:
In the CursorResultFlowable.CursorResultObserver the Disposable object is always disposed because it is created by SingleFromCallable when calling RXModelQueriableImpl.queryResults().  The SingleFromCallable.subscribeActual(SingleObserver) calls singleObserver.onSubscribe(EmptyDisposable.INSTANCE) wich is in state disposed befor callin singleObserver.onSuccess(v). In our case the singleObserver is CursorResultObserver (nestet class of the CursorResultFlowable).