### PR TITLE
fix to #1365.  Support Java @ModelView classes.

### DIFF
--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/ModelViewDefinition.kt
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/ModelViewDefinition.kt
@@ -103,10 +103,6 @@ class ModelViewDefinition(manager: ProcessorManager, element: Element) : BaseTab
                 val columnDefinition = ColumnDefinition(manager, variableElement, this, isPackagePrivateNotInSamePackage)
                 if (columnValidator.validate(manager, columnDefinition)) {
                     columnDefinitions.add(columnDefinition)
-
-                    if (isPackagePrivate) {
-                        columnDefinitions.add(columnDefinition)
-                    }
                 }
 
                 if (columnDefinition.isPrimaryKey || columnDefinition is ForeignKeyColumnDefinition

--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/ModelViewDefinition.kt
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/ModelViewDefinition.kt
@@ -103,6 +103,9 @@ class ModelViewDefinition(manager: ProcessorManager, element: Element) : BaseTab
                 val columnDefinition = ColumnDefinition(manager, variableElement, this, isPackagePrivateNotInSamePackage)
                 if (columnValidator.validate(manager, columnDefinition)) {
                     columnDefinitions.add(columnDefinition)
+                    if (isPackagePrivate) {
+                        packagePrivateList.add(columnDefinition)
+                    }
                 }
 
                 if (columnDefinition.isPrimaryKey || columnDefinition is ForeignKeyColumnDefinition

--- a/dbflow-tests/src/test/java/com/raizlabs/android/dbflow/models/ModelViewTest.kt
+++ b/dbflow-tests/src/test/java/com/raizlabs/android/dbflow/models/ModelViewTest.kt
@@ -2,6 +2,7 @@ package com.raizlabs.android.dbflow.models
 
 import com.raizlabs.android.dbflow.BaseUnitTest
 import com.raizlabs.android.dbflow.assertEquals
+import com.raizlabs.android.dbflow.models.java.JavaModelView
 import org.junit.Test
 
 class ModelViewTest : BaseUnitTest() {
@@ -10,5 +11,10 @@ class ModelViewTest : BaseUnitTest() {
     fun validateModelViewQuery() {
         assertEquals("SELECT `id` AS `authorId`,`first_name` || ' ' || `last_name` AS `authorName` FROM `Author`",
             AuthorView.query)
+    }
+
+    @Test
+    fun validateJavaModelViewQuery() {
+        assertEquals("SELECT `first_name` AS `firstName`,`id` AS `id`", JavaModelView.QUERY)
     }
 }

--- a/dbflow-tests/src/test/java/com/raizlabs/android/dbflow/models/java/JavaModelView.java
+++ b/dbflow-tests/src/test/java/com/raizlabs/android/dbflow/models/java/JavaModelView.java
@@ -1,0 +1,26 @@
+package com.raizlabs.android.dbflow.models.java;
+
+import com.raizlabs.android.dbflow.TestDatabase;
+import com.raizlabs.android.dbflow.annotation.Column;
+import com.raizlabs.android.dbflow.annotation.ModelView;
+import com.raizlabs.android.dbflow.annotation.ModelViewQuery;
+import com.raizlabs.android.dbflow.models.Author_Table;
+import com.raizlabs.android.dbflow.sql.Query;
+import com.raizlabs.android.dbflow.sql.language.SQLite;
+
+@ModelView(database = TestDatabase.class)
+public class JavaModelView {
+
+    @ModelViewQuery
+    public static final Query QUERY = getQuery();
+
+    @Column
+    String id;
+
+    @Column
+    Integer firstName;
+
+    private static Query getQuery() {
+        return SQLite.select(Author_Table.first_name.as("firstName"), Author_Table.id.as("id"));
+    }
+}


### PR DESCRIPTION
fix to #1365, plus unit test.  @ModelView for java classes' _ViewTable.java would not compile since the column was duplicated.
