### PR TITLE
allow model to use byte array for blob type, using a simple TypeConverter

### DIFF
--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/column/ColumnAccessCombiner.kt
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/column/ColumnAccessCombiner.kt
@@ -182,7 +182,12 @@ class SqliteStatementAccessCombiner(combiner: Combiner)
                         statement("statement.bind$statementMethod($offset, $defaultValue)")
                     }
                 } else {
-                    statement("statement.bind${wrapperMethod}OrNull($offset, $subWrapperFieldAccess)")
+                    if (subWrapperAccessor != null) {
+                        statement("statement.bind${wrapperMethod}OrNull($offset, $fieldAccess != null ? $subWrapperFieldAccess : null)")
+                    } else {
+                        statement("statement.bind${wrapperMethod}OrNull($offset, $subWrapperFieldAccess)")
+                    }
+
                 }
             }
         }

--- a/dbflow-tests/src/test/java/com/raizlabs/android/dbflow/models/SimpleTestModels.kt
+++ b/dbflow-tests/src/test/java/com/raizlabs/android/dbflow/models/SimpleTestModels.kt
@@ -78,6 +78,7 @@ class OrderCursorModel(@PrimaryKey var id: Int = 0, @Column var name: String? = 
 
 @Table(database = TestDatabase::class)
 class TypeConverterModel(@PrimaryKey var id: Int = 0,
+                         @Column(typeConverter = BlobConverter::class) var opaqueData: ByteArray? = null,
                          @Column var blob: Blob? = null,
                          @Column(typeConverter = CustomTypeConverter::class)
                          @PrimaryKey var customType: CustomType? = null)
@@ -154,6 +155,18 @@ class CustomEnumTypeConverter : TypeConverter<String, Difficulty>() {
         else -> Difficulty.HARD
     }
 
+}
+
+@com.raizlabs.android.dbflow.annotation.TypeConverter
+class BlobConverter : TypeConverter<Blob, ByteArray>() {
+
+    override fun getDBValue(model: ByteArray?): Blob? {
+        return if (model == null) null else Blob(model)
+    }
+
+    override fun getModelValue(data: Blob?): ByteArray? {
+        return data?.blob
+    }
 }
 
 @Table(database = TestDatabase::class)


### PR DESCRIPTION
Fix for #1385, assuming I understood the issue correctly. 