### PR TITLE
Fix processor api dependencies

### DIFF
--- a/dbflow-processor/build.gradle
+++ b/dbflow-processor/build.gradle
@@ -7,10 +7,10 @@ targetCompatibility = JavaVersion.VERSION_1_8
 sourceCompatibility = JavaVersion.VERSION_1_8
 
 dependencies {
-    implementation project("${dbflow_project_prefix}dbflow-core")
-    implementation 'com.squareup:javapoet:1.9.0'
-    implementation 'com.github.agrosner:KPoet:1.0.0'
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlin_version"
+    api project("${dbflow_project_prefix}dbflow-core")
+    api 'com.squareup:javapoet:1.9.0'
+    api 'com.github.agrosner:KPoet:1.0.0'
+    api "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlin_version"
 
     compileOnly 'org.glassfish:javax.annotation:10.0-b28'
 


### PR DESCRIPTION
These dependencies were marked as implementation in 2ca1a17, however
it forces the user to explicitely include these in the processor path.
The user should not be concerned with these things in case of a
processor, so these should be marked as API.

https://github.com/Raizlabs/DBFlow/issues/1417