### PR TITLE
allow cast directly to variable type

### DIFF
--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/AsyncModel.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/AsyncModel.java
@@ -155,9 +155,9 @@ public class AsyncModel<TModel> extends BaseAsyncObject<AsyncModel<TModel>> impl
      */
     @NonNull
     @Override
-    public AsyncModel<? extends Model> async() {
+    public <TModel extends Model> AsyncModel<TModel> async() {
         //noinspection unchecked
-        return (AsyncModel<? extends Model>) this;
+        return (AsyncModel<TModel>) this;
     }
 
     @Override

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/BaseModel.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/BaseModel.java
@@ -110,8 +110,8 @@ public class BaseModel implements Model {
 
     @NonNull
     @Override
-    public AsyncModel<? extends Model> async() {
-        return new AsyncModel<>(this);
+    public <TModel extends Model> AsyncModel<TModel> async() {
+        return new AsyncModel<>((TModel) this);
     }
 
     /**

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/Model.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/Model.java
@@ -72,6 +72,6 @@ public interface Model extends ReadOnlyModel {
      * @return An async instance of this model where all transactions are on the {@link DefaultTransactionQueue}
      */
     @NonNull
-    AsyncModel<? extends Model> async();
+    <TModel extends Model> AsyncModel<TModel> async();
 
 }


### PR DESCRIPTION
make async() return `AsyncModel<TModel>` instead of `AsyncModel<? extends Model>`.
this way client codes doesn't have to cast the AsyncModel to specific class (for example, `AsyncMode<Book>`.