### PR TITLE
Optionally Configure Table Alias in @Table

### DIFF
--- a/dbflow-core/src/main/java/com/raizlabs/android/dbflow/annotation/Table.java
+++ b/dbflow-core/src/main/java/com/raizlabs/android/dbflow/annotation/Table.java
@@ -23,6 +23,11 @@ public @interface Table {
     String name() default "";
 
     /**
+     * @return the alias that will be used for all queries, unless overridden by withTable()
+     */
+    String tableAlias() default "";
+
+    /**
      * @return Specify the database class that this table belongs to. It must have the {@link Database} annotation.
      */
     Class<?> database();

--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/ClassNames.kt
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/ClassNames.kt
@@ -70,6 +70,7 @@ object ClassNames {
     val OPERATOR_GROUP = ClassName.get(LANGUAGE, "OperatorGroup")
 
     val ICONDITIONAL = ClassName.get(LANGUAGE, "IConditional")
+    val NAMEALIAS = ClassName.get(LANGUAGE, "NameAlias")
 
     val BASE_CONTENT_PROVIDER = ClassName.get(RUNTIME, "BaseContentProvider")
 

--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/TableDefinition.kt
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/TableDefinition.kt
@@ -68,6 +68,8 @@ class TableDefinition(manager: ProcessorManager, element: TypeElement) : BaseTab
 
     var tableName: String? = null
 
+    var tableAlias: String? = null
+
     var insertConflictActionName: String = ""
 
     var updateConflictActionName: String = ""
@@ -123,6 +125,8 @@ class TableDefinition(manager: ProcessorManager, element: TypeElement) : BaseTab
             } catch (mte: MirroredTypeException) {
                 databaseTypeName = TypeName.get(mte.typeMirror)
             }
+
+            this.tableAlias = table.tableAlias
 
             cachingEnabled = table.cachingEnabled
             cacheSize = table.cacheSize
@@ -379,6 +383,11 @@ class TableDefinition(manager: ProcessorManager, element: TypeElement) : BaseTab
             `override fun`(String::class, "getTableName") {
                 modifiers(public, final)
                 `return`(QueryBuilder.quote(tableName).S)
+            }
+
+            `override fun`(String::class, "getTableAlias") {
+                modifiers(public, final)
+                `return`(QueryBuilder.quote(tableAlias).S)
             }
 
             `override fun`(elementClassName!!, "newInstance") {

--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/column/ColumnDefinition.kt
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/column/ColumnDefinition.kt
@@ -314,9 +314,17 @@ constructor(processorManager: ProcessorManager, element: Element,
             val fieldBuilder = FieldSpec.builder(propParam,
                 propertyFieldName, Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL)
 
+            val tableAlias = (baseTableDefinition as? TableDefinition)?.tableAlias
+            val codeBlock = CodeBlock.builder()
+            codeBlock.add("new \$T(\$T.class, ", propParam, tableClass)
+            if (tableAlias != null && tableAlias.isNotBlank()) {
+                codeBlock.add("\$T.builder(\$S).withTable(\$T.of(\$S).getQuery()).build()", ClassNames.NAMEALIAS, columnName, ClassNames.NAMEALIAS, tableAlias)
+            } else {
+                codeBlock.add("\$S", columnName)
+            }
+
             if (isNonPrimitiveTypeConverter) {
-                val codeBlock = CodeBlock.builder()
-                codeBlock.add("new \$T(\$T.class, \$S, true,", propParam, tableClass, columnName)
+                codeBlock.add(", true,")
                 codeBlock.add("\nnew \$T() {" +
                     "\n@Override" +
                     "\npublic \$T getTypeConverter(Class<?> modelClass) {" +
@@ -327,10 +335,10 @@ constructor(processorManager: ProcessorManager, element: Element,
                     baseTableDefinition.outputClassName, baseTableDefinition.outputClassName,
                     ClassNames.FLOW_MANAGER,
                     (wrapperAccessor as TypeConverterScopeColumnAccessor).typeConverterFieldName)
-                fieldBuilder.initializer(codeBlock.build())
             } else {
-                fieldBuilder.initializer("new \$T(\$T.class, \$S)", propParam, tableClass, columnName)
+                codeBlock.add(")")
             }
+            fieldBuilder.initializer(codeBlock.build())
             if (isPrimaryKey) {
                 fieldBuilder.addJavadoc("Primary Key")
             } else if (isPrimaryKeyAutoIncrement) {

--- a/dbflow-tests/src/test/java/com/raizlabs/android/dbflow/TableAliasTest.kt
+++ b/dbflow-tests/src/test/java/com/raizlabs/android/dbflow/TableAliasTest.kt
@@ -1,0 +1,69 @@
+package com.raizlabs.android.dbflow
+
+import com.raizlabs.android.dbflow.annotation.Column
+import com.raizlabs.android.dbflow.annotation.PrimaryKey
+import com.raizlabs.android.dbflow.annotation.Table
+import com.raizlabs.android.dbflow.kotlinextensions.*
+import org.junit.Test
+import com.raizlabs.android.dbflow.AliasedTable_Table.columnOne
+import com.raizlabs.android.dbflow.AliasedTable_Table.columnTwo
+import com.raizlabs.android.dbflow.AnotherAliasedTable_Table.anotherColumnOne
+import com.raizlabs.android.dbflow.kotlinextensions.innerJoin
+import com.raizlabs.android.dbflow.sql.language.NameAlias
+import com.raizlabs.android.dbflow.sql.language.SQLite.select
+
+class TableAliasTest : BaseUnitTest() {
+
+    @Test
+    fun testQueryWithTableAlias() {
+        assertEquals(
+            "SELECT `at`.`columnOne`,`at`.`columnTwo` FROM `AliasedTable` AS `at`",
+            select(columnOne, columnTwo) from AliasedTable::class
+        )
+    }
+
+    @Test
+    fun testQueryWithTableAliasAndWithTableCall() {
+        // show you can override and use withTable
+        assertEquals(
+            "SELECT `AliasedTable`.`columnOne`,`AliasedTable`.`columnTwo` FROM `AliasedTable`",
+            select(columnOne.withTable(), columnTwo.withTable()).from(AliasedTable::class).`as`("")
+        )
+    }
+
+    @Test
+    fun testQueryWithTableAliasAndWithTableColumnAliasCall() {
+        // show you can override with custom alias when you want
+        val alias: NameAlias = NameAlias.of("at2")
+        assertEquals(
+            "SELECT `at2`.`columnOne`,`at2`.`columnTwo` FROM `AliasedTable` AS `at2`",
+            select(columnOne.withTable(alias), columnTwo.withTable(alias)).from(AliasedTable::class).`as`("at2")
+        )
+    }
+
+    @Test
+    fun testJoinWithTableAlias() {
+
+        assertEquals (
+            "SELECT `at`.`columnOne`,`aat`.`anotherColumnOne` FROM `AliasedTable` AS `at` INNER JOIN `AnotherAliasedTable` AS `aat` ON `at`.`anotherId`=`aat`.`id`",
+            select(columnOne, anotherColumnOne)
+                from AliasedTable::class
+                innerJoin AnotherAliasedTable::class
+                on AliasedTable_Table.anotherId.eq(AnotherAliasedTable_Table.id)
+        )
+    }
+}
+
+@Table(database = TestDatabase::class, tableAlias = "at")
+class AliasedTable(
+    @PrimaryKey(autoincrement = true) var id: Int = 0,
+    @Column() var columnOne: String = "",
+    @Column() var columnTwo: String = "",
+    @Column() var anotherId: Int = 0
+)
+
+@Table(database = TestDatabase::class, tableAlias = "aat")
+class AnotherAliasedTable(
+    @PrimaryKey(autoincrement = true) var id: Int = 0,
+    @Column() var anotherColumnOne: String = ""
+)

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/From.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/From.java
@@ -54,6 +54,11 @@ public class From<TModel> extends BaseTransformable<TModel> {
     public From(@NonNull Query querybase, @NonNull Class<TModel> table) {
         super(table);
         queryBase = querybase;
+        String tableAlias = FlowManager.getModelAdapter(table).getTableAlias().trim();
+        if (tableAlias.length() > 0) {
+            as(tableAlias);
+        }
+
     }
 
     /**

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/Join.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/Join.java
@@ -86,7 +86,12 @@ public class Join<TModel, TFromModel> implements Query {
         this.from = from;
         this.table = table;
         type = joinType;
-        alias = new NameAlias.Builder(FlowManager.getTableName(table)).build();
+        NameAlias.Builder builder = new NameAlias.Builder(FlowManager.getTableName(table));
+        String tableAlias = FlowManager.getModelAdapter(table).getTableAlias().trim();
+        if (tableAlias.length() > 0) {
+            builder.as(tableAlias);
+        }
+        alias = builder.build();
     }
 
     public Join(@NonNull From<TFromModel> from, @NonNull JoinType joinType,

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/InternalAdapter.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/InternalAdapter.java
@@ -24,6 +24,12 @@ public interface InternalAdapter<TModel> {
     String getTableName();
 
     /**
+     * @return The table alias of this adapter.
+     */
+    @NonNull
+    String getTableAlias();
+
+    /**
      * Saves the specified model to the DB.
      *
      * @param model The model to save/insert/update


### PR DESCRIPTION
We have a lot of queries that do a lot of joining.  To remove any ambiguity between columns, especially id columns, we always use withTable() on each property and as() for each table.  To shorten the generated SQL we see in our logs, we pass a NameAlias to withTable() and as().  This ends up cluttering our code quite a bit, so this PR makes it so we can optionally add a table alias in the @Table configuration that would get used in all queries, etc.  It can of course still be overridden case by case using the withTable() and as() functions.  If it is not provided in @Table, then it's business as usual.

Thoughts @agrosner?