### PR TITLE
query with custom adapter

### DIFF
--- a/dbflow-tests/src/test/java/com/raizlabs/android/dbflow/sql/queriable/QueryCustomListTest.kt
+++ b/dbflow-tests/src/test/java/com/raizlabs/android/dbflow/sql/queriable/QueryCustomListTest.kt
@@ -1,0 +1,39 @@
+package com.raizlabs.android.dbflow.sql.queriable
+
+import com.raizlabs.android.dbflow.sql.language.SQLite.*
+import com.raizlabs.android.dbflow.BaseUnitTest
+import com.raizlabs.android.dbflow.kotlinextensions.save
+import com.raizlabs.android.dbflow.models.Author
+import com.raizlabs.android.dbflow.models.Author_Table.*
+import org.junit.Assert
+import org.junit.Test
+
+class QueryCustomListTest : BaseUnitTest() {
+
+    @Test
+    fun test() {
+
+        Author ().apply {
+            firstName = "bob"
+            lastName = "ray"
+        }.save()
+
+        Author ().apply {
+            firstName = "bill"
+            lastName = "ray"
+        }.save()
+
+        Author ().apply {
+            firstName = "frank"
+            lastName = "sina"
+        }.save()
+
+        val authorIds =
+            select(id)
+            .from(Author::class.java)
+            .where(last_name.eq("ray"))
+            .queryCustomList({ flowCursor -> flowCursor.getIntOrDefault(0) })
+
+        Assert.assertEquals(2, authorIds.size)
+    }
+}

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/BaseQueriable.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/BaseQueriable.java
@@ -11,10 +11,14 @@ import com.raizlabs.android.dbflow.runtime.NotifyDistributor;
 import com.raizlabs.android.dbflow.sql.SqlUtils;
 import com.raizlabs.android.dbflow.sql.queriable.Queriable;
 import com.raizlabs.android.dbflow.structure.BaseModel;
+import com.raizlabs.android.dbflow.structure.FlowCursorCustomAdapter;
 import com.raizlabs.android.dbflow.structure.database.DatabaseStatement;
 import com.raizlabs.android.dbflow.structure.database.DatabaseStatementWrapper;
 import com.raizlabs.android.dbflow.structure.database.DatabaseWrapper;
 import com.raizlabs.android.dbflow.structure.database.FlowCursor;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Description: Base implementation of something that can be queried from the database.
@@ -105,6 +109,25 @@ public abstract class BaseQueriable<TModel> implements Queriable, Actionable {
             databaseWrapper.execSQL(query);
         }
         return null;
+    }
+
+    public <AnyType> List<AnyType> queryCustomList(FlowCursorCustomAdapter<AnyType> adapter) {
+        List<AnyType> list = new ArrayList<>();
+        FlowCursor cursor = null;
+        try {
+            cursor = query();
+            if (cursor == null) {
+                return list;
+            }
+            while (cursor.moveToNext()) {
+                list.add(adapter.loadFromCursor(cursor));
+            }
+        } finally {
+            if (cursor != null) {
+                cursor.close();
+            }
+        }
+        return list;
     }
 
     @Override

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/queriable/Queriable.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/queriable/Queriable.java
@@ -8,10 +8,13 @@ import com.raizlabs.android.dbflow.sql.language.Delete;
 import com.raizlabs.android.dbflow.sql.language.Insert;
 import com.raizlabs.android.dbflow.sql.language.Set;
 import com.raizlabs.android.dbflow.structure.BaseModel;
+import com.raizlabs.android.dbflow.structure.FlowCursorCustomAdapter;
 import com.raizlabs.android.dbflow.structure.Model;
 import com.raizlabs.android.dbflow.structure.database.DatabaseStatement;
 import com.raizlabs.android.dbflow.structure.database.DatabaseWrapper;
 import com.raizlabs.android.dbflow.structure.database.FlowCursor;
+
+import java.util.List;
 
 /**
  * Description: The most basic interface that some of the classes such as {@link Insert}, {@link ModelQueriable},
@@ -34,6 +37,15 @@ public interface Queriable extends Query {
     @Nullable
     FlowCursor query(@NonNull DatabaseWrapper databaseWrapper);
 
+    /**
+     * Allows the convenience of using DBFlow's wrapper language while using custom loading logic
+     * to result in any type, without the need for a QueryModel.  Useful especially for lists of
+     * results from a single column.
+     * @param adapter a functional interface to adapt the cursor rows to AnyType
+     * @param <AnyType> whatever type you want.  A Long, Integer, whatever.
+     * @return
+     */
+    <AnyType> List<AnyType> queryCustomList(FlowCursorCustomAdapter<AnyType> adapter);
 
     /**
      * @return A new {@link DatabaseStatement} from this query.

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/FlowCursorCustomAdapter.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/FlowCursorCustomAdapter.java
@@ -1,0 +1,8 @@
+package com.raizlabs.android.dbflow.structure;
+
+import com.raizlabs.android.dbflow.structure.database.FlowCursor;
+
+public interface FlowCursorCustomAdapter<AnyType> {
+
+    AnyType loadFromCursor(FlowCursor flowCursor);
+}


### PR DESCRIPTION
allow adapting of wrapper language query results to be handled in a custom way withOUT the need of query model, etc.