### PR TITLE
4.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Image](https://github.com/agrosner/DBFlow/blob/develop/dbflow_banner.png?raw=true)
 
-[![JitPack.io](https://img.shields.io/badge/JitPack.io-4.1.1-red.svg?style=flat)](https://jitpack.io/#Raizlabs/DBFlow) [![Android Weekly](http://img.shields.io/badge/Android%20Weekly-%23129-2CB3E5.svg?style=flat)](http://androidweekly.net/issues/issue-129) [![Android Arsenal](https://img.shields.io/badge/Android%20Arsenal-DBFlow-brightgreen.svg?style=flat)](https://android-arsenal.com/details/1/1134)
+[![JitPack.io](https://img.shields.io/badge/JitPack.io-4.2.0-red.svg?style=flat)](https://jitpack.io/#Raizlabs/DBFlow) [![Android Weekly](http://img.shields.io/badge/Android%20Weekly-%23129-2CB3E5.svg?style=flat)](http://androidweekly.net/issues/issue-129) [![Android Arsenal](https://img.shields.io/badge/Android%20Arsenal-DBFlow-brightgreen.svg?style=flat)](https://android-arsenal.com/details/1/1134)
 
 A robust, powerful, and very simple ORM android database library with **annotation processing**.
 
@@ -43,7 +43,7 @@ Add the library to the project-level build.gradle, using the apt plugin to enabl
 
   apply plugin: 'kotlin-kapt' // required for kotlin.
 
-  def dbflow_version = "4.1.1"
+  def dbflow_version = "4.2.0"
   // or dbflow_version = "develop-SNAPSHOT" for grabbing latest dependency in your project on the develop branch
   // or 10-digit short-hash of a specific commit. (Useful for bugs fixed in develop, but not in a release yet)
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.0-rc2'
+        classpath 'com.android.tools.build:gradle:3.0.1'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
         classpath 'com.getkeepsafe.dexcount:dexcount-gradle-plugin:0.7.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"

--- a/dbflow-tests/src/androidTest/java/com/raizlabs/android/dbflow/contentobserver/ContentObserverTest.kt
+++ b/dbflow-tests/src/androidTest/java/com/raizlabs/android/dbflow/contentobserver/ContentObserverTest.kt
@@ -16,7 +16,6 @@ import com.raizlabs.android.dbflow.sql.language.Delete
 import com.raizlabs.android.dbflow.sql.language.SQLOperator
 import com.raizlabs.android.dbflow.structure.BaseModel
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import java.util.concurrent.CountDownLatch
@@ -34,11 +33,12 @@ class ContentObserverTest : BaseInstrumentedUnitTest() {
     @Test
     fun testSpecificUris() {
         val conditionGroup = FlowManager.getModelAdapter(User::class.java)
-            .getPrimaryConditionClause(user)
-        val uri = SqlUtils.getNotificationUri(User::class.java, BaseModel.Action.DELETE,
-            conditionGroup.conditions.toTypedArray())
+                .getPrimaryConditionClause(user)
+        val uri = SqlUtils.getNotificationUri(FlowManager.DEFAULT_AUTHORITY,
+                User::class.java, BaseModel.Action.DELETE,
+                conditionGroup.conditions.toTypedArray())
 
-        assertEquals(uri.authority, FlowManager.getTableName(User::class.java))
+        assertEquals(uri.authority, FlowManager.DEFAULT_AUTHORITY)
         assertEquals(uri.fragment, BaseModel.Action.DELETE.name)
         assertEquals(Uri.decode(uri.getQueryParameter(Uri.encode(id.query))), "5")
         assertEquals(Uri.decode(uri.getQueryParameter(Uri.encode(name.query))), "Something")
@@ -69,7 +69,7 @@ class ContentObserverTest : BaseInstrumentedUnitTest() {
     }
 
     private fun assertProperConditions(action: BaseModel.Action, userFunc: (User) -> Unit) {
-        val contentObserver = FlowContentObserver()
+        val contentObserver = FlowContentObserver(FlowManager.DEFAULT_AUTHORITY)
         val countDownLatch = CountDownLatch(1)
         val mockOnModelStateChangedListener = MockOnModelStateChangedListener(countDownLatch)
         contentObserver.addModelChangeListener(mockOnModelStateChangedListener)
@@ -79,7 +79,7 @@ class ContentObserverTest : BaseInstrumentedUnitTest() {
         countDownLatch.await()
 
         val ops = mockOnModelStateChangedListener.operators!!
-        assertTrue(ops.size == 2)
+        assertEquals(2, ops.size)
         assertEquals(ops[0].columnName(), id.query)
         assertEquals(ops[1].columnName(), name.query)
         assertEquals(ops[1].value(), "Something")

--- a/dbflow-tests/src/main/AndroidManifest.xml
+++ b/dbflow-tests/src/main/AndroidManifest.xml
@@ -13,6 +13,10 @@
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
+
+        <provider
+            android:name="com.raizlabs.android.dbflow.runtime.StubContentProvider"
+            android:authorities="com.dbflow.authority"/>
     </application>
 
 </manifest>

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/config/DatabaseDefinition.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/config/DatabaseDefinition.java
@@ -263,7 +263,7 @@ public abstract class DatabaseDefinition {
             DatabaseConfig config = FlowManager.getConfig().databaseConfigMap()
                     .get(getAssociatedDatabaseClassFile());
             if (config == null || config.modelNotifier() == null) {
-                modelNotifier = new ContentResolverNotifier();
+                modelNotifier = new ContentResolverNotifier(FlowManager.DEFAULT_AUTHORITY);
             } else {
                 modelNotifier = config.modelNotifier();
             }

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/config/FlowManager.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/config/FlowManager.java
@@ -65,6 +65,8 @@ public class FlowManager {
     private static final String DEFAULT_DATABASE_HOLDER_CLASSNAME =
             DEFAULT_DATABASE_HOLDER_PACKAGE_NAME + "." + DEFAULT_DATABASE_HOLDER_NAME;
 
+    public static final String DEFAULT_AUTHORITY = "com.dbflow.authority";
+
     /**
      * Returns the table name for the specific model class
      *

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/list/FlowQueryList.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/list/FlowQueryList.java
@@ -37,7 +37,7 @@ import java.util.ListIterator;
  * on the underlying table.
  */
 public class FlowQueryList<TModel> extends FlowContentObserver
-    implements List<TModel>, IFlowCursorIterator<TModel> {
+        implements List<TModel>, IFlowCursorIterator<TModel> {
 
     private static final Handler REFRESH_HANDLER = new Handler(Looper.myLooper());
 
@@ -60,16 +60,17 @@ public class FlowQueryList<TModel> extends FlowContentObserver
 
 
     private FlowQueryList(Builder<TModel> builder) {
+        super(FlowManager.DEFAULT_AUTHORITY);
         transact = builder.transact;
         changeInTransaction = builder.changeInTransaction;
         successCallback = builder.success;
         errorCallback = builder.error;
         internalCursorList = new FlowCursorList.Builder<>(builder.table)
-            .cursor(builder.cursor)
-            .cacheModels(builder.cacheModels)
-            .modelQueriable(builder.modelQueriable)
-            .modelCache(builder.modelCache)
-            .build();
+                .cursor(builder.cursor)
+                .cacheModels(builder.cacheModels)
+                .modelQueriable(builder.modelQueriable)
+                .modelCache(builder.modelCache)
+                .build();
     }
 
     /**
@@ -92,8 +93,8 @@ public class FlowQueryList<TModel> extends FlowContentObserver
     @Override
     public void registerForContentChanges(Context context, Class<?> table) {
         throw new RuntimeException(
-            "This method is not to be used in the FlowQueryList. We should only ever receive" +
-                " notifications for one class here. Call registerForContentChanges(Context) instead");
+                "This method is not to be used in the FlowQueryList. We should only ever receive" +
+                        " notifications for one class here. Call registerForContentChanges(Context) instead");
     }
 
     @Override
@@ -165,10 +166,10 @@ public class FlowQueryList<TModel> extends FlowContentObserver
     @NonNull
     public Builder<TModel> newBuilder() {
         return new Builder<>(internalCursorList)
-            .success(successCallback)
-            .error(errorCallback)
-            .changeInTransaction(changeInTransaction)
-            .transact(transact);
+                .success(successCallback)
+                .error(errorCallback)
+                .changeInTransaction(changeInTransaction)
+                .transact(transact);
     }
 
     /**
@@ -223,10 +224,10 @@ public class FlowQueryList<TModel> extends FlowContentObserver
     public boolean add(@Nullable TModel model) {
         if (model != null) {
             Transaction transaction = FlowManager.getDatabaseForTable(internalCursorList.table())
-                .beginTransactionAsync(new ProcessModelTransaction.Builder<>(saveModel)
-                    .add(model).build())
-                .error(internalErrorCallback)
-                .success(internalSuccessCallback).build();
+                    .beginTransactionAsync(new ProcessModelTransaction.Builder<>(saveModel)
+                            .add(model).build())
+                    .error(internalErrorCallback)
+                    .success(internalSuccessCallback).build();
 
             if (transact) {
                 transaction.execute();
@@ -265,10 +266,10 @@ public class FlowQueryList<TModel> extends FlowContentObserver
         final Collection<TModel> tmpCollection = (Collection<TModel>) collection;
 
         Transaction transaction = FlowManager.getDatabaseForTable(internalCursorList.table())
-            .beginTransactionAsync(new ProcessModelTransaction.Builder<>(saveModel)
-                .addAll(tmpCollection).build())
-            .error(internalErrorCallback)
-            .success(internalSuccessCallback).build();
+                .beginTransactionAsync(new ProcessModelTransaction.Builder<>(saveModel)
+                        .addAll(tmpCollection).build())
+                .error(internalErrorCallback)
+                .success(internalSuccessCallback).build();
 
         if (transact) {
             transaction.execute();
@@ -284,11 +285,11 @@ public class FlowQueryList<TModel> extends FlowContentObserver
     @Override
     public void clear() {
         Transaction transaction = FlowManager.getDatabaseForTable(internalCursorList.table())
-            .beginTransactionAsync(new QueryTransaction.Builder<>(
-                SQLite.delete().from(internalCursorList.table())).build())
-            .error(internalErrorCallback)
-            .success(internalSuccessCallback)
-            .build();
+                .beginTransactionAsync(new QueryTransaction.Builder<>(
+                        SQLite.delete().from(internalCursorList.table())).build())
+                .error(internalErrorCallback)
+                .success(internalSuccessCallback)
+                .build();
 
         if (transact) {
             transaction.execute();
@@ -369,7 +370,7 @@ public class FlowQueryList<TModel> extends FlowContentObserver
     @Override
     public int indexOf(Object object) {
         throw new UnsupportedOperationException(
-            "We cannot determine which index in the table this item exists at efficiently");
+                "We cannot determine which index in the table this item exists at efficiently");
     }
 
     @Override
@@ -396,7 +397,7 @@ public class FlowQueryList<TModel> extends FlowContentObserver
     @Override
     public int lastIndexOf(Object object) {
         throw new UnsupportedOperationException(
-            "We cannot determine which index in the table this item exists at efficiently");
+                "We cannot determine which index in the table this item exists at efficiently");
     }
 
     /**
@@ -433,10 +434,10 @@ public class FlowQueryList<TModel> extends FlowContentObserver
         TModel model = internalCursorList.getItem(location);
 
         Transaction transaction = FlowManager.getDatabaseForTable(internalCursorList.table())
-            .beginTransactionAsync(new ProcessModelTransaction.Builder<>(deleteModel)
-                .add(model).build())
-            .error(internalErrorCallback)
-            .success(internalSuccessCallback).build();
+                .beginTransactionAsync(new ProcessModelTransaction.Builder<>(deleteModel)
+                        .add(model).build())
+                .error(internalErrorCallback)
+                .success(internalSuccessCallback).build();
 
         if (transact) {
             transaction.execute();
@@ -462,10 +463,10 @@ public class FlowQueryList<TModel> extends FlowContentObserver
         if (internalCursorList.table().isAssignableFrom(object.getClass())) {
             TModel model = ((TModel) object);
             Transaction transaction = FlowManager.getDatabaseForTable(internalCursorList.table())
-                .beginTransactionAsync(new ProcessModelTransaction.Builder<>(deleteModel)
-                    .add(model).build())
-                .error(internalErrorCallback)
-                .success(internalSuccessCallback).build();
+                    .beginTransactionAsync(new ProcessModelTransaction.Builder<>(deleteModel)
+                            .add(model).build())
+                    .error(internalErrorCallback)
+                    .success(internalSuccessCallback).build();
 
             if (transact) {
                 transaction.execute();
@@ -492,10 +493,10 @@ public class FlowQueryList<TModel> extends FlowContentObserver
         // if its a ModelClass
         Collection<TModel> modelCollection = (Collection<TModel>) collection;
         Transaction transaction = FlowManager.getDatabaseForTable(internalCursorList.table())
-            .beginTransactionAsync(new ProcessModelTransaction.Builder<>(deleteModel)
-                .addAll(modelCollection).build())
-            .error(internalErrorCallback)
-            .success(internalSuccessCallback).build();
+                .beginTransactionAsync(new ProcessModelTransaction.Builder<>(deleteModel)
+                        .addAll(modelCollection).build())
+                .error(internalErrorCallback)
+                .success(internalSuccessCallback).build();
 
         if (transact) {
             transaction.execute();
@@ -518,10 +519,10 @@ public class FlowQueryList<TModel> extends FlowContentObserver
         List<TModel> tableList = internalCursorList.getAll();
         tableList.removeAll(collection);
         Transaction transaction = FlowManager.getDatabaseForTable(internalCursorList.table())
-            .beginTransactionAsync(new ProcessModelTransaction.Builder<>(tableList, deleteModel)
-                .build())
-            .error(internalErrorCallback)
-            .success(internalSuccessCallback).build();
+                .beginTransactionAsync(new ProcessModelTransaction.Builder<>(tableList, deleteModel)
+                        .build())
+                .error(internalErrorCallback)
+                .success(internalSuccessCallback).build();
 
         if (transact) {
             transaction.execute();
@@ -552,11 +553,11 @@ public class FlowQueryList<TModel> extends FlowContentObserver
      */
     public TModel set(TModel object) {
         Transaction transaction = FlowManager.getDatabaseForTable(internalCursorList.table())
-            .beginTransactionAsync(new ProcessModelTransaction.Builder<>(updateModel)
-                .add(object)
-                .build())
-            .error(internalErrorCallback)
-            .success(internalSuccessCallback).build();
+                .beginTransactionAsync(new ProcessModelTransaction.Builder<>(updateModel)
+                        .add(object)
+                        .build())
+                .error(internalErrorCallback)
+                .success(internalSuccessCallback).build();
 
         if (transact) {
             transaction.execute();
@@ -598,28 +599,28 @@ public class FlowQueryList<TModel> extends FlowContentObserver
     }
 
     private final ProcessModelTransaction.ProcessModel<TModel> saveModel =
-        new ProcessModelTransaction.ProcessModel<TModel>() {
-            @Override
-            public void processModel(TModel model, DatabaseWrapper wrapper) {
-                getModelAdapter().save(model);
-            }
-        };
+            new ProcessModelTransaction.ProcessModel<TModel>() {
+                @Override
+                public void processModel(TModel model, DatabaseWrapper wrapper) {
+                    getModelAdapter().save(model);
+                }
+            };
 
     private final ProcessModelTransaction.ProcessModel<TModel> updateModel =
-        new ProcessModelTransaction.ProcessModel<TModel>() {
-            @Override
-            public void processModel(TModel model, DatabaseWrapper wrapper) {
-                getModelAdapter().update(model);
-            }
-        };
+            new ProcessModelTransaction.ProcessModel<TModel>() {
+                @Override
+                public void processModel(TModel model, DatabaseWrapper wrapper) {
+                    getModelAdapter().update(model);
+                }
+            };
 
     private final ProcessModelTransaction.ProcessModel<TModel> deleteModel =
-        new ProcessModelTransaction.ProcessModel<TModel>() {
-            @Override
-            public void processModel(TModel model, DatabaseWrapper wrapper) {
-                getModelAdapter().delete(model);
-            }
-        };
+            new ProcessModelTransaction.ProcessModel<TModel>() {
+                @Override
+                public void processModel(TModel model, DatabaseWrapper wrapper) {
+                    getModelAdapter().delete(model);
+                }
+            };
 
     private final Transaction.Error internalErrorCallback = new Transaction.Error() {
         @Override

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/runtime/ContentResolverNotifier.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/runtime/ContentResolverNotifier.java
@@ -14,13 +14,22 @@ import com.raizlabs.android.dbflow.structure.ModelAdapter;
  * The default use case, it notifies via the {@link ContentResolver} system.
  */
 public class ContentResolverNotifier implements ModelNotifier {
+
+    @NonNull
+    private final String contentAuthority;
+
+    public ContentResolverNotifier(@NonNull String contentAuthority) {
+        this.contentAuthority = contentAuthority;
+    }
+
     @Override
     public <T> void notifyModelChanged(@NonNull T model, @NonNull ModelAdapter<T> adapter,
                                        @NonNull BaseModel.Action action) {
         if (FlowContentObserver.shouldNotify()) {
             FlowManager.getContext().getContentResolver()
-                .notifyChange(SqlUtils.getNotificationUri(adapter.getModelClass(), action,
-                    adapter.getPrimaryConditionClause(model).getConditions()), null, true);
+                    .notifyChange(SqlUtils.getNotificationUri(contentAuthority,
+                            adapter.getModelClass(), action,
+                            adapter.getPrimaryConditionClause(model).getConditions()), null, true);
         }
     }
 
@@ -28,23 +37,24 @@ public class ContentResolverNotifier implements ModelNotifier {
     public <T> void notifyTableChanged(@NonNull Class<T> table, @NonNull BaseModel.Action action) {
         if (FlowContentObserver.shouldNotify()) {
             FlowManager.getContext().getContentResolver()
-                .notifyChange(SqlUtils.getNotificationUri(table, action, (SQLOperator[]) null), null, true);
+                    .notifyChange(SqlUtils.getNotificationUri(contentAuthority,
+                            table, action, (SQLOperator[]) null), null, true);
         }
     }
 
     @Override
     public TableNotifierRegister newRegister() {
-        return new FlowContentTableNotifierRegister();
+        return new FlowContentTableNotifierRegister(contentAuthority);
     }
 
     public static class FlowContentTableNotifierRegister implements TableNotifierRegister {
-
-        private final FlowContentObserver flowContentObserver = new FlowContentObserver();
+        private final FlowContentObserver flowContentObserver;
 
         @Nullable
         private OnTableChangedListener tableChangedListener;
 
-        public FlowContentTableNotifierRegister() {
+        public FlowContentTableNotifierRegister(@NonNull String contentAuthority) {
+            flowContentObserver = new FlowContentObserver(contentAuthority);
             flowContentObserver.addOnTableChangedListener(internalContentChangeListener);
         }
 
@@ -75,7 +85,7 @@ public class ContentResolverNotifier implements ModelNotifier {
         }
 
         private final OnTableChangedListener internalContentChangeListener
-            = new OnTableChangedListener() {
+                = new OnTableChangedListener() {
 
             @Override
             public void onTableChanged(@Nullable Class<?> tableChanged, @NonNull BaseModel.Action action) {

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/runtime/StubContentProvider.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/runtime/StubContentProvider.java
@@ -1,0 +1,56 @@
+package com.raizlabs.android.dbflow.runtime;
+
+/**
+ * Description:
+ */
+
+import android.content.ContentProvider;
+import android.content.ContentValues;
+import android.database.Cursor;
+import android.net.Uri;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+/**
+ * Description: Used as a stub, include this in order to work around Android O changes to {@link ContentProvider}
+ */
+public class StubContentProvider extends ContentProvider {
+
+    @Nullable
+    @Override
+    public Uri insert(@NonNull Uri uri, @Nullable ContentValues values) {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public Cursor query(@NonNull Uri uri,
+                        @Nullable String[] projection,
+                        @Nullable String selection,
+                        @Nullable String[] selectionArgs,
+                        @Nullable String sortOrder) {
+        return null;
+    }
+
+    @Override
+    public boolean onCreate() {
+        return true;
+    }
+
+    @Override
+    public int update(@NonNull Uri uri, @Nullable ContentValues values,
+                      @Nullable String selection, @Nullable String[] selectionArgs) {
+        return 0;
+    }
+
+    @Override
+    public int delete(@NonNull Uri uri, @Nullable String selection, @Nullable String[] selectionArgs) {
+        return 0;
+    }
+
+    @Nullable
+    @Override
+    public String getType(@NonNull Uri uri) {
+        return null;
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=4.1.1
+version=4.2.0
 version_code=1
 group=com.raizlabs.android
 bt_siteUrl=https://github.com/Raizlabs/DBFlow


### PR DESCRIPTION
Support for Android O Content Providers.
Simply add this line to your `AndroidManifest.xml`:
```
<provider
            android:name="com.raizlabs.android.dbflow.runtime.StubContentProvider"
            android:authorities="com.dbflow.authority"/>
```
Which will allow normal content observing to continue. 