### PR TITLE
4.2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Image](https://github.com/agrosner/DBFlow/blob/develop/dbflow_banner.png?raw=true)
 
-[![JitPack.io](https://img.shields.io/badge/JitPack.io-4.2.1-red.svg?style=flat)](https://jitpack.io/#Raizlabs/DBFlow) [![Android Weekly](http://img.shields.io/badge/Android%20Weekly-%23129-2CB3E5.svg?style=flat)](http://androidweekly.net/issues/issue-129) [![Android Arsenal](https://img.shields.io/badge/Android%20Arsenal-DBFlow-brightgreen.svg?style=flat)](https://android-arsenal.com/details/1/1134)
+[![JitPack.io](https://img.shields.io/badge/JitPack.io-4.2.2-red.svg?style=flat)](https://jitpack.io/#Raizlabs/DBFlow) [![Android Weekly](http://img.shields.io/badge/Android%20Weekly-%23129-2CB3E5.svg?style=flat)](http://androidweekly.net/issues/issue-129) [![Android Arsenal](https://img.shields.io/badge/Android%20Arsenal-DBFlow-brightgreen.svg?style=flat)](https://android-arsenal.com/details/1/1134)
 
 A robust, powerful, and very simple ORM android database library with **annotation processing**.
 
@@ -43,7 +43,7 @@ Add the library to the project-level build.gradle, using the apt plugin to enabl
 
   apply plugin: 'kotlin-kapt' // required for kotlin.
 
-  def dbflow_version = "4.2.1"
+  def dbflow_version = "4.2.2"
   // or dbflow_version = "develop-SNAPSHOT" for grabbing latest dependency in your project on the develop branch
   // or 10-digit short-hash of a specific commit. (Useful for bugs fixed in develop, but not in a release yet)
 

--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/SQLiteHelper.kt
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/SQLiteHelper.kt
@@ -79,12 +79,14 @@ enum class SQLiteHelper {
         private val sNumberMethodList = hashSetOf(TypeName.BYTE, TypeName.DOUBLE, TypeName.FLOAT,
             TypeName.LONG, TypeName.SHORT, TypeName.INT)
 
-        operator fun get(typeName: TypeName?): SQLiteHelper = sTypeMap[typeName] ?: SQLiteHelper.TEXT
+        operator fun get(typeName: TypeName?): SQLiteHelper = sTypeMap[typeName]
+            ?: throw IllegalArgumentException("Cannot map $typeName to a SQLite Type. If this is a " +
+            "TypeConverter, ensure it maps to a primitive type.")
 
         fun getWrapperMethod(typeName: TypeName?): String {
             var sqLiteHelper = get(typeName).sqliteStatementWrapperMethod
             if (typeName == TypeName.FLOAT.box()) {
-                sqLiteHelper = "Float";
+                sqLiteHelper = "Float"
             }
             return sqLiteHelper;
         }

--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/column/ColumnAccessCombiner.kt
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/column/ColumnAccessCombiner.kt
@@ -165,7 +165,7 @@ class SqliteStatementAccessCombiner(combiner: Combiner)
             val fieldAccess: CodeBlock = getFieldAccessBlock(this@addCode, modelBlock,
                     defineProperty = defineProperty)
             val wrapperMethod = SQLiteHelper.getWrapperMethod(wrapperFieldTypeName ?: fieldTypeName)
-            val statementMethod = SQLiteHelper[fieldTypeName].sqLiteStatementMethod
+            val statementMethod = SQLiteHelper[wrapperFieldTypeName ?: fieldTypeName].sqLiteStatementMethod
 
             var offset = "$index + $columnRepresentation"
             if (columnRepresentation.isNullOrEmpty()) {

--- a/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/column/DefinitionUtils.kt
+++ b/dbflow-processor/src/main/java/com/raizlabs/android/dbflow/processor/definition/column/DefinitionUtils.kt
@@ -16,7 +16,7 @@ object DefinitionUtils {
         var statement: String? = null
 
         if (SQLiteHelper.containsType(wrapperTypeName ?: elementTypeName)) {
-            statement = SQLiteHelper[elementTypeName].toString()
+            statement = SQLiteHelper[wrapperTypeName ?: elementTypeName].toString()
         }
 
         return CodeBlock.builder().add("\$L \$L", QueryBuilder.quote(columnName), statement)

--- a/dbflow-tests/src/test/java/com/raizlabs/android/dbflow/models/SimpleTestModels.kt
+++ b/dbflow-tests/src/test/java/com/raizlabs/android/dbflow/models/SimpleTestModels.kt
@@ -97,18 +97,18 @@ class FeedEntry(@PrimaryKey var id: Int = 0,
 
 @Table(database = TestDatabase::class)
 @ManyToMany(
-        generatedTableClassName = "Refund", referencedTable = Transfer::class,
-        referencedTableColumnName = "refund_in", thisTableColumnName = "refund_out",
-        saveForeignKeyModels = true
+    generatedTableClassName = "Refund", referencedTable = Transfer::class,
+    referencedTableColumnName = "refund_in", thisTableColumnName = "refund_out",
+    saveForeignKeyModels = true
 )
 data class Transfer(@PrimaryKey var transfer_id: UUID = UUID.randomUUID())
 
 @Table(database = TestDatabase::class)
 data class Transfer2(
-        @PrimaryKey
-        var id: UUID = UUID.randomUUID(),
-        @ForeignKey(stubbedRelationship = true)
-        var origin: Account? = null
+    @PrimaryKey
+    var id: UUID = UUID.randomUUID(),
+    @ForeignKey(stubbedRelationship = true)
+    var origin: Account? = null
 )
 
 @Table(database = TestDatabase::class)
@@ -133,12 +133,12 @@ class SqlListenerModel(@PrimaryKey var id: Int = 0) : SQLiteStatementListener {
     }
 }
 
-class CustomType(var name: String? = "")
+class CustomType(var name: Int? = 0)
 
-class CustomTypeConverter : TypeConverter<String, CustomType>() {
+class CustomTypeConverter : TypeConverter<Int, CustomType>() {
     override fun getDBValue(model: CustomType?) = model?.name
 
-    override fun getModelValue(data: String?) = if (data == null) {
+    override fun getModelValue(data: Int?) = if (data == null) {
         null
     } else {
         CustomType(data)

--- a/dbflow-tests/src/test/java/com/raizlabs/android/dbflow/models/SimpleTestModelsTest.kt
+++ b/dbflow-tests/src/test/java/com/raizlabs/android/dbflow/models/SimpleTestModelsTest.kt
@@ -1,0 +1,22 @@
+package com.raizlabs.android.dbflow.models
+
+import com.raizlabs.android.dbflow.BaseUnitTest
+import com.raizlabs.android.dbflow.kotlinextensions.modelAdapter
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Description:
+ */
+class SimpleTestModelsTest : BaseUnitTest() {
+
+    @Test
+    fun validateCreationQuery() {
+        assertEquals("CREATE TABLE IF NOT EXISTS `TypeConverterModel`(" +
+            "`id` INTEGER, " +
+            "`opaqueData` BLOB, " +
+            "`blob` BLOB, " +
+            "`customType` INTEGER, " +
+            "PRIMARY KEY(`id`, `customType`))", modelAdapter<TypeConverterModel>().creationQuery)
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=4.2.1
+version=4.2.2
 version_code=1
 group=com.raizlabs.android
 bt_siteUrl=https://github.com/Raizlabs/DBFlow


### PR DESCRIPTION
Fix critical issue where TypeConverter always appear as `SQLiteType.TEXT` in the DB even if its type did not match up. 

Adds a test to ensure it stays true.

https://github.com/Raizlabs/DBFlow/issues/1481