### PR TITLE
4.2.3

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,8 +1,5 @@
-
 DBFlow Version:
-Issue Kind (Bug, Question, Feature):
 
-Please note if you are using Instant Run, there may be bugs where generated classes are not created. Ensure you are using
-the [apt](https://bitbucket.org/hvisser/android-apt) or [kapt](http://blog.jetbrains.com/kotlin/2015/06/better-annotation-processing-supporting-stubs-in-kapt/) plugins and that incremental compilation is off.
+Bug or Feature Request:
 
-Description: 
+Description:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Image](https://github.com/agrosner/DBFlow/blob/develop/dbflow_banner.png?raw=true)
 
-[![JitPack.io](https://img.shields.io/badge/JitPack.io-4.2.2-red.svg?style=flat)](https://jitpack.io/#Raizlabs/DBFlow) [![Android Weekly](http://img.shields.io/badge/Android%20Weekly-%23129-2CB3E5.svg?style=flat)](http://androidweekly.net/issues/issue-129) [![Android Arsenal](https://img.shields.io/badge/Android%20Arsenal-DBFlow-brightgreen.svg?style=flat)](https://android-arsenal.com/details/1/1134)
+[![JitPack.io](https://img.shields.io/badge/JitPack.io-4.2.3-red.svg?style=flat)](https://jitpack.io/#Raizlabs/DBFlow) [![Android Weekly](http://img.shields.io/badge/Android%20Weekly-%23129-2CB3E5.svg?style=flat)](http://androidweekly.net/issues/issue-129) [![Android Arsenal](https://img.shields.io/badge/Android%20Arsenal-DBFlow-brightgreen.svg?style=flat)](https://android-arsenal.com/details/1/1134)
 
 A robust, powerful, and very simple ORM android database library with **annotation processing**.
 
@@ -43,7 +43,7 @@ Add the library to the project-level build.gradle, using the apt plugin to enabl
 
   apply plugin: 'kotlin-kapt' // required for kotlin.
 
-  def dbflow_version = "4.2.2"
+  def dbflow_version = "4.2.3"
   // or dbflow_version = "develop-SNAPSHOT" for grabbing latest dependency in your project on the develop branch
   // or 10-digit short-hash of a specific commit. (Useful for bugs fixed in develop, but not in a release yet)
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.0.1'
-        classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
+        classpath 'com.github.dcendents:android-maven-gradle-plugin:2.0'
         classpath 'com.getkeepsafe.dexcount:dexcount-gradle-plugin:0.7.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/Operator.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/sql/language/Operator.java
@@ -551,13 +551,13 @@ public class Operator<T> extends BaseOperator implements IOperator<T> {
             value = typeConverter.getDBValue(value);
         }
         if (value instanceof String || value instanceof IOperator
-            || value instanceof Character) {
+                || value instanceof Character) {
             operation = String.format("%1s %1s ", operation, Operation.CONCATENATE);
         } else if (value instanceof Number) {
             operation = String.format("%1s %1s ", operation, Operation.PLUS);
         } else {
             throw new IllegalArgumentException(
-                String.format("Cannot concatenate the %1s", value != null ? value.getClass() : "null"));
+                    String.format("Cannot concatenate the %1s", value != null ? value.getClass() : "null"));
         }
         this.value = value;
         isValueSet = true;
@@ -617,7 +617,8 @@ public class Operator<T> extends BaseOperator implements IOperator<T> {
                 converted = convertToDB ? typeConverter.getDBValue(object) : object;
             } catch (ClassCastException c) {
                 // if object type is not valid converted type, just use type as is here.
-                FlowLog.log(FlowLog.Level.W, c);
+                FlowLog.log(FlowLog.Level.I, "Value passed to operation is not valid type for TypeConverter in the column. " +
+                        "Preserving value " + object + " to be used as is.");
             }
             return BaseOperator.convertValueToString(converted, appendInnerParenthesis, false);
         } else {
@@ -792,10 +793,10 @@ public class Operator<T> extends BaseOperator implements IOperator<T> {
         @Override
         public void appendConditionToQuery(@NonNull QueryBuilder queryBuilder) {
             queryBuilder.append(columnName()).append(operation())
-                .append(convertObjectToString(value(), true))
-                .appendSpaceSeparated(Operation.AND)
-                .append(convertObjectToString(secondValue(), true))
-                .appendSpace().appendOptional(postArgument());
+                    .append(convertObjectToString(value(), true))
+                    .appendSpaceSeparated(Operation.AND)
+                    .append(convertObjectToString(secondValue(), true))
+                    .appendSpace().appendOptional(postArgument());
         }
 
         @Override
@@ -852,7 +853,7 @@ public class Operator<T> extends BaseOperator implements IOperator<T> {
         @Override
         public void appendConditionToQuery(@NonNull QueryBuilder queryBuilder) {
             queryBuilder.append(columnName()).append(operation())
-                .append("(").append(OperatorGroup.joinArguments(",", inArguments, this)).append(")");
+                    .append("(").append(OperatorGroup.joinArguments(",", inArguments, this)).append(")");
         }
 
         @Override

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/InternalAdapter.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/InternalAdapter.java
@@ -4,6 +4,7 @@ import android.content.ContentValues;
 import android.database.sqlite.SQLiteStatement;
 import android.support.annotation.IntRange;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 
 import com.raizlabs.android.dbflow.annotation.PrimaryKey;
 import com.raizlabs.android.dbflow.structure.database.DatabaseStatement;
@@ -211,7 +212,7 @@ public interface InternalAdapter<TModel> {
      * @return The value for the {@link PrimaryKey#autoincrement()}
      * if it has the field. This method is overridden when its specified for the {@link TModel}
      */
-    @NonNull
+    @Nullable
     Number getAutoIncrementingId(@NonNull TModel model);
 
     /**

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/ModelAdapter.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/ModelAdapter.java
@@ -3,6 +3,7 @@ package com.raizlabs.android.dbflow.structure;
 import android.content.ContentValues;
 import android.database.sqlite.SQLiteStatement;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 
 import com.raizlabs.android.dbflow.annotation.ConflictAction;
 import com.raizlabs.android.dbflow.annotation.ForeignKey;
@@ -291,7 +292,7 @@ public abstract class ModelAdapter<TModel> extends InstanceAdapter<TModel>
      * @return The value for the {@link PrimaryKey#autoincrement()}
      * if it has the field. This method is overridden when its specified for the {@link TModel}
      */
-    @NonNull
+    @Nullable
     @Override
     public Number getAutoIncrementingId(@NonNull TModel model) {
         throw new InvalidDBConfiguration(
@@ -314,11 +315,7 @@ public abstract class ModelAdapter<TModel> extends InstanceAdapter<TModel>
 
     public boolean hasAutoIncrement(TModel model) {
         Number id = getAutoIncrementingId(model);
-        //noinspection ConstantConditions
-        if (id == null) {
-            throw new IllegalStateException("An autoincrementing column field cannot be null.");
-        }
-        return id.longValue() > 0;
+        return id != null && id.longValue() > 0;
     }
 
     /**

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=4.2.2
+version=4.2.3
 version_code=1
 group=com.raizlabs.android
 bt_siteUrl=https://github.com/Raizlabs/DBFlow


### PR DESCRIPTION
1. update PR template
2. fix pom file generation on jitpack #1487 
3. fix issue where `save(DatabaseWrapper)` would leave open insert or update statment. #1496
4. Allow (but still warn) about autoincrementing ids being null. if null, they are treated as if they are 0 meaning that they will get inserted rather than updated in the DB during a save operation. #1490 
5. Update warning on wrong type passed in operator class for value #1488  