### PR TITLE
Fix NPE of ContentResolver query cursor.

### DIFF
--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/database/FlowCursor.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/database/FlowCursor.java
@@ -11,6 +11,7 @@ import android.support.annotation.Nullable;
  */
 public class FlowCursor extends CursorWrapper {
 
+    @NonNull
     public static FlowCursor from(@NonNull Cursor cursor) {
         if (cursor instanceof FlowCursor) {
             return (FlowCursor) cursor;

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/provider/BaseProviderModel.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/provider/BaseProviderModel.java
@@ -67,11 +67,12 @@ public abstract class BaseProviderModel
     @SuppressWarnings("unchecked")
     public void load(@NonNull OperatorGroup whereConditions,
                      @Nullable String orderBy, String... columns) {
-        FlowCursor cursor = FlowCursor.from(ContentUtils.query(FlowManager.getContext().getContentResolver(),
-            getQueryUri(), whereConditions, orderBy, columns));
-        if (cursor != null && cursor.moveToFirst()) {
-            getModelAdapter().loadFromCursor(cursor, this);
-            cursor.close();
+        Cursor cursor = ContentUtils.query(FlowManager.getContext().getContentResolver(),
+            getQueryUri(), whereConditions, orderBy, columns);
+        FlowCursor flowCursor = cursor == null ? null : FlowCursor.from(cursor);
+        if (flowCursor != null && flowCursor.moveToFirst()) {
+            getModelAdapter().loadFromCursor(flowCursor, this);
+            flowCursor.close();
         }
     }
 

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/provider/BaseSyncableProviderModel.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/provider/BaseSyncableProviderModel.java
@@ -1,6 +1,7 @@
 package com.raizlabs.android.dbflow.structure.provider;
 
 import android.content.ContentProvider;
+import android.database.Cursor;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
@@ -46,11 +47,12 @@ public abstract class BaseSyncableProviderModel extends BaseModel implements Mod
     @SuppressWarnings("unchecked")
     public void load(@NonNull OperatorGroup whereOperatorGroup,
                      @Nullable String orderBy, String... columns) {
-        FlowCursor cursor = FlowCursor.from(ContentUtils.query(FlowManager.getContext().getContentResolver(),
-            getQueryUri(), whereOperatorGroup, orderBy, columns));
-        if (cursor != null && cursor.moveToFirst()) {
-            getModelAdapter().loadFromCursor(cursor, this);
-            cursor.close();
+        Cursor cursor = ContentUtils.query(FlowManager.getContext().getContentResolver(),
+            getQueryUri(), whereOperatorGroup, orderBy, columns);
+        FlowCursor flowCursor = cursor == null ? null : FlowCursor.from(cursor);
+        if (flowCursor != null && flowCursor.moveToFirst()) {
+            getModelAdapter().loadFromCursor(flowCursor, this);
+            flowCursor.close();
         }
     }
 

--- a/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/provider/ContentUtils.java
+++ b/dbflow/src/main/java/com/raizlabs/android/dbflow/structure/provider/ContentUtils.java
@@ -4,6 +4,7 @@ import android.content.ContentResolver;
 import android.content.ContentValues;
 import android.database.Cursor;
 import android.net.Uri;
+import android.support.annotation.Nullable;
 
 import com.raizlabs.android.dbflow.annotation.provider.ContentProvider;
 import com.raizlabs.android.dbflow.config.FlowLog;
@@ -208,6 +209,7 @@ public class ContentUtils {
      * @param columns         The list of columns to query.
      * @return A {@link android.database.Cursor}
      */
+    @Nullable
     public static Cursor query(ContentResolver contentResolver, Uri queryUri,
                                OperatorGroup whereConditions,
                                String orderBy, String... columns) {
@@ -248,11 +250,12 @@ public class ContentUtils {
                                                           Class<TableClass> table,
                                                           OperatorGroup whereConditions,
                                                           String orderBy, String... columns) {
-        FlowCursor cursor = FlowCursor.from(contentResolver.query(queryUri, columns, whereConditions.getQuery(), null, orderBy));
-        if (cursor != null) {
+        Cursor cursor = contentResolver.query(queryUri, columns, whereConditions.getQuery(), null, orderBy);
+        FlowCursor flowCursor = cursor == null ? null : FlowCursor.from(cursor);
+        if (flowCursor != null) {
             return FlowManager.getModelAdapter(table)
                 .getListModelLoader()
-                .load(cursor);
+                .load(flowCursor);
         }
         return new ArrayList<>();
     }


### PR DESCRIPTION
When ContentProvider not ready, a query from content resolver may return
a null cursor, we need to detect this, instead of wrap to FlowCursor
direct.
The issue may happen when query across process, that other App may not
installed, or provider not setup yet.